### PR TITLE
Endpoint tester UI, tenant diagnostics, env-var credentials, GH issue tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -1,0 +1,179 @@
+# Grace Engineering — Plex API: Claude Code Briefing
+
+This is the primary context document for AI-assisted development sessions.
+Read this first, then read plex_api.py and tool_library_loader.py.
+
+---
+
+## What this project is
+
+Nightly automation that syncs Autodesk Fusion 360 tool library data into
+Rockwell Automation Plex Smart Manufacturing (ERP). Fusion 360 JSON files
+on a local network share are the absolute source of truth. The script reads
+them and pushes tooling data to Plex via REST API every night at midnight.
+
+---
+
+## Repo: https://github.com/grace-shane/plex-api
+
+Forked from just-shane/plex-api. Grace Engineering's working copy.
+
+---
+
+## Current situation
+
+- Connected and authenticating successfully — but to the WRONG tenant (G5)
+- G5 is real production data belonging to another company — READ ONLY, no writes
+- IT (Courtney) is resolving tenant access for Grace Engineering
+- No new credentials needed — switching tenants = enabling one header
+- Use https://test.connect.plex.com (test. prefix) for all development
+
+---
+
+## Auth — three headers required
+X-Plex-Connect-Api-Key:    <key>      # identifies the app
+X-Plex-Connect-Api-Secret: <secret>   # second factor, same credential
+X-Plex-Connect-Tenant-Id:  <uuid>     # tenant routing — omit = defaults to G5
+
+Keys and secrets are managed here in Claude Code via environment variables.
+Never hardcode credentials. Never commit credentials.
+
+### Tenants
+
+| Name            | Tenant ID                              | Status                        |
+|-----------------|----------------------------------------|-------------------------------|
+| Grace Eng.      | a6af9c99-bce5-4938-a007-364dc5603d08  | Target — waiting on IT        |
+| G5              | b406c8c4-cef0-4d62-862c-1758b702cd02  | Currently connected — READ ONLY |
+
+---
+
+## Architecture
+
+Fusion 360 .json (network share, via ADC)
+└── tool_library_loader.py   reads + validates JSON, stale-file guard
+└── transform layer  (build_part_payload, build_assembly_payload)
+└── plex_api.py / PlexClient   pushes to Plex REST API
+├── mdm/v1/parts                (consumable tools)
+├── mdm/v1/suppliers            (resolve vendor UUIDs)
+├── tooling/v1/tool-assemblies  (BLOCKED — see below)
+└── production/v1/control/workcenters
+
+### Industry hierarchy (Plex data model)
+
+1. Purchased consumables — cutting tools as bought parts (end mills, drills, etc.)
+2. Tool assemblies — consumable + holder paired together
+3. Routings / operations — assemblies mapped to machining ops
+4. Jobs — ops executed on the shop floor
+5. Manufactured parts — end product, with full tool traceability
+
+---
+
+## Plex API endpoints
+
+### Working (test environment)
+
+| Endpoint                               | Notes                                          |
+|----------------------------------------|------------------------------------------------|
+| GET mdm/v1/tenants                     | Returns tenants for credential. Currently G5.  |
+| GET mdm/v1/parts                       | NO pagination — always filter status=Active    |
+| GET mdm/v1/suppliers                   | Returns UUIDs, not supplier codes              |
+| GET purchasing/v1/purchase-orders      | URL-encode spaces in filter values             |
+| GET production/v1/control/workcenters  | Target for pocket/turret assignment pushes     |
+
+### 403 responses — suspected tenant routing, not subscription
+
+- tooling/v1/tools
+- tooling/v1/tool-assemblies
+- tooling/v1/tool-inventory
+
+Working hypothesis: these 403s will resolve once IT completes the tenant
+routing change for Grace Engineering. Cannot verify until tenant access lands,
+since G5 is another company's data and we have no authority to test writes
+there. The tenant change is the **only** open IT blocker.
+
+---
+
+## Fusion 360 JSON schema (key fields)
+
+Source file: BROTHER SPEEDIO ALUMINUM.json (28 entries, root "data" array)
+
+| Field                  | Maps to Plex                        | Notes                              |
+|------------------------|-------------------------------------|------------------------------------|
+| guid                   | External reference key              | Use for dedup on re-sync           |
+| type                   | Item sub-category                   | Filter out "holder" and "probe"    |
+| description            | Part description                    |                                    |
+| product-id             | Part number                         | Vendor part number, key for PO link|
+| vendor                 | Supplier (resolve to UUID first)    |                                    |
+| post-process.number    | Pocket / turret number              | Critical for workcenter doc update |
+| geometry.DC            | Cutting diameter                    | Blocked endpoint                   |
+| geometry.OAL           | Overall length                      | Blocked endpoint                   |
+| geometry.NOF           | Number of flutes                    | Blocked endpoint                   |
+| holder (object)        | Assembly component / BOM link       | Blocked endpoint                   |
+
+Tool type distribution in active library:
+- flat end mill: 12  |  holder: 6  |  bull nose end mill: 4  |  drill: 2
+- face mill: 1  |  form mill: 1  |  slot mill: 1  |  probe: 1
+
+Sync filter: include only type != "holder" AND type != "probe"
+
+---
+
+## What's built
+
+### plex_api.py
+- PlexClient base class with throttling (200 calls/min rate limit)
+- get() and get_paginated() methods
+- Extraction functions: extract_purchase_orders, extract_parts, extract_workcenters
+- discover_all() endpoint probe utility
+- **NEEDS UPDATE**: PlexClient constructor is missing api_secret parameter
+  and X-Plex-Connect-Api-Secret header — fix this before any further work
+
+### tool_library_loader.py
+- load_library(path) — loads single .json, returns data array
+- load_all_libraries(directory) — globs all .json files in CAMTools dir
+- Stale file guard — aborts if files older than 25h (ADC sync stall detection)
+- PermissionError and JSONDecodeError handling (ADC mid-sync file locks)
+- report_library_contents() — diagnostic summary
+
+---
+
+## Immediate TODO (in priority order)
+
+1. Fix PlexClient constructor — add api_secret, include header
+2. build_part_payload(tool: dict) -> dict
+   Maps Fusion tool object to mdm/v1/parts POST body
+3. resolve_supplier_uuid(vendor_name: str) -> str
+   Looks up supplier UUID from mdm/v1/suppliers — safe to test on G5 (read-only)
+4. build_assembly_payload(tool: dict, holder: dict) -> dict
+   Stub only — tooling endpoints blocked, but payload shape can be drafted
+5. Core sync logic — upsert with guid-based dedup
+6. Error handling + logging to network share text file
+
+---
+
+## Gotchas — read before touching anything
+
+- **G5 is production data. Read only. No writes, no mutations.**
+- PlexClient missing api_secret — fix before running anything
+- mdm/v1/parts has NO server-side pagination — unfiltered = entire DB pulled
+- supplierId in responses is a UUID, not a supplier code (MSC != "MSC001")
+- URL-encode spaces in filter strings (MRO SUPPLIES -> MRO%20SUPPLIES)
+- API key must be in header — URL parameter returns 401
+- PowerShell: use Invoke-RestMethod, not curl (alias doesn't pass headers)
+- Tooling 403s look like 404s — it's a subscription issue, not missing endpoints
+- Fusion Tool objects from CAM API are copies, not references
+- ADC stale file guard will abort sync if network share files are > 25h old
+- BROTHER SPEEDIO ALUMINUM.json is committed to repo for reference only —
+  sync script must always read from network share, not this file
+
+---
+
+## DNC / machine connections (for future NC program push work)
+
+| Machine              | Protocol       | Address                     |
+|----------------------|----------------|-----------------------------|
+| Brother Speedio 879  | FTP            | 192.168.25.79               |
+| Brother Speedio 880  | FTP            | 192.168.25.80               |
+| Citizen / Tsugami    | RS-232 → TCP   | Moxa NPort 5150/5250        |
+| Haas VMCs            | Ethernet       | Sigma 5 native              |
+

--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -122,11 +122,20 @@ Sync filter: include only type != "holder" AND type != "probe"
 
 ### plex_api.py
 - PlexClient base class with throttling (200 calls/min rate limit)
+- Constructor takes api_key, api_secret, tenant_id, use_test
+- Sets X-Plex-Connect-Api-Key, X-Plex-Connect-Api-Secret, and
+  X-Plex-Connect-Tenant-Id headers
+- Credentials read from PLEX_API_KEY / PLEX_API_SECRET env vars
 - get() and get_paginated() methods
 - Extraction functions: extract_purchase_orders, extract_parts, extract_workcenters
 - discover_all() endpoint probe utility
-- **NEEDS UPDATE**: PlexClient constructor is missing api_secret parameter
-  and X-Plex-Connect-Api-Secret header — fix this before any further work
+
+### plex_diagnostics.py
+- list_tenants(client) — GET /mdm/v1/tenants
+- get_tenant(client, id) — GET /mdm/v1/tenants/{id}
+- tenant_whoami(client, configured_id) — composite check that compares
+  visible tenants against the known Grace and G5 UUIDs and returns a
+  structured report. Run this first to verify tenant routing.
 
 ### tool_library_loader.py
 - load_library(path) — loads single .json, returns data array
@@ -135,32 +144,52 @@ Sync filter: include only type != "holder" AND type != "probe"
 - PermissionError and JSONDecodeError handling (ADC mid-sync file locks)
 - report_library_contents() — diagnostic summary
 
+### app.py + templates/static
+- Flask endpoint tester UI at http://localhost:5000
+- Left rail: Diagnostics (run first), Plex presets, Extractors, Fusion local
+- Top: method selector + URL bar + query params + Send (Ctrl/Cmd+Enter)
+- Tabbed response pane (Body / Headers / Raw), copy and clear, history
+- /api/plex/raw proxy lets the UI hit any Plex endpoint via PlexClient
+  without exposing credentials to the browser
+- /api/diagnostics/tenant runs tenant_whoami from plex_diagnostics
+
 ---
 
 ## Immediate TODO (in priority order)
 
-1. Fix PlexClient constructor — add api_secret, include header
-2. build_part_payload(tool: dict) -> dict
+All items below are mirrored as GitHub Issues — see
+https://github.com/grace-shane/plex-api/issues for live status.
+
+1. ~~Fix PlexClient constructor — add api_secret, include header~~ DONE
+2. Read baseline tooling inventory from mdm/v1/parts — issue #2 (unblocked,
+   read-only — can start today on G5)
+3. build_part_payload(tool: dict) -> dict — issue #3
    Maps Fusion tool object to mdm/v1/parts POST body
-3. resolve_supplier_uuid(vendor_name: str) -> str
-   Looks up supplier UUID from mdm/v1/suppliers — safe to test on G5 (read-only)
-4. build_assembly_payload(tool: dict, holder: dict) -> dict
-   Stub only — tooling endpoints blocked, but payload shape can be drafted
-5. Core sync logic — upsert with guid-based dedup
-6. Error handling + logging to network share text file
+4. resolve_supplier_uuid(vendor_name: str) -> str — issue #3
+   Looks up supplier UUID from mdm/v1/suppliers (safe to test on G5 read)
+5. build_assembly_payload(tool: dict, holder: dict) -> dict — issue #4
+   Draft only — endpoints currently 403 (suspected tenant scoping)
+6. Core sync logic — upsert with guid-based dedup — issue #7
+7. Error handling + logging to network share text file — issue #8
 
 ---
 
 ## Gotchas — read before touching anything
 
 - **G5 is production data. Read only. No writes, no mutations.**
-- PlexClient missing api_secret — fix before running anything
+- PLEX_API_KEY and PLEX_API_SECRET must be set in the environment before
+  running plex_api.py or app.py — both will hard-fail with a clear message
+  if they are missing
+- The previously hardcoded API key (k3SmLW3y…) is still in git history on
+  master and must be rotated before production deployment — see issue #12
 - mdm/v1/parts has NO server-side pagination — unfiltered = entire DB pulled
 - supplierId in responses is a UUID, not a supplier code (MSC != "MSC001")
 - URL-encode spaces in filter strings (MRO SUPPLIES -> MRO%20SUPPLIES)
 - API key must be in header — URL parameter returns 401
 - PowerShell: use Invoke-RestMethod, not curl (alias doesn't pass headers)
-- Tooling 403s look like 404s — it's a subscription issue, not missing endpoints
+- Tooling 403s on tooling/v1/* are SUSPECTED to be tenant scoping, not API
+  collection subscription. Working hypothesis only — cannot verify until
+  tenant routing lands. See issue #1.
 - Fusion Tool objects from CAM API are copies, not references
 - ADC stale file guard will abort sync if network share files are > 25h old
 - BROTHER SPEEDIO ALUMINUM.json is committed to repo for reference only —

--- a/Plex_API_Reference.md
+++ b/Plex_API_Reference.md
@@ -40,10 +40,12 @@ The target architecture requires pushing Fusion 360 data to the Tooling/Workcent
 | Purchasing | `purchasing/v1/purchase-orders` | Returns full PO headers (e.g., tooling orders from MSC). |
 | Production | `production/v1/control/workcenters` | Discovered on Dev Portal. Replaces old 404 manufacturing endpoint. |
 
-### ⚠️ Blocked Endpoints (Action Required)
->
+### ⚠️ 403 Responses — Tenant Routing Suspected
+
 > [!IMPORTANT]
-> **ACTION REQUIRED**: IT (Courtney) must enable the **Tooling** and **Manufacturing** API collections for the currently active App in the Plex Developer Portal. Initial testing returned 403 authorization failures. The Tooling endpoint documentation remains completely hidden from the public developer portal until you authenticate with a subscribed developer account.
+> **ACTION REQUIRED**: IT (Courtney) must complete the tenant routing change so Grace Engineering credentials land on the Grace tenant (`a6af9c99-bce5-4938-a007-364dc5603d08`) instead of G5 (`b406c8c4-cef0-4d62-862c-1758b702cd02`). This is the **only** open IT blocker.
+>
+> The 403s observed on the endpoints below are suspected to be tenant-scoping rather than API collection subscription. **This is a working hypothesis** — we cannot verify it until tenant access is resolved, because G5 is another company's production data and we have no authority to test writes there. Re-run `discover_all()` once tenant routing lands to confirm.
 
 - `tooling/v1/tools`
 - `tooling/v1/tool-assemblies`

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,9 @@
 
 This document outlines the step-by-step implementation plan for the Autodesk Fusion 360 tool library to Plex Manufacturing Cloud synchronization project.
 
+> **Live tracking:** All unchecked items below are mirrored as GitHub Issues.
+> See <https://github.com/grace-shane/plex-api/issues> for current status, comments, and blockers.
+
 ## Phase 1: API Discovery & Authentication
 
 - [x] Set up Postman and discover relevant Plex API endpoints.
@@ -17,26 +20,27 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 
 ## Phase 3: Plex API Source-of-Truth Implementation
 
-- [ ] Implement API call to retrieve current tooling inventory from Plex (master list) to prep for overwrite.
-- [ ] Implement API call to update/create purchased parts (focused first on **consumables** like cutting tools) in Plex.
-- [ ] Implement API call to create/update Tool Assemblies, assigning the purchased consumable parts to them.
-- [ ] Implement API call to link Tool Assemblies to Routings/Operations.
-- [ ] Implement API call to update tooling within the specific Workcenter Document (`production/v1/control/workcenters`).
-- [ ] **BLOCKED**: Waiting on IT (Courtney) to enable Tooling & Manufacturing APIs in the Developer Portal.
+- [ ] Implement API call to retrieve current tooling inventory from Plex (master list) to prep for overwrite. → [#2](https://github.com/grace-shane/plex-api/issues/2)
+- [ ] Implement API call to update/create purchased parts (focused first on **consumables** like cutting tools) in Plex. → [#3](https://github.com/grace-shane/plex-api/issues/3)
+- [ ] Implement API call to create/update Tool Assemblies, assigning the purchased consumable parts to them. → [#4](https://github.com/grace-shane/plex-api/issues/4)
+- [ ] Implement API call to link Tool Assemblies to Routings/Operations. → [#5](https://github.com/grace-shane/plex-api/issues/5)
+- [ ] Implement API call to update tooling within the specific Workcenter Document (`production/v1/control/workcenters`). → [#6](https://github.com/grace-shane/plex-api/issues/6)
+- [ ] **BLOCKED**: Waiting on IT (Courtney) to enable Tooling & Manufacturing APIs in the Developer Portal. → [#1](https://github.com/grace-shane/plex-api/issues/1)
 
 ## Phase 4: Data Mapping & Sync Logic
 
 - [x] Create a mapping definition between Fusion 360 data structures and Plex API payload requirements (Completed in `Fusion360_Tool_Library_Reference.md`).
-- [ ] Implement the core synchronization logic:
+- [ ] Implement the core synchronization logic: → [#7](https://github.com/grace-shane/plex-api/issues/7)
   - Utilize the Fusion JSON file output as the explicit Source of Truth relative to Plex.
   - Push updates for purchased consumables to the master inventory list.
   - Link those consumables into Tool Assemblies.
   - Ensure those assemblies dynamically flow down to the Routing and then the Job when run in the shop, linking tools directly to manufactured parts.
   - Push final setups to the workcenter documents.
-- [ ] Add basic error handling and logging (e.g., logging successful syncs or failed API calls to a text file on the network share).
+- [ ] Add basic error handling and logging (e.g., logging successful syncs or failed API calls to a text file on the network share). → [#8](https://github.com/grace-shane/plex-api/issues/8)
 
 ## Phase 5: Automation & Deployment
 
-- [ ] Finalize the synchronization script.
-- [ ] Deploy the script to a server or always-on PC with access to the network share.
-- [ ] Schedule the script to run daily at midnight (e.g., using Windows Task Scheduler).
+- [ ] Finalize the synchronization script. → [#9](https://github.com/grace-shane/plex-api/issues/9)
+- [ ] Deploy the script to a server or always-on PC with access to the network share. → [#10](https://github.com/grace-shane/plex-api/issues/10)
+- [ ] Schedule the script to run daily at midnight (e.g., using Windows Task Scheduler). → [#11](https://github.com/grace-shane/plex-api/issues/11)
+- [ ] Rotate the Plex API key before production (previous key is still in git history). → [#12](https://github.com/grace-shane/plex-api/issues/12)

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 - [ ] Implement API call to create/update Tool Assemblies, assigning the purchased consumable parts to them. → [#4](https://github.com/grace-shane/plex-api/issues/4)
 - [ ] Implement API call to link Tool Assemblies to Routings/Operations. → [#5](https://github.com/grace-shane/plex-api/issues/5)
 - [ ] Implement API call to update tooling within the specific Workcenter Document (`production/v1/control/workcenters`). → [#6](https://github.com/grace-shane/plex-api/issues/6)
-- [ ] **BLOCKED**: Waiting on IT (Courtney) to enable Tooling & Manufacturing APIs in the Developer Portal. → [#1](https://github.com/grace-shane/plex-api/issues/1)
+- [ ] **BLOCKED**: Waiting on IT (Courtney) to complete tenant routing so credentials land on Grace Engineering instead of G5. Hypothesis: the 403s on `tooling/v1/*` endpoints will resolve once tenant access is fixed. → [#1](https://github.com/grace-shane/plex-api/issues/1)
 
 ## Phase 4: Data Mapping & Sync Logic
 

--- a/app.py
+++ b/app.py
@@ -1,19 +1,22 @@
 from flask import Flask, render_template, jsonify, request
 import os
 import json
+import time
 import traceback
+import requests
 
 # Import our existing scripts
 from plex_api import (
-    PlexClient, 
-    API_KEY, 
-    TENANT_ID, 
+    PlexClient,
+    API_KEY,
+    API_SECRET,
+    TENANT_ID,
     USE_TEST,
     discover_all,
     extract_parts,
     extract_purchase_orders,
     extract_workcenters,
-    extract_operations
+    extract_operations,
 )
 from tool_library_loader import load_all_libraries
 
@@ -22,14 +25,92 @@ app = Flask(__name__)
 # Initialize Plex Client
 client = PlexClient(
     api_key=API_KEY,
+    api_secret=API_SECRET,
     tenant_id=TENANT_ID,
-    use_test=USE_TEST
+    use_test=USE_TEST,
 )
+
 
 @app.route('/')
 def index():
     """Serve the main dashboard HTML."""
     return render_template('index.html')
+
+
+# ─────────────────────────────────────────────
+# Raw proxy — lets the UI hit ANY Plex endpoint
+# through the authenticated PlexClient without
+# ever exposing credentials to the browser.
+# ─────────────────────────────────────────────
+@app.route('/api/plex/raw', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
+def api_plex_raw():
+    """
+    Proxy an arbitrary Plex REST call.
+
+    Query params (for the tester):
+        path   — full path after the base URL, e.g. "mdm/v1/parts"
+        ...    — all other query params are forwarded as-is to Plex
+
+    For non-GET, JSON body from the client is forwarded as-is.
+    Always returns {status, http_status, elapsed_ms, size_bytes, headers, body}.
+    """
+    path = (request.args.get('path') or '').strip().lstrip('/')
+    if not path:
+        return jsonify({
+            "status": "error",
+            "message": "Missing required 'path' query param (e.g. mdm/v1/parts)",
+        }), 400
+
+    # Forward all query params EXCEPT our own 'path' marker.
+    forwarded_params = {k: v for k, v in request.args.items() if k != 'path'}
+
+    url = f"{client.base}/{path}"
+    method = request.method.upper()
+
+    body = None
+    if method in ('POST', 'PUT', 'PATCH'):
+        body = request.get_json(silent=True)
+
+    started = time.perf_counter()
+    try:
+        r = requests.request(
+            method=method,
+            url=url,
+            headers=client.headers,
+            params=forwarded_params,
+            json=body,
+            timeout=30,
+        )
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+        # Try to parse JSON, fall back to text
+        try:
+            parsed = r.json()
+        except ValueError:
+            parsed = r.text
+
+        return jsonify({
+            "status": "success" if r.ok else "error",
+            "http_status": r.status_code,
+            "http_reason": r.reason,
+            "elapsed_ms": elapsed_ms,
+            "size_bytes": len(r.content),
+            "url": r.url,
+            "method": method,
+            "headers": dict(r.headers),
+            "body": parsed,
+        })
+    except requests.exceptions.RequestException as e:
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        return jsonify({
+            "status": "error",
+            "http_status": 0,
+            "elapsed_ms": elapsed_ms,
+            "url": url,
+            "method": method,
+            "message": str(e),
+        }), 502
+
 
 @app.route('/api/plex/discover')
 def api_discover():
@@ -39,6 +120,7 @@ def api_discover():
         return jsonify({"status": "success", "data": report})
     except Exception as e:
         return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
 
 @app.route('/api/plex/<endpoint_type>')
 def api_extract(endpoint_type):
@@ -54,14 +136,15 @@ def api_extract(endpoint_type):
             data = extract_operations(client)
         else:
             return jsonify({"status": "error", "message": "Unknown endpoint"}), 400
-            
+
         return jsonify({
-            "status": "success", 
+            "status": "success",
             "count": len(data) if data else 0,
             "data": data[:100] if data else []  # Return first 100 for UI performance
         })
     except Exception as e:
         return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
 
 @app.route('/api/fusion/tools', methods=['GET', 'POST'])
 def api_fusion_tools():
@@ -81,16 +164,16 @@ def api_fusion_tools():
         else:
             abort_on_stale = request.args.get('abort_on_stale', 'true').lower() == 'true'
             libs = load_all_libraries(abort_on_stale=abort_on_stale)
-        
+
         # Transform the dict of libraries into a UI-friendly list
         summary = []
         for name, tools in libs.items():
             summary.append({
                 "library_name": name,
                 "tool_count": len(tools),
-                "tools_sample": tools[:5] # Send a sample for the UI
+                "tools_sample": tools[:5]  # Send a sample for the UI
             })
-            
+
         return jsonify({
             "status": "success",
             "library_count": len(libs),
@@ -98,6 +181,19 @@ def api_fusion_tools():
         })
     except Exception as e:
         return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+@app.route('/api/config')
+def api_config():
+    """Expose non-secret client config to the UI (base URL, tenant, env)."""
+    return jsonify({
+        "base_url": client.base,
+        "environment": "test" if USE_TEST else "production",
+        "tenant_id": TENANT_ID,
+        "has_key": bool(API_KEY),
+        "has_secret": bool(API_SECRET),
+    })
+
 
 if __name__ == '__main__':
     # Run the server on port 5000

--- a/app.py
+++ b/app.py
@@ -1,0 +1,105 @@
+from flask import Flask, render_template, jsonify, request
+import os
+import json
+import traceback
+
+# Import our existing scripts
+from plex_api import (
+    PlexClient, 
+    API_KEY, 
+    TENANT_ID, 
+    USE_TEST,
+    discover_all,
+    extract_parts,
+    extract_purchase_orders,
+    extract_workcenters,
+    extract_operations
+)
+from tool_library_loader import load_all_libraries
+
+app = Flask(__name__)
+
+# Initialize Plex Client
+client = PlexClient(
+    api_key=API_KEY,
+    tenant_id=TENANT_ID,
+    use_test=USE_TEST
+)
+
+@app.route('/')
+def index():
+    """Serve the main dashboard HTML."""
+    return render_template('index.html')
+
+@app.route('/api/plex/discover')
+def api_discover():
+    """Run discover_all on Plex."""
+    try:
+        report = discover_all(client)
+        return jsonify({"status": "success", "data": report})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+@app.route('/api/plex/<endpoint_type>')
+def api_extract(endpoint_type):
+    """Run one of the extraction tools."""
+    try:
+        if endpoint_type == 'parts':
+            data = extract_parts(client)
+        elif endpoint_type == 'purchase_orders':
+            data = extract_purchase_orders(client, date_from="2025-01-01")
+        elif endpoint_type == 'workcenters':
+            data = extract_workcenters(client)
+        elif endpoint_type == 'operations':
+            data = extract_operations(client)
+        else:
+            return jsonify({"status": "error", "message": "Unknown endpoint"}), 400
+            
+        return jsonify({
+            "status": "success", 
+            "count": len(data) if data else 0,
+            "data": data[:100] if data else []  # Return first 100 for UI performance
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+@app.route('/api/fusion/tools', methods=['GET', 'POST'])
+def api_fusion_tools():
+    """Load Fusion 360 libraries."""
+    try:
+        libs = {}
+        if request.method == 'POST':
+            for key, uploaded_file in request.files.items():
+                if uploaded_file.filename.endswith('.json'):
+                    content = uploaded_file.read().decode('utf-8')
+                    try:
+                        raw = json.loads(content)
+                        if 'data' in raw and isinstance(raw['data'], list):
+                            libs[uploaded_file.filename.replace('.json', '')] = raw['data']
+                    except Exception as e:
+                        print(f"Error parsing {uploaded_file.filename}: {e}")
+        else:
+            abort_on_stale = request.args.get('abort_on_stale', 'true').lower() == 'true'
+            libs = load_all_libraries(abort_on_stale=abort_on_stale)
+        
+        # Transform the dict of libraries into a UI-friendly list
+        summary = []
+        for name, tools in libs.items():
+            summary.append({
+                "library_name": name,
+                "tool_count": len(tools),
+                "tools_sample": tools[:5] # Send a sample for the UI
+            })
+            
+        return jsonify({
+            "status": "success",
+            "library_count": len(libs),
+            "data": summary
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+if __name__ == '__main__':
+    # Run the server on port 5000
+    print("Starting UX Test Server...")
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from plex_api import (
     extract_operations,
 )
 from tool_library_loader import load_all_libraries
+from plex_diagnostics import tenant_whoami, list_tenants, get_tenant
 
 app = Flask(__name__)
 
@@ -118,6 +119,45 @@ def api_discover():
     try:
         report = discover_all(client)
         return jsonify({"status": "success", "data": report})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+# ─────────────────────────────────────────────
+# Diagnostics — read-only sanity checks
+# ─────────────────────────────────────────────
+@app.route('/api/diagnostics/tenant')
+def api_diagnostics_tenant():
+    """
+    Composite tenant diagnostic.
+
+    Calls /mdm/v1/tenants and (if a TENANT_ID is configured) /mdm/v1/tenants/{id},
+    then compares the result against the known Grace and G5 UUIDs so the UI can
+    show a clear "is this the right tenant?" status. Read-only and safe.
+    """
+    try:
+        report = tenant_whoami(client, TENANT_ID)
+        return jsonify({"status": "success", "data": report})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+@app.route('/api/diagnostics/tenants/list')
+def api_diagnostics_tenants_list():
+    """Raw GET /mdm/v1/tenants — list all tenants visible to the credential."""
+    try:
+        data = list_tenants(client)
+        return jsonify({"status": "success", "data": data})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+@app.route('/api/diagnostics/tenants/<tenant_id>')
+def api_diagnostics_tenant_get(tenant_id):
+    """Raw GET /mdm/v1/tenants/{id} — fetch a single tenant by UUID."""
+    try:
+        data = get_tenant(client, tenant_id)
+        return jsonify({"status": "success", "data": data})
     except Exception as e:
         return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
 

--- a/plex_api.py
+++ b/plex_api.py
@@ -271,18 +271,18 @@ def discover_all(client):
             status = r.status_code
             note = ""
             if status == 200:
-                note = "✅ Available"
+                note = "[OK] Available"
             elif status == 401:
-                note = "❌ Auth error"
+                note = "[ERR] Auth error"
             elif status == 403:
-                note = "🔒 Not subscribed"
+                note = "[LOCK] Not subscribed"
             elif status == 404:
-                note = "❓ Not found"
+                note = "[?] Not found"
             else:
-                note = f"⚠️  HTTP {status}"
+                note = f"[!] HTTP {status}"
         except Exception as e:
             status = 0
-            note = f"❌ Exception: {e}"
+            note = f"[ERR] Exception: {e}"
 
         print(f"  {note:25s} {collection}/{version}/{resource}")
         report.append({

--- a/plex_api.py
+++ b/plex_api.py
@@ -17,11 +17,16 @@ from datetime import datetime
 # ─────────────────────────────────────────────
 # CONFIGURATION — fill these in
 # ─────────────────────────────────────────────
-API_KEY     = "k3SmLW3y3mhqJiG6osixbYUmiPsHfB51"       # from developers.plex.com → My Apps
-TENANT_ID   = "a6af9c99-bce5-4938-a007-364dc5603d08"                             # leave blank for default tenant (your PCN)
+# Credentials come from environment variables — never hardcode/commit.
+#   PLEX_API_KEY     — Consumer Key from developers.plex.com → My Apps
+#   PLEX_API_SECRET  — Consumer Secret, paired with the key
+API_KEY     = os.environ.get("PLEX_API_KEY", "")
+API_SECRET  = os.environ.get("PLEX_API_SECRET", "")
+# Tenant IDs are not secrets — safe to commit. G5 is what we currently have access to.
+TENANT_ID   = "b406c8c4-cef0-4d62-862c-1758b702cd02"  # G5 (read-only) — Grace UUID = a6af9c99-bce5-4938-a007-364dc5603d08
 BASE_URL    = "https://connect.plex.com"
 TEST_URL    = "https://test.connect.plex.com"
-USE_TEST    = False                          # flip to True to hit test environment first
+USE_TEST    = True                           # all dev work goes against test.connect.plex.com
 
 OUTPUT_DIR   = "C:/projects/plex-api/outputs"
 TOOL_LIB_DIR = "Z:\\Engineering\\Tooling\\Fusion_Libraries"  # Mapped drive path containing JSON files
@@ -30,13 +35,15 @@ TOOL_LIB_DIR = "Z:\\Engineering\\Tooling\\Fusion_Libraries"  # Mapped drive path
 # BASE CLIENT
 # ─────────────────────────────────────────────
 class PlexClient:
-    def __init__(self, api_key, tenant_id="", use_test=False):
+    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False):
         self.base = TEST_URL if use_test else BASE_URL
         self.headers = {
             "X-Plex-Connect-Api-Key": api_key,
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+        if api_secret:
+            self.headers["X-Plex-Connect-Api-Secret"] = api_secret
         if tenant_id:
             self.headers["X-Plex-Connect-Tenant-Id"] = tenant_id
 
@@ -341,8 +348,14 @@ def explore_parts(client):
 
 
 if __name__ == "__main__":
+    if not API_KEY or not API_SECRET:
+        raise SystemExit(
+            "Missing credentials. Set PLEX_API_KEY and PLEX_API_SECRET environment variables."
+        )
+
     client = PlexClient(
         api_key=API_KEY,
+        api_secret=API_SECRET,
         tenant_id=TENANT_ID,
         use_test=USE_TEST,
     )

--- a/plex_diagnostics.py
+++ b/plex_diagnostics.py
@@ -1,0 +1,212 @@
+"""
+plex_diagnostics.py
+Plex Connect — diagnostic checks
+================================
+Small suite of read-only checks against the Plex API to verify connectivity,
+authentication, and tenant routing. Used as a sanity layer before any sync
+work and as the visible "is the right tenant connected?" indicator in the UI.
+
+All functions are read-only and safe to run against any tenant — including
+G5, where we have read access only.
+"""
+
+from typing import Any
+
+# ─────────────────────────────────────────────
+# Known tenants
+# Tenant IDs are not secrets — committing them is fine. These labels are
+# used to make the whoami report human-readable.
+# ─────────────────────────────────────────────
+GRACE_TENANT_ID = "a6af9c99-bce5-4938-a007-364dc5603d08"
+G5_TENANT_ID    = "b406c8c4-cef0-4d62-862c-1758b702cd02"
+
+KNOWN_TENANTS = {
+    GRACE_TENANT_ID: "Grace Engineering",
+    G5_TENANT_ID:    "G5",
+}
+
+
+# ─────────────────────────────────────────────
+# Raw endpoint wrappers
+# ─────────────────────────────────────────────
+def list_tenants(client) -> Any:
+    """
+    GET /mdm/v1/tenants
+
+    Returns the list of tenants visible to the active credential.
+    For a correctly-scoped credential this is typically a single tenant
+    (the one your API key is bound to). Useful for confirming which
+    tenant the credential actually lands on.
+    """
+    return client.get("mdm", "v1", "tenants")
+
+
+def get_tenant(client, tenant_id: str) -> Any:
+    """
+    GET /mdm/v1/tenants/{id}
+
+    Returns the full record for a specific tenant. 404 if the tenant
+    does not exist or is not visible to the credential.
+    """
+    return client.get("mdm", "v1", f"tenants/{tenant_id}")
+
+
+# ─────────────────────────────────────────────
+# Composite check — the main diagnostic
+# ─────────────────────────────────────────────
+def tenant_whoami(client, configured_tenant_id: str = "") -> dict:
+    """
+    Composite tenant diagnostic.
+
+    Calls list_tenants() and (if a configured ID is provided) get_tenant(),
+    then compares the visible tenant(s) against the known Grace and G5 UUIDs
+    so the UI can show a clear "is this the right tenant?" status.
+
+    Returns a structured report:
+        {
+            "configured_tenant_id":    "<uuid or ''>",
+            "configured_tenant_label": "Grace Engineering" | "G5" | "unknown",
+            "visible_tenants":         [{id, code, name, label}, ...],
+            "list_tenants_raw":        <raw API response>,
+            "get_tenant_raw":          <raw API response or None>,
+            "match":                   "grace" | "g5" | "configured" |
+                                       "other" | "no_data",
+            "summary":                 "<one-line human-readable status>",
+        }
+    """
+    report: dict = {
+        "configured_tenant_id":    configured_tenant_id or "",
+        "configured_tenant_label": KNOWN_TENANTS.get(configured_tenant_id, "unknown"),
+        "visible_tenants":         [],
+        "list_tenants_raw":        None,
+        "get_tenant_raw":          None,
+        "match":                   "no_data",
+        "summary":                 "",
+    }
+
+    # ── Step 1: list_tenants ────────────────────
+    listed = list_tenants(client)
+    report["list_tenants_raw"] = listed
+
+    if listed is None:
+        report["summary"] = (
+            "list_tenants returned no data — credentials likely invalid, "
+            "or test.connect.plex.com is unreachable."
+        )
+        return report
+
+    # Normalize the response. Plex sometimes wraps lists in {data|items|rows}.
+    if isinstance(listed, list):
+        items = listed
+    elif isinstance(listed, dict):
+        items = (
+            listed.get("items")
+            or listed.get("data")
+            or listed.get("rows")
+            or [listed]   # single tenant returned as a bare object
+        )
+    else:
+        items = []
+
+    visible: list[dict] = []
+    for t in items:
+        if not isinstance(t, dict):
+            continue
+        tid = t.get("id") or t.get("tenantId") or t.get("Id")
+        visible.append({
+            "id":    tid,
+            "code":  t.get("code") or t.get("Code"),
+            "name":  t.get("name") or t.get("Name"),
+            "label": KNOWN_TENANTS.get(tid, "unknown"),
+        })
+    report["visible_tenants"] = visible
+
+    # ── Step 2: get_tenant for the configured ID ────────────────
+    if configured_tenant_id:
+        report["get_tenant_raw"] = get_tenant(client, configured_tenant_id)
+
+    # ── Step 3: match logic ─────────────────────
+    visible_ids = {t["id"] for t in visible if t.get("id")}
+
+    if not visible_ids:
+        report["match"] = "no_data"
+        report["summary"] = (
+            "list_tenants returned a response but no tenant IDs could be parsed. "
+            "Check the raw response in this report."
+        )
+        return report
+
+    if GRACE_TENANT_ID in visible_ids:
+        report["match"] = "grace"
+        report["summary"] = (
+            "[OK] Connected to Grace Engineering. Tenant routing is resolved — "
+            "you may flip TENANT_ID in plex_api.py to the Grace UUID and "
+            "begin write-path testing."
+        )
+        return report
+
+    if G5_TENANT_ID in visible_ids:
+        report["match"] = "g5"
+        report["summary"] = (
+            "[WARN] Connected to G5 (read-only, another company's data). "
+            "Awaiting IT (Courtney) to complete tenant routing for Grace. "
+            "All writes are prohibited until this resolves — see issue #1."
+        )
+        return report
+
+    if configured_tenant_id and configured_tenant_id in visible_ids:
+        report["match"] = "configured"
+        report["summary"] = (
+            f"Connected to the configured tenant "
+            f"({report['configured_tenant_label']}), which is neither "
+            f"Grace nor G5. Verify this is intentional."
+        )
+        return report
+
+    report["match"] = "other"
+    report["summary"] = (
+        "Connected to an unrecognized tenant. Inspect visible_tenants in "
+        "this report and confirm the credential routing is what you expect."
+    )
+    return report
+
+
+# ─────────────────────────────────────────────
+# Standalone test
+# ─────────────────────────────────────────────
+if __name__ == "__main__":
+    import json
+    import sys
+
+    # Force UTF-8 stdout so em-dashes / brackets in summary strings don't
+    # blow up on a Windows cp1252 console.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    from plex_api import PlexClient, API_KEY, API_SECRET, TENANT_ID, USE_TEST
+
+    if not API_KEY or not API_SECRET:
+        raise SystemExit(
+            "Missing credentials. Set PLEX_API_KEY and PLEX_API_SECRET "
+            "environment variables before running this diagnostic."
+        )
+
+    client = PlexClient(
+        api_key=API_KEY,
+        api_secret=API_SECRET,
+        tenant_id=TENANT_ID,
+        use_test=USE_TEST,
+    )
+
+    print(f"Plex Diagnostics — {'TEST' if USE_TEST else 'PRODUCTION'}")
+    print(f"Base URL: {client.base}")
+    print(f"Configured TENANT_ID: {TENANT_ID}\n")
+
+    report = tenant_whoami(client, TENANT_ID)
+
+    print("─" * 60)
+    print(report["summary"])
+    print("─" * 60)
+    print(json.dumps(report, indent=2, default=str))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short
+filterwarnings =
+    ignore::DeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+requests>=2.31

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,474 +1,567 @@
-/* 
-  Modern Premium Dark Theme 
-  Glassmorphism + Gradients + Micro-animations
-*/
+/*
+ * plex-api · endpoint tester
+ * Flat, neutral, no gradients, no glass, no glow.
+ * Single blue accent. Semantic color only for status.
+ */
 
 :root {
-    --bg-base: #0f1115;
-    --bg-panel: rgba(25, 28, 36, 0.6);
-    --panel-border: rgba(255, 255, 255, 0.08);
-    
-    --text-main: #f1f3f5;
-    --text-muted: #8b92a5;
-    
-    --accent-gradient: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
-    --accent-glow: rgba(168, 85, 247, 0.4);
-    --accent-hover: rgba(99, 102, 241, 0.2);
-    
-    --success: #10b981;
-    --error: #ef4444;
-    
-    --font-ui: 'Inter', system-ui, -apple-system, sans-serif;
+    /* surface */
+    --bg-0: #0b0b0d;   /* base */
+    --bg-1: #111115;   /* panel */
+    --bg-2: #17171c;   /* panel hover / input */
+    --bg-3: #1d1d23;   /* chip */
+    --border: #24242b;
+    --border-strong: #2e2e36;
+
+    /* text */
+    --fg-0: #f2f2f3;
+    --fg-1: #c9c9cf;
+    --fg-2: #8a8a94;
+    --fg-3: #55555e;
+
+    /* accents (solid, single hue) */
+    --accent: #3b82f6;
+    --accent-hover: #2563eb;
+    --accent-fg: #ffffff;
+
+    /* semantic */
+    --ok: #22c55e;
+    --warn: #eab308;
+    --err: #ef4444;
+    --info: #38bdf8;
+
+    /* http methods */
+    --get: #22c55e;
+    --post: #eab308;
+    --put: #38bdf8;
+    --patch: #a855f7;
+    --delete: #ef4444;
+    --internal: #8a8a94;
+
+    /* metrics */
+    --rail-w: 280px;
+    --radius: 4px;
+    --radius-lg: 6px;
+
+    /* fonts */
+    --font-ui: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+    height: 100%;
 }
 
 body {
-    background-color: var(--bg-base);
-    color: var(--text-main);
+    background: var(--bg-0);
+    color: var(--fg-0);
     font-family: var(--font-ui);
-    height: 100vh;
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
     overflow: hidden;
-    background-image: 
-        radial-gradient(circle at 15% 50%, rgba(99, 102, 241, 0.08), transparent 25%),
-        radial-gradient(circle at 85% 30%, rgba(236, 72, 153, 0.08), transparent 25%);
 }
 
-.dashboard-wrapper {
-    display: flex;
+button, input, select, textarea {
+    font: inherit;
+    color: inherit;
+}
+
+button { cursor: pointer; }
+
+/* ─────────────────────────────────
+   Layout
+   ───────────────────────────────── */
+.app {
+    display: grid;
+    grid-template-columns: var(--rail-w) 1fr;
     height: 100vh;
-    padding: 1rem;
-    gap: 1rem;
 }
 
-/* Glassmorphism Utilities */
-.glass-panel {
-    background: var(--bg-panel);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border: 1px solid var(--panel-border);
-    border-radius: 16px;
-    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
-}
-
-/* -------------------------------
-   Sidebar
-------------------------------- */
-.sidebar {
-    width: 280px;
+/* ─────────────────────────────────
+   Left rail
+   ───────────────────────────────── */
+.rail {
+    background: var(--bg-1);
+    border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
-    padding: 1.5rem;
+    overflow: hidden;
+}
+
+.rail-header {
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border);
     flex-shrink: 0;
 }
 
-.sidebar-header {
+.brand {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--fg-0);
+}
+
+.env-chip {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 3px 7px;
+    border-radius: var(--radius);
+    background: var(--bg-3);
+    color: var(--fg-2);
+    border: 1px solid var(--border);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.env-chip.test { color: var(--warn); border-color: rgba(234, 179, 8, 0.3); }
+.env-chip.prod { color: var(--err); border-color: rgba(239, 68, 68, 0.3); }
+
+.rail-section {
+    padding: 12px 12px 16px;
+    border-bottom: 1px solid var(--border);
+}
+
+.rail-section.rail-history {
+    border-bottom: none;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.rail-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    padding: 4px 4px 8px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 2.5rem;
 }
 
-.sidebar-header h2 {
-    font-size: 1.25rem;
-    font-weight: 700;
-    background: var(--accent-gradient);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
+.rail-sub {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+    padding: 0 2px;
 }
 
-.badge {
-    background: rgba(255,255,255,0.1);
-    font-size: 0.75rem;
-    padding: 2px 8px;
-    border-radius: 9999px;
-    font-weight: 600;
-}
-
-.action-nav {
+.preset-list {
+    list-style: none;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1px;
 }
 
-.nav-group h3 {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    margin-bottom: 1rem;
-}
-
-.nav-group {
+.preset {
+    width: 100%;
     display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.mt-2 {
-    margin-top: 1rem;
-}
-
-/* Buttons */
-.action-btn {
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
     background: transparent;
     border: 1px solid transparent;
-    color: var(--text-main);
-    padding: 0.75rem 1rem;
-    border-radius: 8px;
-    font-family: var(--font-ui);
-    font-size: 0.9rem;
-    font-weight: 500;
+    border-radius: var(--radius);
     text-align: left;
-    cursor: pointer;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
+    color: var(--fg-1);
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    transition: background 0.08s ease, border-color 0.08s ease;
 }
 
-.action-btn:hover {
-    background: var(--accent-hover);
-    border-color: rgba(99, 102, 241, 0.5);
-    transform: translateX(4px);
+.preset:hover {
+    background: var(--bg-2);
 }
 
-.action-btn.active {
-    background: rgba(255,255,255,0.1);
-    border-color: var(--panel-border);
+.preset:focus-visible {
+    outline: none;
+    border-color: var(--accent);
 }
 
-.accent-btn {
-    background: var(--accent-gradient);
-    border: none;
-    font-weight: 600;
-    box-shadow: 0 4px 15px var(--accent-glow);
+.preset .m {
+    flex-shrink: 0;
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 2px 5px;
+    border-radius: 3px;
+    background: var(--bg-3);
+    color: var(--fg-2);
+    min-width: 34px;
+    text-align: center;
 }
 
-.accent-btn:hover {
-    background: var(--accent-gradient);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px var(--accent-glow);
-}
+.preset .m-get { color: var(--get); }
+.preset .m-post { color: var(--post); }
+.preset .m-put { color: var(--put); }
+.preset .m-patch { color: var(--patch); }
+.preset .m-delete { color: var(--delete); }
+.preset .m-int { color: var(--internal); }
 
-/* -------------------------------
-   Main Content Area
-------------------------------- */
-.main-content {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    overflow: hidden;
-}
-
-.top-bar {
-    padding: 1rem 2rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.status-indicator {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: var(--text-muted);
-}
-
-.pulse-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: var(--success);
-    box-shadow: 0 0 8px var(--success);
-    animation: pulse 2s infinite;
-}
-
-@keyframes pulse {
-    0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
-    70% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
-}
-
-.data-view {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    position: relative;
-}
-
-.view-header {
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--panel-border);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.ghost-btn {
-    background: transparent;
-    border: 1px solid var(--panel-border);
-    color: var(--text-muted);
-    padding: 0.4rem 0.8rem;
-    border-radius: 6px;
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: 0.2s ease;
-}
-
-.ghost-btn:hover {
-    color: var(--text-main);
-    background: rgba(255,255,255,0.05);
-}
-
-.console-body {
-    flex-grow: 1;
-    padding: 1.5rem;
-    overflow-y: auto;
-}
-
-pre#json-output {
-    font-family: 'Consolas', 'Monaco', monospace;
-    font-size: 0.85rem;
-    color: #a5b4fc; /* soft blue tone for code */
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    line-height: 1.5;
-}
-
-/* -------------------------------
-   Loader Overlay
-------------------------------- */
-#loading-overlay {
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background: rgba(15, 17, 21, 0.8);
-    backdrop-filter: blur(4px);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    z-index: 10;
-    transition: opacity 0.3s ease;
-}
-
-#loading-overlay.hidden {
-    opacity: 0;
-    pointer-events: none;
-}
-
-.spinner {
-    width: 40px;
-    height: 40px;
-    border: 3px solid rgba(255,255,255,0.1);
-    border-top-color: #a855f7;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
-
-/* Custom Scrollbar */
-::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-}
-::-webkit-scrollbar-track {
-    background: transparent;
-}
-::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 4px;
-}
-::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.2);
-}
-
-/* -------------------------------
-   Formatted Output & Library Grid
-------------------------------- */
-#formatted-output {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    animation: fadeIn 0.4s ease forwards;
-}
-
-#formatted-output.hidden {
-    display: none !important;
-}
-
-.formatted-header h2 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--text-main);
-    border-left: 4px solid var(--success);
-    padding-left: 10px;
-}
-
-.library-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: 1.5rem;
-}
-
-.library-card {
-    display: flex;
-    flex-direction: column;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-    background: rgba(25, 28, 36, 0.4);
-}
-
-.library-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.4);
-    border-color: rgba(168, 85, 247, 0.3);
-}
-
-.library-header {
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--panel-border);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: rgba(0,0,0,0.2);
-    border-radius: 16px 16px 0 0;
-}
-
-.library-header h4 {
-    font-size: 1.05rem;
-    font-weight: 600;
-    color: var(--text-main);
+.preset .p {
+    flex: 1;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-right: 10px;
+    color: var(--fg-1);
 }
 
-.accent-badge {
-    background: var(--accent-gradient);
-    color: #fff;
+.preset .tag {
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: rgba(239, 68, 68, 0.1);
+    color: var(--err);
+    border: 1px solid rgba(239, 68, 68, 0.2);
 }
 
-.small-badge {
-    font-size: 0.65rem;
-    background: rgba(255,255,255,0.08);
+/* history list */
+.history-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
 }
 
-.library-body {
-    padding: 1.25rem;
-    flex-grow: 1;
+.history-empty {
+    padding: 10px;
+    color: var(--fg-3);
+    font-size: 11px;
+    text-align: center;
 }
 
-.library-body h5 {
-    font-size: 0.75rem;
+.history-item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-1);
+    text-align: left;
+}
+
+.history-item:hover { background: var(--bg-2); }
+
+.history-item .h-status {
+    flex-shrink: 0;
+    font-weight: 600;
+    font-size: 10px;
+    min-width: 28px;
+}
+.history-item.ok .h-status { color: var(--ok); }
+.history-item.warn .h-status { color: var(--warn); }
+.history-item.err .h-status { color: var(--err); }
+
+.history-item .h-path {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--fg-2);
+}
+
+.history-item .h-time {
+    color: var(--fg-3);
+    font-size: 10px;
+    flex-shrink: 0;
+}
+
+/* ─────────────────────────────────
+   Main
+   ───────────────────────────────── */
+.main {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--bg-0);
+}
+
+/* URL bar */
+.url-bar {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    padding: 14px 16px 8px;
+    flex-shrink: 0;
+}
+
+.method-select {
+    appearance: none;
+    -webkit-appearance: none;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    color: var(--fg-0);
+    padding: 0 28px 0 12px;
+    border-radius: var(--radius);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 600;
+    height: 34px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%238a8a94' stroke-width='1.5' fill='none' stroke-linecap='round'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+}
+
+.method-select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.url-host {
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-right: none;
+    border-radius: var(--radius) 0 0 var(--radius);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--fg-2);
+    white-space: nowrap;
+    height: 34px;
+}
+
+.path-input {
+    flex: 1;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-left: none;
+    border-radius: 0 var(--radius) var(--radius) 0;
+    padding: 0 12px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--fg-0);
+    height: 34px;
+    min-width: 0;
+}
+
+.path-input::placeholder { color: var(--fg-3); }
+
+.path-input:focus,
+.url-host:has(+ .path-input:focus) {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.btn-primary {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border: 1px solid var(--accent);
+    padding: 0 18px;
+    border-radius: var(--radius);
+    font-size: 12px;
+    font-weight: 600;
+    height: 34px;
+    white-space: nowrap;
+    transition: background 0.1s ease;
+}
+
+.btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+.btn-primary:active { transform: none; }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Params row */
+.params-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 16px 12px;
+    flex-shrink: 0;
+}
+
+.params-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    padding-left: 4px;
+    min-width: 48px;
+}
+
+.params-input {
+    flex: 1;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0 12px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--fg-0);
+    height: 30px;
+}
+
+.params-input::placeholder { color: var(--fg-3); }
+
+.params-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* Status strip */
+.status-strip {
+    padding: 10px 16px;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-1);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    min-height: 38px;
+    flex-shrink: 0;
+}
+
+.ss-idle { color: var(--fg-3); }
+.ss-loading { color: var(--fg-2); }
+
+.ss-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--fg-2);
+}
+
+.ss-item .k {
+    color: var(--fg-3);
+    font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--text-muted);
-    margin-bottom: 0.75rem;
 }
 
-.tools-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+.ss-item .v { color: var(--fg-1); font-weight: 600; }
+
+.ss-status {
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: var(--radius);
+    font-size: 11px;
 }
 
-.tool-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.5rem 0.75rem;
-    background: rgba(255,255,255,0.03);
-    border-radius: 6px;
-    border: 1px solid rgba(255,255,255,0.02);
-}
+.ss-status.ok { color: var(--ok); background: rgba(34, 197, 94, 0.1); }
+.ss-status.warn { color: var(--warn); background: rgba(234, 179, 8, 0.1); }
+.ss-status.err { color: var(--err); background: rgba(239, 68, 68, 0.1); }
+.ss-status.info { color: var(--info); background: rgba(56, 189, 248, 0.1); }
 
-.tool-num {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #a855f7;
-    width: 30px;
-}
-
-.tool-desc {
-    font-size: 0.85rem;
-    flex-grow: 1;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.muted {
-    color: var(--text-muted);
-    font-style: italic;
-}
-
-.library-footer {
-    padding: 0.75rem 1.25rem;
-    border-top: 1px solid var(--panel-border);
-    display: flex;
-    justify-content: flex-end;
-}
-
-.btn-sm {
-    padding: 0.3rem 0.6rem;
-    font-size: 0.75rem;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-/* Modal */
-.modal-overlay {
-    position: fixed;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background: rgba(0,0,0,0.6);
-    backdrop-filter: blur(8px);
-    z-index: 100;
+/* Response tabs */
+.resp-tabs {
     display: flex;
     align-items: center;
-    justify-content: center;
-    animation: fadeIn 0.2s ease forwards;
+    gap: 2px;
+    padding: 0 12px;
+    background: var(--bg-1);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
 }
 
-.modal-content {
-    width: 80%;
-    max-width: 800px;
-    max-height: 80vh;
-    display: flex;
-    flex-direction: column;
-    background: var(--bg-base);
+.tab {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 9px 12px;
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--fg-2);
+    margin-bottom: -1px;
 }
 
-.modal-header {
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--panel-border);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+.tab:hover { color: var(--fg-0); }
+.tab.active { color: var(--fg-0); border-bottom-color: var(--accent); }
+
+.tab-spacer { flex: 1; }
+
+/* Response body */
+.resp-body {
+    flex: 1;
+    overflow: auto;
+    background: var(--bg-0);
+    min-height: 0;
 }
 
-.modal-body {
-    padding: 1.5rem;
-    overflow-y: auto;
-    font-family: 'Consolas', 'Monaco', monospace;
-    font-size: 0.85rem;
-    color: #a5b4fc;
-    white-space: pre-wrap;
-    margin: 0;
+.resp-pre {
+    padding: 14px 16px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--fg-1);
+    white-space: pre;
+    tab-size: 2;
 }
+
+.resp-pre.empty { color: var(--fg-3); }
+
+/* JSON syntax coloring (set by JS via classed spans) */
+.json-key { color: var(--accent); }
+.json-str { color: var(--ok); }
+.json-num { color: var(--warn); }
+.json-bool { color: var(--patch); }
+.json-null { color: var(--err); }
+
+/* ─────────────────────────────────
+   Generic buttons
+   ───────────────────────────────── */
+.btn-ghost {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--fg-2);
+    padding: 4px 10px;
+    border-radius: var(--radius);
+    font-size: 11px;
+    transition: background 0.08s, color 0.08s, border-color 0.08s;
+}
+
+.btn-ghost:hover {
+    color: var(--fg-0);
+    background: var(--bg-2);
+    border-color: var(--border-strong);
+}
+
+.btn-xs {
+    padding: 2px 8px;
+    font-size: 10px;
+}
+
+/* ─────────────────────────────────
+   Scrollbars (minimal)
+   ───────────────────────────────── */
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border: 2px solid var(--bg-0);
+    border-radius: 10px;
+}
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+/* ─────────────────────────────────
+   Focus
+   ───────────────────────────────── */
+:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+
+button:focus:not(:focus-visible) { outline: none; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,474 @@
+/* 
+  Modern Premium Dark Theme 
+  Glassmorphism + Gradients + Micro-animations
+*/
+
+:root {
+    --bg-base: #0f1115;
+    --bg-panel: rgba(25, 28, 36, 0.6);
+    --panel-border: rgba(255, 255, 255, 0.08);
+    
+    --text-main: #f1f3f5;
+    --text-muted: #8b92a5;
+    
+    --accent-gradient: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+    --accent-glow: rgba(168, 85, 247, 0.4);
+    --accent-hover: rgba(99, 102, 241, 0.2);
+    
+    --success: #10b981;
+    --error: #ef4444;
+    
+    --font-ui: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-base);
+    color: var(--text-main);
+    font-family: var(--font-ui);
+    height: 100vh;
+    overflow: hidden;
+    background-image: 
+        radial-gradient(circle at 15% 50%, rgba(99, 102, 241, 0.08), transparent 25%),
+        radial-gradient(circle at 85% 30%, rgba(236, 72, 153, 0.08), transparent 25%);
+}
+
+.dashboard-wrapper {
+    display: flex;
+    height: 100vh;
+    padding: 1rem;
+    gap: 1rem;
+}
+
+/* Glassmorphism Utilities */
+.glass-panel {
+    background: var(--bg-panel);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+/* -------------------------------
+   Sidebar
+------------------------------- */
+.sidebar {
+    width: 280px;
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem;
+    flex-shrink: 0;
+}
+
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 2.5rem;
+}
+
+.sidebar-header h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    background: var(--accent-gradient);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.badge {
+    background: rgba(255,255,255,0.1);
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-weight: 600;
+}
+
+.action-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.nav-group h3 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+}
+
+.nav-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.mt-2 {
+    margin-top: 1rem;
+}
+
+/* Buttons */
+.action-btn {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-main);
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    font-family: var(--font-ui);
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.action-btn:hover {
+    background: var(--accent-hover);
+    border-color: rgba(99, 102, 241, 0.5);
+    transform: translateX(4px);
+}
+
+.action-btn.active {
+    background: rgba(255,255,255,0.1);
+    border-color: var(--panel-border);
+}
+
+.accent-btn {
+    background: var(--accent-gradient);
+    border: none;
+    font-weight: 600;
+    box-shadow: 0 4px 15px var(--accent-glow);
+}
+
+.accent-btn:hover {
+    background: var(--accent-gradient);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px var(--accent-glow);
+}
+
+/* -------------------------------
+   Main Content Area
+------------------------------- */
+.main-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow: hidden;
+}
+
+.top-bar {
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-muted);
+}
+
+.pulse-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--success);
+    box-shadow: 0 0 8px var(--success);
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
+    70% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+
+.data-view {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    position: relative;
+}
+
+.view-header {
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--panel-border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.ghost-btn {
+    background: transparent;
+    border: 1px solid var(--panel-border);
+    color: var(--text-muted);
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: 0.2s ease;
+}
+
+.ghost-btn:hover {
+    color: var(--text-main);
+    background: rgba(255,255,255,0.05);
+}
+
+.console-body {
+    flex-grow: 1;
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+pre#json-output {
+    font-family: 'Consolas', 'Monaco', monospace;
+    font-size: 0.85rem;
+    color: #a5b4fc; /* soft blue tone for code */
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    line-height: 1.5;
+}
+
+/* -------------------------------
+   Loader Overlay
+------------------------------- */
+#loading-overlay {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(15, 17, 21, 0.8);
+    backdrop-filter: blur(4px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    z-index: 10;
+    transition: opacity 0.3s ease;
+}
+
+#loading-overlay.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid rgba(255,255,255,0.1);
+    border-top-color: #a855f7;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Custom Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+/* -------------------------------
+   Formatted Output & Library Grid
+------------------------------- */
+#formatted-output {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    animation: fadeIn 0.4s ease forwards;
+}
+
+#formatted-output.hidden {
+    display: none !important;
+}
+
+.formatted-header h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-main);
+    border-left: 4px solid var(--success);
+    padding-left: 10px;
+}
+
+.library-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+.library-card {
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: rgba(25, 28, 36, 0.4);
+}
+
+.library-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.4);
+    border-color: rgba(168, 85, 247, 0.3);
+}
+
+.library-header {
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--panel-border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(0,0,0,0.2);
+    border-radius: 16px 16px 0 0;
+}
+
+.library-header h4 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-main);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 10px;
+}
+
+.accent-badge {
+    background: var(--accent-gradient);
+    color: #fff;
+}
+
+.small-badge {
+    font-size: 0.65rem;
+    background: rgba(255,255,255,0.08);
+}
+
+.library-body {
+    padding: 1.25rem;
+    flex-grow: 1;
+}
+
+.library-body h5 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+}
+
+.tools-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.tool-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(255,255,255,0.03);
+    border-radius: 6px;
+    border: 1px solid rgba(255,255,255,0.02);
+}
+
+.tool-num {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #a855f7;
+    width: 30px;
+}
+
+.tool-desc {
+    font-size: 0.85rem;
+    flex-grow: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.muted {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.library-footer {
+    padding: 0.75rem 1.25rem;
+    border-top: 1px solid var(--panel-border);
+    display: flex;
+    justify-content: flex-end;
+}
+
+.btn-sm {
+    padding: 0.3rem 0.6rem;
+    font-size: 0.75rem;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* Modal */
+.modal-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.6);
+    backdrop-filter: blur(8px);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.2s ease forwards;
+}
+
+.modal-content {
+    width: 80%;
+    max-width: 800px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-base);
+}
+
+.modal-header {
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--panel-border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+    font-family: 'Consolas', 'Monaco', monospace;
+    font-size: 0.85rem;
+    color: #a5b4fc;
+    white-space: pre-wrap;
+    margin: 0;
+}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,0 +1,205 @@
+document.addEventListener('DOMContentLoaded', () => {
+    
+    const actionBtns = document.querySelectorAll('.action-btn');
+    const loadingOverlay = document.getElementById('loading-overlay');
+    const jsonOutput = document.getElementById('json-output');
+    const formattedOutput = document.getElementById('formatted-output');
+    const btnClear = document.getElementById('btn-clear');
+    const viewTitle = document.getElementById('view-title');
+    
+    const btnPickFiles = document.getElementById('btn-pick-files');
+    const btnPickDir = document.getElementById('btn-pick-dir');
+    const fusionFileInput = document.getElementById('fusion-file-input');
+    const fusionDirInput = document.getElementById('fusion-dir-input');
+    
+    // Clear console output
+    btnClear.addEventListener('click', () => {
+        jsonOutput.textContent = "Console cleared. Select an action...";
+        jsonOutput.style.display = 'block';
+        if (formattedOutput) formattedOutput.classList.add('hidden');
+        viewTitle.textContent = "Ready";
+        removeActiveStates();
+    });
+    
+    // Handle action buttons
+    actionBtns.forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+            const endpoint = btn.getAttribute('data-endpoint');
+            const name = btn.getAttribute('data-name');
+            
+            // UI updates
+            removeActiveStates();
+            btn.classList.add('active');
+            viewTitle.textContent = `Executing: ${name}`;
+            
+            await fetchData(endpoint);
+        });
+    });
+    
+    function removeActiveStates() {
+        actionBtns.forEach(b => b.classList.remove('active'));
+    }
+    
+    async function fetchData(url) {
+        // Show loader
+        loadingOverlay.classList.remove('hidden');
+        jsonOutput.textContent = "Fetching data...";
+        jsonOutput.style.display = 'block';
+        if (formattedOutput) formattedOutput.classList.add('hidden');
+        
+        try {
+            const response = await fetch(url);
+            const data = await response.json();
+            
+            if (url.includes('/api/fusion/tools') && data.status === 'success') {
+                renderFusionTools(data);
+            } else {
+                // Format JSON output beautifully
+                jsonOutput.textContent = JSON.stringify(data, null, 4);
+            }
+            
+        } catch (err) {
+            console.error(err);
+            jsonOutput.textContent = `CRITICAL ERROR: Unable to reach backend.\n\n${err.message}`;
+        } finally {
+            // Hide loader
+            loadingOverlay.classList.add('hidden');
+        }
+    }
+
+    function renderFusionTools(data) {
+        jsonOutput.style.display = 'none';
+        formattedOutput.classList.remove('hidden');
+        formattedOutput.innerHTML = '';
+        
+        const header = document.createElement('div');
+        header.className = 'formatted-header';
+        header.innerHTML = `<h2>Successfully Loaded ${data.library_count} Libraries</h2>`;
+        formattedOutput.appendChild(header);
+        
+        const grid = document.createElement('div');
+        grid.className = 'library-grid';
+        
+        data.data.forEach(lib => {
+            const card = document.createElement('div');
+            card.className = 'library-card glass-panel';
+            
+            let toolsHtml = '';
+            if (lib.tools_sample && lib.tools_sample.length > 0) {
+                lib.tools_sample.forEach(tool => {
+                    const desc = tool.description || tool.Description || 'Untitled Tool';
+                    const type = tool.type || tool.Type || 'Unknown Type';
+                    const num = (tool.postProcess && tool.postProcess.number !== undefined) ? tool.postProcess.number : (tool.id || '-');
+                    
+                    toolsHtml += `
+                        <div class="tool-item">
+                            <span class="tool-num">#${num}</span>
+                            <span class="tool-desc">${desc}</span>
+                            <span class="badge small-badge">${type}</span>
+                        </div>
+                    `;
+                });
+            } else {
+                toolsHtml = `<div class="tool-item"><span class="tool-desc muted">No tools found</span></div>`;
+            }
+            
+            card.innerHTML = `
+                <div class="library-header">
+                    <h4>${lib.library_name}</h4>
+                    <span class="badge accent-badge">${lib.tool_count} Tools</span>
+                </div>
+                <div class="library-body">
+                    <h5>Sample Tools</h5>
+                    <div class="tools-list">
+                        ${toolsHtml}
+                    </div>
+                </div>
+                <div class="library-footer">
+                    <button class="ghost-btn btn-sm view-raw-btn" data-lib="${lib.library_name}">View JSON</button>
+                </div>
+            `;
+            
+            // Add view raw JSON functionality
+            const viewRawBtn = card.querySelector('.view-raw-btn');
+            viewRawBtn.addEventListener('click', () => {
+                const modalOverlay = document.createElement('div');
+                modalOverlay.className = 'modal-overlay';
+                modalOverlay.innerHTML = `
+                    <div class="modal-content glass-panel">
+                        <div class="modal-header">
+                            <h4>${lib.library_name} JSON Sample</h4>
+                            <button class="close-modal ghost-btn">Close</button>
+                        </div>
+                        <pre class="modal-body">${JSON.stringify(lib.tools_sample, null, 4)}</pre>
+                    </div>
+                `;
+                document.body.appendChild(modalOverlay);
+                
+                modalOverlay.querySelector('.close-modal').addEventListener('click', () => {
+                    document.body.removeChild(modalOverlay);
+                });
+            });
+            
+            grid.appendChild(card);
+        });
+        
+        formattedOutput.appendChild(grid);
+    }
+
+    if (btnPickFiles && fusionFileInput) {
+        btnPickFiles.addEventListener('click', () => fusionFileInput.click());
+    }
+
+    if (btnPickDir && fusionDirInput) {
+        btnPickDir.addEventListener('click', () => fusionDirInput.click());
+    }
+    
+    const handleFileSelect = async (e) => {
+        const files = e.target.files;
+        if (!files || files.length === 0) return;
+        
+        removeActiveStates();
+        viewTitle.textContent = `Executing: Custom Selection`;
+        loadingOverlay.classList.remove('hidden');
+        jsonOutput.textContent = "Uploading and processing files...";
+        jsonOutput.style.display = 'block';
+        if (formattedOutput) formattedOutput.classList.add('hidden');
+        
+        try {
+            const formData = new FormData();
+            let added = 0;
+            for (let i = 0; i < files.length; i++) {
+                if (files[i].name.endsWith('.json')) {
+                    formData.append('file_' + i, files[i]);
+                    added++;
+                }
+            }
+            
+            if (added === 0) {
+                throw new Error("No valid .json files were found in the selection.");
+            }
+            
+            const response = await fetch('/api/fusion/tools', {
+                method: 'POST',
+                body: formData
+            });
+            const data = await response.json();
+            
+            if (data.status === 'success') {
+                renderFusionTools(data);
+            } else {
+                jsonOutput.textContent = JSON.stringify(data, null, 4);
+            }
+        } catch (err) {
+            console.error(err);
+            jsonOutput.textContent = `CRITICAL ERROR: ${err.message}`;
+        } finally {
+            loadingOverlay.classList.add('hidden');
+            e.target.value = ''; // Reset for re-selection
+        }
+    };
+
+    if (fusionFileInput) fusionFileInput.addEventListener('change', handleFileSelect);
+    if (fusionDirInput) fusionDirInput.addEventListener('change', handleFileSelect);
+
+});

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,205 +1,455 @@
-document.addEventListener('DOMContentLoaded', () => {
-    
-    const actionBtns = document.querySelectorAll('.action-btn');
-    const loadingOverlay = document.getElementById('loading-overlay');
-    const jsonOutput = document.getElementById('json-output');
-    const formattedOutput = document.getElementById('formatted-output');
-    const btnClear = document.getElementById('btn-clear');
-    const viewTitle = document.getElementById('view-title');
-    
-    const btnPickFiles = document.getElementById('btn-pick-files');
-    const btnPickDir = document.getElementById('btn-pick-dir');
-    const fusionFileInput = document.getElementById('fusion-file-input');
-    const fusionDirInput = document.getElementById('fusion-dir-input');
-    
-    // Clear console output
-    btnClear.addEventListener('click', () => {
-        jsonOutput.textContent = "Console cleared. Select an action...";
-        jsonOutput.style.display = 'block';
-        if (formattedOutput) formattedOutput.classList.add('hidden');
-        viewTitle.textContent = "Ready";
-        removeActiveStates();
-    });
-    
-    // Handle action buttons
-    actionBtns.forEach(btn => {
-        btn.addEventListener('click', async (e) => {
-            const endpoint = btn.getAttribute('data-endpoint');
-            const name = btn.getAttribute('data-name');
-            
-            // UI updates
-            removeActiveStates();
-            btn.classList.add('active');
-            viewTitle.textContent = `Executing: ${name}`;
-            
-            await fetchData(endpoint);
-        });
-    });
-    
-    function removeActiveStates() {
-        actionBtns.forEach(b => b.classList.remove('active'));
-    }
-    
-    async function fetchData(url) {
-        // Show loader
-        loadingOverlay.classList.remove('hidden');
-        jsonOutput.textContent = "Fetching data...";
-        jsonOutput.style.display = 'block';
-        if (formattedOutput) formattedOutput.classList.add('hidden');
-        
-        try {
-            const response = await fetch(url);
-            const data = await response.json();
-            
-            if (url.includes('/api/fusion/tools') && data.status === 'success') {
-                renderFusionTools(data);
-            } else {
-                // Format JSON output beautifully
-                jsonOutput.textContent = JSON.stringify(data, null, 4);
-            }
-            
-        } catch (err) {
-            console.error(err);
-            jsonOutput.textContent = `CRITICAL ERROR: Unable to reach backend.\n\n${err.message}`;
-        } finally {
-            // Hide loader
-            loadingOverlay.classList.add('hidden');
-        }
-    }
+/*
+ * plex-api · endpoint tester
+ * Minimal, no framework. Vanilla DOM.
+ */
+(() => {
+    "use strict";
 
-    function renderFusionTools(data) {
-        jsonOutput.style.display = 'none';
-        formattedOutput.classList.remove('hidden');
-        formattedOutput.innerHTML = '';
-        
-        const header = document.createElement('div');
-        header.className = 'formatted-header';
-        header.innerHTML = `<h2>Successfully Loaded ${data.library_count} Libraries</h2>`;
-        formattedOutput.appendChild(header);
-        
-        const grid = document.createElement('div');
-        grid.className = 'library-grid';
-        
-        data.data.forEach(lib => {
-            const card = document.createElement('div');
-            card.className = 'library-card glass-panel';
-            
-            let toolsHtml = '';
-            if (lib.tools_sample && lib.tools_sample.length > 0) {
-                lib.tools_sample.forEach(tool => {
-                    const desc = tool.description || tool.Description || 'Untitled Tool';
-                    const type = tool.type || tool.Type || 'Unknown Type';
-                    const num = (tool.postProcess && tool.postProcess.number !== undefined) ? tool.postProcess.number : (tool.id || '-');
-                    
-                    toolsHtml += `
-                        <div class="tool-item">
-                            <span class="tool-num">#${num}</span>
-                            <span class="tool-desc">${desc}</span>
-                            <span class="badge small-badge">${type}</span>
-                        </div>
-                    `;
-                });
-            } else {
-                toolsHtml = `<div class="tool-item"><span class="tool-desc muted">No tools found</span></div>`;
-            }
-            
-            card.innerHTML = `
-                <div class="library-header">
-                    <h4>${lib.library_name}</h4>
-                    <span class="badge accent-badge">${lib.tool_count} Tools</span>
-                </div>
-                <div class="library-body">
-                    <h5>Sample Tools</h5>
-                    <div class="tools-list">
-                        ${toolsHtml}
-                    </div>
-                </div>
-                <div class="library-footer">
-                    <button class="ghost-btn btn-sm view-raw-btn" data-lib="${lib.library_name}">View JSON</button>
-                </div>
-            `;
-            
-            // Add view raw JSON functionality
-            const viewRawBtn = card.querySelector('.view-raw-btn');
-            viewRawBtn.addEventListener('click', () => {
-                const modalOverlay = document.createElement('div');
-                modalOverlay.className = 'modal-overlay';
-                modalOverlay.innerHTML = `
-                    <div class="modal-content glass-panel">
-                        <div class="modal-header">
-                            <h4>${lib.library_name} JSON Sample</h4>
-                            <button class="close-modal ghost-btn">Close</button>
-                        </div>
-                        <pre class="modal-body">${JSON.stringify(lib.tools_sample, null, 4)}</pre>
-                    </div>
-                `;
-                document.body.appendChild(modalOverlay);
-                
-                modalOverlay.querySelector('.close-modal').addEventListener('click', () => {
-                    document.body.removeChild(modalOverlay);
-                });
-            });
-            
-            grid.appendChild(card);
-        });
-        
-        formattedOutput.appendChild(grid);
-    }
+    // ── DOM ─────────────────────────────────────────
+    const $ = (sel) => document.querySelector(sel);
+    const $$ = (sel) => document.querySelectorAll(sel);
 
-    if (btnPickFiles && fusionFileInput) {
-        btnPickFiles.addEventListener('click', () => fusionFileInput.click());
-    }
+    const methodEl   = $("#method");
+    const pathEl     = $("#path-input");
+    const paramsEl   = $("#params-input");
+    const urlHostEl  = $("#url-host");
+    const sendBtn    = $("#btn-send");
+    const envChipEl  = $("#env-chip");
 
-    if (btnPickDir && fusionDirInput) {
-        btnPickDir.addEventListener('click', () => fusionDirInput.click());
-    }
-    
-    const handleFileSelect = async (e) => {
-        const files = e.target.files;
-        if (!files || files.length === 0) return;
-        
-        removeActiveStates();
-        viewTitle.textContent = `Executing: Custom Selection`;
-        loadingOverlay.classList.remove('hidden');
-        jsonOutput.textContent = "Uploading and processing files...";
-        jsonOutput.style.display = 'block';
-        if (formattedOutput) formattedOutput.classList.add('hidden');
-        
-        try {
-            const formData = new FormData();
-            let added = 0;
-            for (let i = 0; i < files.length; i++) {
-                if (files[i].name.endsWith('.json')) {
-                    formData.append('file_' + i, files[i]);
-                    added++;
-                }
-            }
-            
-            if (added === 0) {
-                throw new Error("No valid .json files were found in the selection.");
-            }
-            
-            const response = await fetch('/api/fusion/tools', {
-                method: 'POST',
-                body: formData
-            });
-            const data = await response.json();
-            
-            if (data.status === 'success') {
-                renderFusionTools(data);
-            } else {
-                jsonOutput.textContent = JSON.stringify(data, null, 4);
-            }
-        } catch (err) {
-            console.error(err);
-            jsonOutput.textContent = `CRITICAL ERROR: ${err.message}`;
-        } finally {
-            loadingOverlay.classList.add('hidden');
-            e.target.value = ''; // Reset for re-selection
-        }
+    const statusStripEl = $("#status-strip");
+    const respPre       = $("#resp-pre");
+    const tabsEl        = $$(".tab");
+    const copyBtn       = $("#btn-copy");
+    const clearBtn      = $("#btn-clear");
+    const clearHistBtn  = $("#btn-clear-history");
+    const historyListEl = $("#history-list");
+
+    const btnPickFiles  = $("#btn-pick-files");
+    const btnPickDir    = $("#btn-pick-dir");
+    const fileInput     = $("#fusion-file-input");
+    const dirInput      = $("#fusion-dir-input");
+
+    // ── State ───────────────────────────────────────
+    const state = {
+        activeTab: "body",
+        lastResponse: null,     // { body, headers, raw, http_status, elapsed_ms, size_bytes, method, url }
+        history: [],
+        maxHistory: 20,
     };
 
-    if (fusionFileInput) fusionFileInput.addEventListener('change', handleFileSelect);
-    if (fusionDirInput) fusionDirInput.addEventListener('change', handleFileSelect);
+    // ── Boot ────────────────────────────────────────
+    loadConfig();
+    wireEvents();
+    renderHistory();
 
-});
+    async function loadConfig() {
+        try {
+            const r = await fetch("/api/config");
+            const cfg = await r.json();
+            urlHostEl.textContent = `${cfg.base_url}/`;
+            envChipEl.textContent = cfg.environment;
+            envChipEl.classList.remove("test", "prod");
+            envChipEl.classList.add(cfg.environment === "test" ? "test" : "prod");
+            envChipEl.title = `Tenant ${cfg.tenant_id || "(default)"} · key:${cfg.has_key ? "✓" : "✗"} secret:${cfg.has_secret ? "✓" : "✗"}`;
+        } catch (e) {
+            envChipEl.textContent = "offline";
+        }
+    }
+
+    function wireEvents() {
+        // Send button
+        sendBtn.addEventListener("click", send);
+
+        // Ctrl/Cmd+Enter to send
+        document.addEventListener("keydown", (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+                e.preventDefault();
+                send();
+            }
+        });
+
+        // Presets
+        $$(".preset").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                const internal = btn.getAttribute("data-internal");
+                if (internal) {
+                    runInternal(internal, btn.querySelector(".p")?.textContent || internal);
+                    return;
+                }
+                const m = btn.getAttribute("data-method") || "GET";
+                const p = btn.getAttribute("data-path") || "";
+                methodEl.value = m;
+                pathEl.value = p;
+                pathEl.focus();
+            });
+        });
+
+        // Tabs
+        tabsEl.forEach((tab) => {
+            tab.addEventListener("click", () => {
+                tabsEl.forEach((t) => t.classList.remove("active"));
+                tab.classList.add("active");
+                state.activeTab = tab.getAttribute("data-tab");
+                renderResponseTab();
+            });
+        });
+
+        copyBtn.addEventListener("click", copyResponse);
+        clearBtn.addEventListener("click", clearResponse);
+        clearHistBtn.addEventListener("click", () => {
+            state.history = [];
+            renderHistory();
+        });
+
+        // Fusion local uploads
+        if (btnPickFiles && fileInput) {
+            btnPickFiles.addEventListener("click", () => fileInput.click());
+            fileInput.addEventListener("change", handleFileSelect);
+        }
+        if (btnPickDir && dirInput) {
+            btnPickDir.addEventListener("click", () => dirInput.click());
+            dirInput.addEventListener("change", handleFileSelect);
+        }
+    }
+
+    // ── Core: send via proxy ────────────────────────
+    async function send() {
+        const path = pathEl.value.trim().replace(/^\/+/, "");
+        const method = methodEl.value;
+        if (!path) {
+            setStatusStrip({ error: "Missing path" });
+            pathEl.focus();
+            return;
+        }
+
+        const qs = new URLSearchParams();
+        qs.set("path", path);
+
+        if (paramsEl.value.trim()) {
+            const extra = parseParams(paramsEl.value.trim());
+            for (const [k, v] of extra) qs.append(k, v);
+        }
+
+        const url = `/api/plex/raw?${qs.toString()}`;
+
+        setLoading(true, `${method} ${path}`);
+        const started = performance.now();
+        try {
+            const r = await fetch(url, { method });
+            const data = await r.json();
+            const elapsed = Math.round(performance.now() - started);
+
+            const resp = {
+                method,
+                path,
+                http_status: data.http_status ?? 0,
+                http_reason: data.http_reason || "",
+                elapsed_ms: data.elapsed_ms ?? elapsed,
+                size_bytes: data.size_bytes ?? 0,
+                url: data.url || "",
+                headers: data.headers || {},
+                body: data.body ?? data,
+                raw: data,
+            };
+            state.lastResponse = resp;
+            setStatusStripFromResponse(resp);
+            renderResponseTab();
+            pushHistory(resp);
+        } catch (err) {
+            state.lastResponse = {
+                error: err.message,
+                raw: { error: err.message },
+                headers: {},
+                body: null,
+            };
+            setStatusStrip({ error: err.message });
+            respPre.textContent = `// fetch failed\n${err.message}`;
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    // ── Internal (non-proxy) endpoints ──────────────
+    async function runInternal(endpoint, label) {
+        setLoading(true, `RUN ${label}`);
+        const started = performance.now();
+        try {
+            const r = await fetch(endpoint);
+            const data = await r.json();
+            const elapsed = Math.round(performance.now() - started);
+            const text = JSON.stringify(data, null, 2);
+
+            const resp = {
+                method: "RUN",
+                path: endpoint,
+                http_status: r.status,
+                http_reason: r.statusText,
+                elapsed_ms: elapsed,
+                size_bytes: new Blob([text]).size,
+                url: endpoint,
+                headers: Object.fromEntries(r.headers.entries()),
+                body: data,
+                raw: data,
+            };
+            state.lastResponse = resp;
+            setStatusStripFromResponse(resp);
+            renderResponseTab();
+            pushHistory(resp);
+        } catch (err) {
+            setStatusStrip({ error: err.message });
+            respPre.textContent = `// fetch failed\n${err.message}`;
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    // ── Fusion file upload ──────────────────────────
+    async function handleFileSelect(e) {
+        const files = e.target.files;
+        if (!files || files.length === 0) return;
+
+        const fd = new FormData();
+        let added = 0;
+        for (let i = 0; i < files.length; i++) {
+            if (files[i].name.toLowerCase().endsWith(".json")) {
+                fd.append(`file_${i}`, files[i]);
+                added++;
+            }
+        }
+        if (added === 0) {
+            setStatusStrip({ error: "No .json files in selection" });
+            return;
+        }
+
+        setLoading(true, `UPLOAD ${added} file${added === 1 ? "" : "s"}`);
+        const started = performance.now();
+        try {
+            const r = await fetch("/api/fusion/tools", { method: "POST", body: fd });
+            const data = await r.json();
+            const elapsed = Math.round(performance.now() - started);
+            const text = JSON.stringify(data, null, 2);
+
+            const resp = {
+                method: "POST",
+                path: "/api/fusion/tools",
+                http_status: r.status,
+                http_reason: r.statusText,
+                elapsed_ms: elapsed,
+                size_bytes: new Blob([text]).size,
+                url: "/api/fusion/tools",
+                headers: Object.fromEntries(r.headers.entries()),
+                body: data,
+                raw: data,
+            };
+            state.lastResponse = resp;
+            setStatusStripFromResponse(resp);
+            renderResponseTab();
+            pushHistory(resp);
+        } catch (err) {
+            setStatusStrip({ error: err.message });
+            respPre.textContent = `// upload failed\n${err.message}`;
+        } finally {
+            setLoading(false);
+            e.target.value = "";
+        }
+    }
+
+    // ── Status strip ────────────────────────────────
+    function setStatusStrip({ error } = {}) {
+        if (error) {
+            statusStripEl.innerHTML = `<span class="ss-status err">ERROR</span><span class="ss-item"><span class="v">${escapeHtml(error)}</span></span>`;
+            return;
+        }
+        statusStripEl.innerHTML = `<span class="ss-idle">Ready · Ctrl+Enter to send</span>`;
+    }
+
+    function setStatusStripFromResponse(r) {
+        const status = r.http_status;
+        let cls = "info";
+        if (status >= 200 && status < 300) cls = "ok";
+        else if (status >= 300 && status < 400) cls = "warn";
+        else if (status >= 400) cls = "err";
+        else if (status === 0) cls = "err";
+
+        const label = status ? `${status} ${r.http_reason || ""}`.trim() : "NO RESP";
+
+        statusStripEl.innerHTML = `
+            <span class="ss-status ${cls}">${escapeHtml(label)}</span>
+            <span class="ss-item"><span class="k">time</span><span class="v">${r.elapsed_ms}ms</span></span>
+            <span class="ss-item"><span class="k">size</span><span class="v">${formatBytes(r.size_bytes)}</span></span>
+            <span class="ss-item"><span class="k">${r.method}</span><span class="v">${escapeHtml(r.path)}</span></span>
+        `;
+    }
+
+    function setLoading(isLoading, label) {
+        sendBtn.disabled = isLoading;
+        if (isLoading) {
+            statusStripEl.innerHTML = `<span class="ss-loading">… ${escapeHtml(label || "sending")}</span>`;
+            respPre.classList.add("empty");
+            respPre.textContent = "// waiting for response";
+        }
+    }
+
+    // ── Response rendering ──────────────────────────
+    function renderResponseTab() {
+        const r = state.lastResponse;
+        if (!r) {
+            respPre.classList.add("empty");
+            respPre.textContent = "// Response will appear here";
+            return;
+        }
+        respPre.classList.remove("empty");
+
+        if (state.activeTab === "headers") {
+            const lines = Object.entries(r.headers || {})
+                .map(([k, v]) => `${k}: ${v}`)
+                .join("\n");
+            respPre.textContent = lines || "// no headers";
+            return;
+        }
+
+        if (state.activeTab === "raw") {
+            respPre.textContent = JSON.stringify(r.raw, null, 2);
+            return;
+        }
+
+        // body tab — try to render just the body nicely
+        const body = r.body;
+        if (body == null) {
+            respPre.textContent = "// empty body";
+            return;
+        }
+        if (typeof body === "string") {
+            respPre.textContent = body;
+            return;
+        }
+        try {
+            respPre.innerHTML = syntaxHighlight(JSON.stringify(body, null, 2));
+        } catch {
+            respPre.textContent = String(body);
+        }
+    }
+
+    function syntaxHighlight(json) {
+        const esc = escapeHtml(json);
+        return esc.replace(
+            /(&quot;(\\.|[^&])*?&quot;)(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g,
+            (match, strMatch, _c, colon) => {
+                if (strMatch !== undefined) {
+                    return colon
+                        ? `<span class="json-key">${strMatch}</span>${colon}`
+                        : `<span class="json-str">${strMatch}</span>`;
+                }
+                if (match === "true" || match === "false") return `<span class="json-bool">${match}</span>`;
+                if (match === "null") return `<span class="json-null">${match}</span>`;
+                return `<span class="json-num">${match}</span>`;
+            }
+        );
+    }
+
+    // ── Copy / clear ────────────────────────────────
+    async function copyResponse() {
+        const txt = respPre.textContent || "";
+        try {
+            await navigator.clipboard.writeText(txt);
+            flashBtn(copyBtn, "Copied");
+        } catch {
+            flashBtn(copyBtn, "Fail");
+        }
+    }
+
+    function clearResponse() {
+        state.lastResponse = null;
+        respPre.classList.add("empty");
+        respPre.textContent = "// Response will appear here";
+        setStatusStrip();
+    }
+
+    function flashBtn(btn, text) {
+        const prev = btn.textContent;
+        btn.textContent = text;
+        setTimeout(() => (btn.textContent = prev), 900);
+    }
+
+    // ── History ─────────────────────────────────────
+    function pushHistory(r) {
+        const item = {
+            method: r.method,
+            path: r.path,
+            http_status: r.http_status,
+            elapsed_ms: r.elapsed_ms,
+            ts: Date.now(),
+            snapshot: r,
+        };
+        state.history.unshift(item);
+        state.history = state.history.slice(0, state.maxHistory);
+        renderHistory();
+    }
+
+    function renderHistory() {
+        historyListEl.innerHTML = "";
+        if (state.history.length === 0) {
+            const li = document.createElement("li");
+            li.className = "history-empty";
+            li.textContent = "No requests yet";
+            historyListEl.appendChild(li);
+            return;
+        }
+        state.history.forEach((item, idx) => {
+            const li = document.createElement("li");
+            const btn = document.createElement("button");
+            let cls = "history-item";
+            if (item.http_status >= 200 && item.http_status < 300) cls += " ok";
+            else if (item.http_status >= 300 && item.http_status < 400) cls += " warn";
+            else cls += " err";
+            btn.className = cls;
+            btn.innerHTML = `
+                <span class="h-status">${item.http_status || "—"}</span>
+                <span class="h-path">${escapeHtml(item.path)}</span>
+                <span class="h-time">${item.elapsed_ms}ms</span>
+            `;
+            btn.addEventListener("click", () => {
+                state.lastResponse = item.snapshot;
+                setStatusStripFromResponse(item.snapshot);
+                renderResponseTab();
+            });
+            li.appendChild(btn);
+            historyListEl.appendChild(li);
+        });
+    }
+
+    // ── Helpers ─────────────────────────────────────
+    function parseParams(s) {
+        // Accept "k=v&k2=v2" or one-per-line
+        const out = [];
+        const chunks = s.split(/[&\n]/);
+        for (const chunk of chunks) {
+            const t = chunk.trim();
+            if (!t) continue;
+            const i = t.indexOf("=");
+            if (i === -1) out.push([t, ""]);
+            else out.push([t.slice(0, i).trim(), t.slice(i + 1).trim()]);
+        }
+        return out;
+    }
+
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    function formatBytes(n) {
+        if (!n) return "0 B";
+        const units = ["B", "KB", "MB", "GB"];
+        let i = 0;
+        while (n >= 1024 && i < units.length - 1) {
+            n /= 1024;
+            i++;
+        }
+        return `${n.toFixed(n >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+    }
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,9 +23,9 @@
                     <li><button class="preset" data-method="GET" data-path="mdm/v1/tenants"><span class="m m-get">GET</span><span class="p">mdm/v1/tenants</span></button></li>
                     <li><button class="preset" data-method="GET" data-path="purchasing/v1/purchase-orders"><span class="m m-get">GET</span><span class="p">purchasing/v1/purchase-orders</span></button></li>
                     <li><button class="preset" data-method="GET" data-path="production/v1/control/workcenters"><span class="m m-get">GET</span><span class="p">production/v1/control/workcenters</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tools"><span class="m m-get">GET</span><span class="p">tooling/v1/tools</span><span class="tag">403</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-assemblies"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-assemblies</span><span class="tag">403</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-inventory"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-inventory</span><span class="tag">403</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tools"><span class="m m-get">GET</span><span class="p">tooling/v1/tools</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-assemblies"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-assemblies</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-inventory"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-inventory</span></button></li>
                 </ul>
             </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,88 +3,124 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tooling Sync | Admin Dashboard</title>
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Local CSS -->
+    <title>plex-api · endpoint tester</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-    
-    <div class="dashboard-wrapper">
-        <!-- Sidebar Navigation -->
-        <aside class="sidebar glass-panel">
-            <div class="sidebar-header">
-                <h2>Sync Dashboard</h2>
-                <span class="badge">v1.2</span>
-            </div>
-            
-            <nav class="action-nav">
-                <div class="nav-group">
-                    <h3>Plex Cloud API</h3>
-                    <button class="action-btn" data-endpoint="/api/plex/discover" data-name="API Discovery">
-                        <span class="btn-icon">🔍</span> Probe Endpoints
-                    </button>
-                    <button class="action-btn" data-endpoint="/api/plex/parts" data-name="Plex Parts">
-                        <span class="btn-icon">⚙️</span> Extract Parts
-                    </button>
-                    <button class="action-btn" data-endpoint="/api/plex/purchase_orders" data-name="Purchase Orders">
-                        <span class="btn-icon">📦</span> Extract POs
-                    </button>
-                    <button class="action-btn" data-endpoint="/api/plex/operations" data-name="Operations">
-                        <span class="btn-icon">📋</span> Extract Operations
-                    </button>
-                </div>
-
-                <div class="nav-group mt-2">
-                    <h3>Fusion 360 Local Data</h3>
-                    <button class="action-btn accent-btn" data-endpoint="/api/fusion/tools" data-name="Fusion Tool Libraries">
-                        <span class="btn-icon">⚡</span> Sync Default Path
-                    </button>
-                    
-                    <div style="display:flex; gap:0.5rem; margin-top: 0.5rem;">
-                        <button class="ghost-btn btn-sm" id="btn-pick-files" style="flex:1;">📁 File(s)</button>
-                        <button class="ghost-btn btn-sm" id="btn-pick-dir" style="flex:1;">📂 Folder</button>
-                    </div>
-
-                    <input type="file" id="fusion-file-input" accept=".json" multiple class="hidden">
-                    <input type="file" id="fusion-dir-input" webkitdirectory directory class="hidden">
-                </div>
-            </nav>
-        </aside>
-
-        <!-- Main Display Content -->
-        <main class="main-content">
-            <header class="top-bar glass-panel">
-                <div class="status-indicator">
-                    <span class="pulse-dot"></span> System Online
-                </div>
-                <!-- Dynamic Title -->
-                <h1 id="view-title">Welcome to Tooling Sync</h1>
+    <div class="app">
+        <!-- ── LEFT RAIL ─────────────────────────────── -->
+        <aside class="rail">
+            <header class="rail-header">
+                <div class="brand">plex-api</div>
+                <div class="env-chip" id="env-chip" title="Environment">—</div>
             </header>
 
-            <section class="data-view glass-panel">
-                <div id="loading-overlay" class="hidden">
-                    <div class="spinner"></div>
-                    <p>Executing Request...</p>
+            <section class="rail-section">
+                <div class="rail-label">Plex presets</div>
+                <ul class="preset-list" id="plex-presets">
+                    <li><button class="preset" data-method="GET" data-path="mdm/v1/parts"><span class="m m-get">GET</span><span class="p">mdm/v1/parts</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="mdm/v1/suppliers"><span class="m m-get">GET</span><span class="p">mdm/v1/suppliers</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="mdm/v1/tenants"><span class="m m-get">GET</span><span class="p">mdm/v1/tenants</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="purchasing/v1/purchase-orders"><span class="m m-get">GET</span><span class="p">purchasing/v1/purchase-orders</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="production/v1/control/workcenters"><span class="m m-get">GET</span><span class="p">production/v1/control/workcenters</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tools"><span class="m m-get">GET</span><span class="p">tooling/v1/tools</span><span class="tag">403</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-assemblies"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-assemblies</span><span class="tag">403</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-inventory"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-inventory</span><span class="tag">403</span></button></li>
+                </ul>
+            </section>
+
+            <section class="rail-section">
+                <div class="rail-label">Extractors</div>
+                <ul class="preset-list">
+                    <li><button class="preset internal" data-internal="/api/plex/discover"><span class="m m-int">RUN</span><span class="p">discover_all</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/plex/parts"><span class="m m-int">RUN</span><span class="p">extract_parts</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/plex/purchase_orders"><span class="m m-int">RUN</span><span class="p">extract_purchase_orders</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/plex/workcenters"><span class="m m-int">RUN</span><span class="p">extract_workcenters</span></button></li>
+                </ul>
+            </section>
+
+            <section class="rail-section">
+                <div class="rail-label">Fusion 360 local</div>
+                <ul class="preset-list">
+                    <li><button class="preset internal" data-internal="/api/fusion/tools"><span class="m m-int">RUN</span><span class="p">load_all_libraries</span></button></li>
+                </ul>
+                <div class="rail-sub">
+                    <button class="btn-ghost btn-xs" id="btn-pick-files">Upload files…</button>
+                    <button class="btn-ghost btn-xs" id="btn-pick-dir">Upload folder…</button>
                 </div>
-                
-                <div class="view-header">
-                    <h3>Output Console</h3>
-                    <div class="view-actions">
-                        <button id="btn-clear" class="ghost-btn">Clear</button>
-                    </div>
+                <input type="file" id="fusion-file-input" accept=".json" multiple hidden>
+                <input type="file" id="fusion-dir-input" webkitdirectory directory hidden>
+            </section>
+
+            <section class="rail-section rail-history">
+                <div class="rail-label">
+                    History
+                    <button class="btn-ghost btn-xs" id="btn-clear-history">clear</button>
                 </div>
-                
-                <div class="console-body">
-                    <pre id="json-output">Select an action on the left to execute scripts and view output here...</pre>
-                    <div id="formatted-output" class="hidden"></div>
-                </div>
+                <ul class="history-list" id="history-list">
+                    <li class="history-empty">No requests yet</li>
+                </ul>
+            </section>
+        </aside>
+
+        <!-- ── MAIN ──────────────────────────────────── -->
+        <main class="main">
+            <!-- URL bar -->
+            <div class="url-bar">
+                <select id="method" class="method-select" aria-label="HTTP method">
+                    <option value="GET">GET</option>
+                    <option value="POST">POST</option>
+                    <option value="PUT">PUT</option>
+                    <option value="PATCH">PATCH</option>
+                    <option value="DELETE">DELETE</option>
+                </select>
+                <div class="url-host" id="url-host">https://test.connect.plex.com/</div>
+                <input
+                    type="text"
+                    id="path-input"
+                    class="path-input"
+                    placeholder="mdm/v1/parts"
+                    spellcheck="false"
+                    autocomplete="off"
+                >
+                <button class="btn-primary" id="btn-send">Send</button>
+            </div>
+
+            <!-- Params -->
+            <div class="params-row">
+                <label class="params-label">Query</label>
+                <input
+                    type="text"
+                    id="params-input"
+                    class="params-input"
+                    placeholder="key=value&key2=value2"
+                    spellcheck="false"
+                    autocomplete="off"
+                >
+            </div>
+
+            <!-- Response status strip -->
+            <div class="status-strip" id="status-strip">
+                <span class="ss-idle">Ready · Ctrl+Enter to send</span>
+            </div>
+
+            <!-- Response tabs -->
+            <div class="resp-tabs">
+                <button class="tab active" data-tab="body">Body</button>
+                <button class="tab" data-tab="headers">Headers</button>
+                <button class="tab" data-tab="raw">Raw</button>
+                <div class="tab-spacer"></div>
+                <button class="btn-ghost btn-xs" id="btn-copy">Copy</button>
+                <button class="btn-ghost btn-xs" id="btn-clear">Clear</button>
+            </div>
+
+            <!-- Response body -->
+            <section class="resp-body">
+                <pre id="resp-pre" class="resp-pre">// Response will appear here</pre>
             </section>
         </main>
     </div>
 
-    <!-- Local Script -->
     <script src="{{ url_for('static', filename='js/script.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tooling Sync | Admin Dashboard</title>
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Local CSS -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    
+    <div class="dashboard-wrapper">
+        <!-- Sidebar Navigation -->
+        <aside class="sidebar glass-panel">
+            <div class="sidebar-header">
+                <h2>Sync Dashboard</h2>
+                <span class="badge">v1.2</span>
+            </div>
+            
+            <nav class="action-nav">
+                <div class="nav-group">
+                    <h3>Plex Cloud API</h3>
+                    <button class="action-btn" data-endpoint="/api/plex/discover" data-name="API Discovery">
+                        <span class="btn-icon">🔍</span> Probe Endpoints
+                    </button>
+                    <button class="action-btn" data-endpoint="/api/plex/parts" data-name="Plex Parts">
+                        <span class="btn-icon">⚙️</span> Extract Parts
+                    </button>
+                    <button class="action-btn" data-endpoint="/api/plex/purchase_orders" data-name="Purchase Orders">
+                        <span class="btn-icon">📦</span> Extract POs
+                    </button>
+                    <button class="action-btn" data-endpoint="/api/plex/operations" data-name="Operations">
+                        <span class="btn-icon">📋</span> Extract Operations
+                    </button>
+                </div>
+
+                <div class="nav-group mt-2">
+                    <h3>Fusion 360 Local Data</h3>
+                    <button class="action-btn accent-btn" data-endpoint="/api/fusion/tools" data-name="Fusion Tool Libraries">
+                        <span class="btn-icon">⚡</span> Sync Default Path
+                    </button>
+                    
+                    <div style="display:flex; gap:0.5rem; margin-top: 0.5rem;">
+                        <button class="ghost-btn btn-sm" id="btn-pick-files" style="flex:1;">📁 File(s)</button>
+                        <button class="ghost-btn btn-sm" id="btn-pick-dir" style="flex:1;">📂 Folder</button>
+                    </div>
+
+                    <input type="file" id="fusion-file-input" accept=".json" multiple class="hidden">
+                    <input type="file" id="fusion-dir-input" webkitdirectory directory class="hidden">
+                </div>
+            </nav>
+        </aside>
+
+        <!-- Main Display Content -->
+        <main class="main-content">
+            <header class="top-bar glass-panel">
+                <div class="status-indicator">
+                    <span class="pulse-dot"></span> System Online
+                </div>
+                <!-- Dynamic Title -->
+                <h1 id="view-title">Welcome to Tooling Sync</h1>
+            </header>
+
+            <section class="data-view glass-panel">
+                <div id="loading-overlay" class="hidden">
+                    <div class="spinner"></div>
+                    <p>Executing Request...</p>
+                </div>
+                
+                <div class="view-header">
+                    <h3>Output Console</h3>
+                    <div class="view-actions">
+                        <button id="btn-clear" class="ghost-btn">Clear</button>
+                    </div>
+                </div>
+                
+                <div class="console-body">
+                    <pre id="json-output">Select an action on the left to execute scripts and view output here...</pre>
+                    <div id="formatted-output" class="hidden"></div>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <!-- Local Script -->
+    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,14 @@
             </header>
 
             <section class="rail-section">
+                <div class="rail-label">Diagnostics</div>
+                <ul class="preset-list">
+                    <li><button class="preset internal" data-internal="/api/diagnostics/tenant"><span class="m m-int">RUN</span><span class="p">tenant_whoami</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/diagnostics/tenants/list"><span class="m m-int">RUN</span><span class="p">list_tenants</span></button></li>
+                </ul>
+            </section>
+
+            <section class="rail-section">
                 <div class="rail-label">Plex presets</div>
                 <ul class="preset-list" id="plex-presets">
                     <li><button class="preset" data-method="GET" data-path="mdm/v1/parts"><span class="m m-get">GET</span><span class="p">mdm/v1/parts</span></button></li>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+"""
+Shared pytest fixtures and setup for the plex-api test suite.
+
+Sets PLEX_API_KEY and PLEX_API_SECRET to dummy values BEFORE any test
+imports app.py — otherwise the import-time guard at the bottom of
+plex_api.py will reject empty credentials and break test collection.
+
+Tests must NEVER hit the real Plex API. All requests should be patched
+or routed through fake clients.
+"""
+import os
+import sys
+from pathlib import Path
+
+# Make the project root importable so `import plex_api` works regardless
+# of where pytest is invoked from.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Inject dummy credentials before any module-level reads happen.
+os.environ.setdefault("PLEX_API_KEY", "test-key-do-not-use")
+os.environ.setdefault("PLEX_API_SECRET", "test-secret-do-not-use")
+
+
+# ─────────────────────────────────────────────
+# Shared fixtures
+# ─────────────────────────────────────────────
+import pytest
+
+
+class FakePlexClient:
+    """
+    Drop-in replacement for plex_api.PlexClient that records calls
+    and returns canned responses without ever touching the network.
+
+    Usage:
+        c = FakePlexClient()
+        c.set_response("tenants", [{"id": "...", "code": "G5"}])
+        result = c.get("mdm", "v1", "tenants")  # returns the canned response
+        assert c.calls == [("mdm", "v1", "tenants")]
+    """
+
+    def __init__(self, base="https://test.connect.plex.com"):
+        self.base = base
+        self.headers = {
+            "X-Plex-Connect-Api-Key": "test-key",
+            "X-Plex-Connect-Api-Secret": "test-secret",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        self.calls = []
+        self._responses = {}
+        self._default = None
+
+    def set_response(self, resource, payload):
+        """Canned response for a specific resource string (last segment)."""
+        self._responses[resource] = payload
+
+    def set_default(self, payload):
+        """Canned response for any resource not explicitly set."""
+        self._default = payload
+
+    def get(self, collection, version, resource, params=None):
+        self.calls.append((collection, version, resource, params))
+        # Match by full resource string first, then by leading segment
+        if resource in self._responses:
+            return self._responses[resource]
+        head = resource.split("/")[0]
+        if head in self._responses:
+            return self._responses[head]
+        return self._default
+
+
+@pytest.fixture
+def fake_client():
+    """A fresh FakePlexClient for each test."""
+    return FakePlexClient()

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -1,0 +1,203 @@
+"""
+Tests for the Flask routes in app.py.
+
+These are smoke tests — they verify that each route registers, responds
+with the right shape, and doesn't blow up. The actual Plex client and
+diagnostics are mocked so no real network calls happen.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# conftest.py has already injected dummy PLEX_API_KEY/SECRET into env
+import app as app_module
+
+
+@pytest.fixture
+def client():
+    """Flask test client."""
+    app_module.app.config["TESTING"] = True
+    return app_module.app.test_client()
+
+
+# ─────────────────────────────────────────────
+# Index
+# ─────────────────────────────────────────────
+class TestIndex:
+    def test_index_returns_html(self, client):
+        rv = client.get("/")
+        assert rv.status_code == 200
+        assert b"<!DOCTYPE html>" in rv.data
+        assert b"plex-api" in rv.data
+
+
+# ─────────────────────────────────────────────
+# /api/config
+# ─────────────────────────────────────────────
+class TestConfig:
+    def test_config_returns_expected_keys(self, client):
+        rv = client.get("/api/config")
+        assert rv.status_code == 200
+        body = rv.get_json()
+        for key in ("base_url", "environment", "tenant_id", "has_key", "has_secret"):
+            assert key in body
+
+    def test_config_environment_is_test_or_prod(self, client):
+        rv = client.get("/api/config")
+        body = rv.get_json()
+        assert body["environment"] in ("test", "production")
+
+    def test_config_reports_credentials_present(self, client):
+        rv = client.get("/api/config")
+        body = rv.get_json()
+        # conftest.py injects dummy values, so both should be True
+        assert body["has_key"] is True
+        assert body["has_secret"] is True
+
+
+# ─────────────────────────────────────────────
+# /api/diagnostics/tenant
+# ─────────────────────────────────────────────
+class TestDiagnosticsTenant:
+    def test_returns_success_envelope(self, client):
+        with patch.object(app_module, "tenant_whoami") as mock_whoami:
+            mock_whoami.return_value = {
+                "match": "g5",
+                "summary": "test summary",
+                "configured_tenant_label": "G5",
+            }
+            rv = client.get("/api/diagnostics/tenant")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["data"]["match"] == "g5"
+            assert body["data"]["summary"] == "test summary"
+
+    def test_passes_configured_tenant_id_to_whoami(self, client):
+        with patch.object(app_module, "tenant_whoami") as mock_whoami:
+            mock_whoami.return_value = {"match": "g5", "summary": ""}
+            client.get("/api/diagnostics/tenant")
+            mock_whoami.assert_called_once()
+            # Second positional arg is the configured tenant ID
+            call_args = mock_whoami.call_args
+            assert call_args[0][1] == app_module.TENANT_ID
+
+    def test_returns_500_on_exception(self, client):
+        with patch.object(app_module, "tenant_whoami", side_effect=RuntimeError("boom")):
+            rv = client.get("/api/diagnostics/tenant")
+            assert rv.status_code == 500
+            body = rv.get_json()
+            assert body["status"] == "error"
+            assert "boom" in body["message"]
+
+
+# ─────────────────────────────────────────────
+# /api/diagnostics/tenants/list
+# ─────────────────────────────────────────────
+class TestDiagnosticsTenantsList:
+    def test_returns_list_payload(self, client):
+        with patch.object(app_module, "list_tenants") as mock_list:
+            mock_list.return_value = [{"id": "abc", "code": "TEST"}]
+            rv = client.get("/api/diagnostics/tenants/list")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["data"] == [{"id": "abc", "code": "TEST"}]
+
+
+# ─────────────────────────────────────────────
+# /api/diagnostics/tenants/<id>
+# ─────────────────────────────────────────────
+class TestDiagnosticsTenantById:
+    def test_passes_id_to_get_tenant(self, client):
+        with patch.object(app_module, "get_tenant") as mock_get:
+            mock_get.return_value = {"id": "abc-123", "name": "Test"}
+            rv = client.get("/api/diagnostics/tenants/abc-123")
+            assert rv.status_code == 200
+            mock_get.assert_called_once()
+            assert mock_get.call_args[0][1] == "abc-123"
+
+
+# ─────────────────────────────────────────────
+# /api/plex/raw — proxy
+# ─────────────────────────────────────────────
+class TestPlexRawProxy:
+    def test_missing_path_returns_400(self, client):
+        rv = client.get("/api/plex/raw")
+        assert rv.status_code == 400
+        body = rv.get_json()
+        assert "Missing required" in body["message"]
+
+    def test_forwards_get_to_plex(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.ok = True
+        mock_response.content = b'{"items":[]}'
+        mock_response.json.return_value = {"items": []}
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.url = "https://test.connect.plex.com/mdm/v1/parts"
+
+        with patch.object(app_module.requests, "request", return_value=mock_response) as mock_req:
+            rv = client.get("/api/plex/raw?path=mdm/v1/parts")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["http_status"] == 200
+            assert body["method"] == "GET"
+            assert body["body"] == {"items": []}
+
+            # Verify the proxy actually forwarded to the right URL with the
+            # client's auth headers
+            mock_req.assert_called_once()
+            call_kwargs = mock_req.call_args.kwargs
+            assert "mdm/v1/parts" in call_kwargs["url"]
+            assert "X-Plex-Connect-Api-Key" in call_kwargs["headers"]
+
+    def test_strips_path_query_param_from_forwarded_params(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.ok = True
+        mock_response.content = b"{}"
+        mock_response.json.return_value = {}
+        mock_response.headers = {}
+        mock_response.url = "https://test.connect.plex.com/mdm/v1/parts"
+
+        with patch.object(app_module.requests, "request", return_value=mock_response) as mock_req:
+            client.get("/api/plex/raw?path=mdm/v1/parts&limit=5&status=Active")
+            forwarded = mock_req.call_args.kwargs["params"]
+            assert "path" not in forwarded
+            assert forwarded["limit"] == "5"
+            assert forwarded["status"] == "Active"
+
+    def test_error_response_propagates_status(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.reason = "Forbidden"
+        mock_response.ok = False
+        mock_response.content = b'{"error":"forbidden"}'
+        mock_response.json.return_value = {"error": "forbidden"}
+        mock_response.headers = {}
+        mock_response.url = "https://test.connect.plex.com/tooling/v1/tools"
+
+        with patch.object(app_module.requests, "request", return_value=mock_response):
+            rv = client.get("/api/plex/raw?path=tooling/v1/tools")
+            assert rv.status_code == 200  # envelope status, not the inner one
+            body = rv.get_json()
+            assert body["status"] == "error"
+            assert body["http_status"] == 403
+
+
+# ─────────────────────────────────────────────
+# /api/plex/discover
+# ─────────────────────────────────────────────
+class TestDiscover:
+    def test_calls_discover_all(self, client):
+        with patch.object(app_module, "discover_all") as mock_discover:
+            mock_discover.return_value = [{"endpoint": "x", "status": 200}]
+            rv = client.get("/api/plex/discover")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["data"] == [{"endpoint": "x", "status": 200}]

--- a/tests/test_plex_api.py
+++ b/tests/test_plex_api.py
@@ -1,0 +1,85 @@
+"""
+Tests for plex_api.PlexClient — header construction and configuration.
+
+These tests verify the BRIEFING item 1 fix: that the constructor accepts
+api_secret and adds the X-Plex-Connect-Api-Secret header. They also lock
+in the test/prod URL switch and tenant header behaviour.
+"""
+from plex_api import PlexClient, BASE_URL, TEST_URL
+
+
+# ─────────────────────────────────────────────
+# Header construction
+# ─────────────────────────────────────────────
+class TestPlexClientHeaders:
+    def test_sets_api_key_header(self):
+        c = PlexClient(api_key="my-key")
+        assert c.headers["X-Plex-Connect-Api-Key"] == "my-key"
+
+    def test_sets_api_secret_header_when_provided(self):
+        c = PlexClient(api_key="k", api_secret="my-secret")
+        assert c.headers["X-Plex-Connect-Api-Secret"] == "my-secret"
+
+    def test_omits_api_secret_header_when_empty(self):
+        c = PlexClient(api_key="k", api_secret="")
+        assert "X-Plex-Connect-Api-Secret" not in c.headers
+
+    def test_omits_api_secret_header_by_default(self):
+        c = PlexClient(api_key="k")
+        assert "X-Plex-Connect-Api-Secret" not in c.headers
+
+    def test_sets_tenant_id_header_when_provided(self):
+        c = PlexClient(api_key="k", tenant_id="abc-123")
+        assert c.headers["X-Plex-Connect-Tenant-Id"] == "abc-123"
+
+    def test_omits_tenant_id_header_when_empty(self):
+        c = PlexClient(api_key="k", tenant_id="")
+        assert "X-Plex-Connect-Tenant-Id" not in c.headers
+
+    def test_sets_content_type_and_accept_headers(self):
+        c = PlexClient(api_key="k")
+        assert c.headers["Content-Type"] == "application/json"
+        assert c.headers["Accept"] == "application/json"
+
+    def test_all_three_auth_headers_when_full_credentials(self):
+        c = PlexClient(api_key="k", api_secret="s", tenant_id="t")
+        assert c.headers["X-Plex-Connect-Api-Key"] == "k"
+        assert c.headers["X-Plex-Connect-Api-Secret"] == "s"
+        assert c.headers["X-Plex-Connect-Tenant-Id"] == "t"
+
+
+# ─────────────────────────────────────────────
+# Environment routing
+# ─────────────────────────────────────────────
+class TestPlexClientEnvironment:
+    def test_use_test_true_uses_test_url(self):
+        c = PlexClient(api_key="k", use_test=True)
+        assert c.base == TEST_URL
+        assert "test." in c.base
+
+    def test_use_test_false_uses_prod_url(self):
+        c = PlexClient(api_key="k", use_test=False)
+        assert c.base == BASE_URL
+        assert "test." not in c.base
+
+    def test_use_test_default_is_prod(self):
+        # Default constructor arg is use_test=False
+        c = PlexClient(api_key="k")
+        assert c.base == BASE_URL
+
+
+# ─────────────────────────────────────────────
+# Throttle initialization
+# ─────────────────────────────────────────────
+class TestPlexClientThrottle:
+    def test_throttle_state_initialized(self):
+        c = PlexClient(api_key="k")
+        assert c._call_count == 0
+        assert c._window_start > 0
+
+    def test_throttle_increments_call_count(self):
+        c = PlexClient(api_key="k")
+        c._throttle()
+        assert c._call_count == 1
+        c._throttle()
+        assert c._call_count == 2

--- a/tests/test_plex_diagnostics.py
+++ b/tests/test_plex_diagnostics.py
@@ -1,0 +1,202 @@
+"""
+Tests for plex_diagnostics — tenant_whoami composite check.
+
+Verifies all 6 logic branches:
+  1. Connected to Grace
+  2. Connected to G5
+  3. Connected to a configured-but-unknown tenant
+  4. Connected to an unrecognized tenant
+  5. list_tenants returns None (auth failure)
+  6. list_tenants returns empty list / no parseable IDs
+
+Plus normalization of dict-wrapped responses (Plex sometimes returns
+{"items": [...]}, {"data": [...]}, or a bare list).
+"""
+import pytest
+
+from plex_diagnostics import (
+    GRACE_TENANT_ID,
+    G5_TENANT_ID,
+    KNOWN_TENANTS,
+    list_tenants,
+    get_tenant,
+    tenant_whoami,
+)
+
+
+# ─────────────────────────────────────────────
+# Constants sanity
+# ─────────────────────────────────────────────
+class TestKnownTenants:
+    def test_grace_tenant_id_in_known(self):
+        assert GRACE_TENANT_ID in KNOWN_TENANTS
+        assert KNOWN_TENANTS[GRACE_TENANT_ID] == "Grace Engineering"
+
+    def test_g5_tenant_id_in_known(self):
+        assert G5_TENANT_ID in KNOWN_TENANTS
+        assert KNOWN_TENANTS[G5_TENANT_ID] == "G5"
+
+    def test_grace_and_g5_are_distinct(self):
+        assert GRACE_TENANT_ID != G5_TENANT_ID
+
+
+# ─────────────────────────────────────────────
+# Raw wrappers — verify they call client.get with the right path
+# ─────────────────────────────────────────────
+class TestRawWrappers:
+    def test_list_tenants_calls_correct_endpoint(self, fake_client):
+        fake_client.set_response("tenants", [])
+        list_tenants(fake_client)
+        assert fake_client.calls[0][:3] == ("mdm", "v1", "tenants")
+
+    def test_get_tenant_calls_correct_endpoint(self, fake_client):
+        fake_client.set_default({"id": "abc"})
+        get_tenant(fake_client, "abc-123")
+        assert fake_client.calls[0][:3] == ("mdm", "v1", "tenants/abc-123")
+
+
+# ─────────────────────────────────────────────
+# tenant_whoami — match logic
+# ─────────────────────────────────────────────
+class TestTenantWhoami:
+    def test_grace_match(self, fake_client):
+        fake_client.set_response("tenants", [
+            {"id": GRACE_TENANT_ID, "code": "GRACE", "name": "Grace Engineering"}
+        ])
+        report = tenant_whoami(fake_client, GRACE_TENANT_ID)
+        assert report["match"] == "grace"
+        assert "Grace Engineering" in report["summary"]
+        assert "[OK]" in report["summary"]
+
+    def test_g5_match(self, fake_client):
+        fake_client.set_response("tenants", [
+            {"id": G5_TENANT_ID, "code": "G5", "name": "G5 Manufacturing"}
+        ])
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert report["match"] == "g5"
+        assert "G5" in report["summary"]
+        assert "[WARN]" in report["summary"]
+
+    def test_no_data_when_list_returns_none(self, fake_client):
+        # No set_response → fake_client.get returns None
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert report["match"] == "no_data"
+        assert "no data" in report["summary"].lower()
+
+    def test_no_data_when_list_returns_empty(self, fake_client):
+        fake_client.set_response("tenants", [])
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert report["match"] == "no_data"
+
+    def test_unknown_tenant_match(self, fake_client):
+        unknown_id = "11111111-2222-3333-4444-555555555555"
+        fake_client.set_response("tenants", [
+            {"id": unknown_id, "code": "UNK", "name": "Unknown Co"}
+        ])
+        report = tenant_whoami(fake_client, unknown_id)
+        assert report["match"] == "configured"
+        assert "Verify this is intentional" in report["summary"]
+
+    def test_other_match_when_visible_unrecognized_and_no_config(self, fake_client):
+        unknown_id = "11111111-2222-3333-4444-555555555555"
+        fake_client.set_response("tenants", [
+            {"id": unknown_id, "code": "UNK"}
+        ])
+        report = tenant_whoami(fake_client, "")
+        assert report["match"] == "other"
+
+    def test_grace_takes_priority_over_configured_g5(self, fake_client):
+        # Edge case: visible tenants include Grace, but TENANT_ID is still G5.
+        # The match should be "grace" because the routing has actually landed.
+        fake_client.set_response("tenants", [
+            {"id": GRACE_TENANT_ID, "code": "GRACE"}
+        ])
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert report["match"] == "grace"
+
+
+# ─────────────────────────────────────────────
+# Response shape normalization
+# ─────────────────────────────────────────────
+class TestResponseNormalization:
+    def test_handles_bare_list_response(self, fake_client):
+        fake_client.set_response("tenants", [
+            {"id": G5_TENANT_ID, "code": "G5"}
+        ])
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert len(report["visible_tenants"]) == 1
+
+    def test_handles_dict_data_wrapper(self, fake_client):
+        fake_client.set_response("tenants", {
+            "data": [{"id": G5_TENANT_ID, "code": "G5"}]
+        })
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert len(report["visible_tenants"]) == 1
+        assert report["match"] == "g5"
+
+    def test_handles_dict_items_wrapper(self, fake_client):
+        fake_client.set_response("tenants", {
+            "items": [{"id": G5_TENANT_ID, "code": "G5"}]
+        })
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert len(report["visible_tenants"]) == 1
+
+    def test_handles_dict_rows_wrapper(self, fake_client):
+        fake_client.set_response("tenants", {
+            "rows": [{"id": G5_TENANT_ID, "code": "G5"}]
+        })
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert len(report["visible_tenants"]) == 1
+
+    def test_handles_single_object_response(self, fake_client):
+        # Some endpoints return a bare object instead of a list
+        fake_client.set_response("tenants", {
+            "id": G5_TENANT_ID, "code": "G5"
+        })
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert len(report["visible_tenants"]) == 1
+        assert report["match"] == "g5"
+
+
+# ─────────────────────────────────────────────
+# Report structure
+# ─────────────────────────────────────────────
+class TestReportStructure:
+    def test_report_has_required_keys(self, fake_client):
+        fake_client.set_response("tenants", [{"id": G5_TENANT_ID}])
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        for key in (
+            "configured_tenant_id",
+            "configured_tenant_label",
+            "visible_tenants",
+            "list_tenants_raw",
+            "get_tenant_raw",
+            "match",
+            "summary",
+        ):
+            assert key in report
+
+    def test_report_records_configured_label(self, fake_client):
+        fake_client.set_response("tenants", [{"id": G5_TENANT_ID}])
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert report["configured_tenant_label"] == "G5"
+
+    def test_report_records_unknown_label_for_unknown_id(self, fake_client):
+        unknown = "deadbeef-dead-beef-dead-beefdeadbeef"
+        fake_client.set_response("tenants", [{"id": unknown}])
+        report = tenant_whoami(fake_client, unknown)
+        assert report["configured_tenant_label"] == "unknown"
+
+    def test_get_tenant_called_when_configured_id_provided(self, fake_client):
+        fake_client.set_response("tenants", [{"id": G5_TENANT_ID}])
+        fake_client.set_response(f"tenants/{G5_TENANT_ID}", {"id": G5_TENANT_ID, "name": "G5 Detail"})
+        report = tenant_whoami(fake_client, G5_TENANT_ID)
+        assert report["get_tenant_raw"] is not None
+        # Two calls should have been made: list + get
+        assert any(c[2] == "tenants" for c in fake_client.calls)
+        assert any(c[2] == f"tenants/{G5_TENANT_ID}" for c in fake_client.calls)
+
+    def test_get_tenant_skipped_when_no_configured_id(self, fake_client):
+        fake_client.set_response("tenants", [{"id": G5_TENANT_ID}])
+        report = tenant_whoami(fake_client, "")
+        assert report["get_tenant_raw"] is None

--- a/tests/test_tool_library_loader.py
+++ b/tests/test_tool_library_loader.py
@@ -1,0 +1,176 @@
+"""
+Tests for tool_library_loader — JSON parsing, schema validation,
+stale-file guard, and directory glob.
+
+All tests use tmp_path so we don't touch the real CAMTools directory.
+"""
+import json
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tool_library_loader import (
+    load_library,
+    load_all_libraries,
+    report_library_contents,
+    _check_file_age,
+    MAX_FILE_AGE_HOURS,
+)
+
+
+# ─────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────
+SAMPLE_LIBRARY = {
+    "data": [
+        {"guid": "tool-1", "type": "flat end mill", "description": "5/8 SQ"},
+        {"guid": "tool-2", "type": "drill", "description": "1/4 drill"},
+        {"guid": "tool-3", "type": "holder", "description": "BT30"},
+    ]
+}
+
+
+def write_json(path: Path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ─────────────────────────────────────────────
+# load_library — happy path
+# ─────────────────────────────────────────────
+class TestLoadLibraryHappyPath:
+    def test_loads_valid_library(self, tmp_path):
+        f = tmp_path / "lib.json"
+        write_json(f, SAMPLE_LIBRARY)
+        tools = load_library(f)
+        assert tools is not None
+        assert len(tools) == 3
+        assert tools[0]["guid"] == "tool-1"
+
+    def test_empty_data_array_is_valid(self, tmp_path):
+        f = tmp_path / "lib.json"
+        write_json(f, {"data": []})
+        tools = load_library(f)
+        assert tools == []
+
+
+# ─────────────────────────────────────────────
+# load_library — error handling
+# ─────────────────────────────────────────────
+class TestLoadLibraryErrors:
+    def test_returns_none_for_malformed_json(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text("{not valid json", encoding="utf-8")
+        assert load_library(f) is None
+
+    def test_returns_none_for_missing_data_key(self, tmp_path):
+        f = tmp_path / "lib.json"
+        write_json(f, {"tools": [{"guid": "x"}]})  # wrong root key
+        assert load_library(f) is None
+
+    def test_returns_none_when_data_is_not_a_list(self, tmp_path):
+        f = tmp_path / "lib.json"
+        write_json(f, {"data": "not a list"})
+        assert load_library(f) is None
+
+    def test_returns_none_for_stale_file(self, tmp_path):
+        f = tmp_path / "stale.json"
+        write_json(f, SAMPLE_LIBRARY)
+        # Backdate the mtime to 100 hours ago — well past the 25h limit.
+        old = time.time() - (100 * 3600)
+        os.utime(f, (old, old))
+        assert load_library(f) is None
+
+
+# ─────────────────────────────────────────────
+# _check_file_age
+# ─────────────────────────────────────────────
+class TestFileAgeCheck:
+    def test_recent_file_passes(self, tmp_path):
+        f = tmp_path / "fresh.json"
+        f.write_text("{}", encoding="utf-8")
+        assert _check_file_age(f) is True
+
+    def test_stale_file_fails(self, tmp_path):
+        f = tmp_path / "stale.json"
+        f.write_text("{}", encoding="utf-8")
+        old = time.time() - ((MAX_FILE_AGE_HOURS + 5) * 3600)
+        os.utime(f, (old, old))
+        assert _check_file_age(f) is False
+
+    def test_custom_max_age_window(self, tmp_path):
+        f = tmp_path / "f.json"
+        f.write_text("{}", encoding="utf-8")
+        old = time.time() - (3 * 3600)  # 3 hours old
+        os.utime(f, (old, old))
+        assert _check_file_age(f, max_age_hours=5) is True
+        assert _check_file_age(f, max_age_hours=1) is False
+
+
+# ─────────────────────────────────────────────
+# load_all_libraries
+# ─────────────────────────────────────────────
+class TestLoadAllLibraries:
+    def test_returns_empty_for_missing_directory(self, tmp_path):
+        missing = tmp_path / "nope"
+        result = load_all_libraries(missing)
+        assert result == {}
+
+    def test_loads_multiple_files(self, tmp_path):
+        write_json(tmp_path / "a.json", SAMPLE_LIBRARY)
+        write_json(tmp_path / "b.json", {"data": [{"guid": "z", "type": "drill"}]})
+        result = load_all_libraries(tmp_path)
+        assert set(result.keys()) == {"a", "b"}
+        assert len(result["a"]) == 3
+        assert len(result["b"]) == 1
+
+    def test_returns_empty_when_no_json_files(self, tmp_path):
+        (tmp_path / "readme.txt").write_text("hi", encoding="utf-8")
+        result = load_all_libraries(tmp_path)
+        assert result == {}
+
+    def test_abort_on_stale_aborts_full_run(self, tmp_path):
+        # Two files, one fresh, one stale → with abort_on_stale=True (default),
+        # the entire load should return {}.
+        write_json(tmp_path / "fresh.json", SAMPLE_LIBRARY)
+        stale = tmp_path / "stale.json"
+        write_json(stale, SAMPLE_LIBRARY)
+        old = time.time() - (100 * 3600)
+        os.utime(stale, (old, old))
+
+        result = load_all_libraries(tmp_path, abort_on_stale=True)
+        assert result == {}
+
+    def test_skip_stale_continues_with_fresh(self, tmp_path):
+        write_json(tmp_path / "fresh.json", SAMPLE_LIBRARY)
+        stale = tmp_path / "stale.json"
+        write_json(stale, SAMPLE_LIBRARY)
+        old = time.time() - (100 * 3600)
+        os.utime(stale, (old, old))
+
+        result = load_all_libraries(tmp_path, abort_on_stale=False)
+        assert "fresh" in result
+        assert "stale" not in result
+
+
+# ─────────────────────────────────────────────
+# report_library_contents — smoke test
+# ─────────────────────────────────────────────
+class TestReportLibraryContents:
+    def test_runs_without_error(self, capsys):
+        libs = {"sample": SAMPLE_LIBRARY["data"]}
+        report_library_contents(libs)
+        captured = capsys.readouterr()
+        # Should print library name + per-type counts
+        assert "sample" in captured.out
+        assert "flat end mill" in captured.out
+        assert "drill" in captured.out
+        assert "holder" in captured.out
+
+    def test_handles_empty_library(self, capsys):
+        report_library_contents({})
+        captured = capsys.readouterr()
+        # No exception, no output for an empty dict
+        assert captured.out == ""


### PR DESCRIPTION
## Summary

Eight commits worth of foundational work setting the project up to actually start writing the sync. Highlights:

- **Credential hygiene** — `PlexClient` constructor now takes `api_secret` and reads both key and secret from `PLEX_API_KEY` / `PLEX_API_SECRET` environment variables. The hardcoded key is gone from the working tree (still in history — see #12 for rotation tracking).
- **Test environment + correct tenant** — `USE_TEST=True`, `TENANT_ID` set to G5 (the tenant we actually have access to), fail-fast guard if env vars are missing.
- **UI rewrite** — the gradient/glass dashboard is gone. Replaced with a flat, neutral endpoint tester (left rail of presets + history, URL bar with method selector and query params, tabbed response pane with Body/Headers/Raw, JSON syntax highlighting, Ctrl/Cmd+Enter to send). Backed by a new `/api/plex/raw` proxy that lets the browser hit any Plex endpoint via the authenticated `PlexClient` without ever exposing credentials.
- **Tenant diagnostics suite** — new `plex_diagnostics.py` with `list_tenants`, `get_tenant`, and a composite `tenant_whoami` that compares visible tenants against the known Grace and G5 UUIDs and returns a structured report. New `Diagnostics` section at the top of the UI rail. This is the **baseline check** to verify we're connected to the right tenant — run it first whenever the connection state is in question.
- **GitHub Issues tracker** — TODO.md is now mirrored as 12 GitHub Issues with phase labels, dependency graph baked into the bodies, and a corrected understanding that the only IT blocker is **tenant routing**, not API collection subscription. Each unchecked item in TODO.md links to its issue.
- **BRIEFING.md tracked** in git for the first time, with stale sections cleaned up to reflect the current state of the branch.

## Commits

| SHA | Title |
|---|---|
| `66baef5` | fix: PlexClient takes api_secret, env-var credentials, G5 test env |
| `d449db1` | feat: rewrite UI as minimal endpoint tester |
| `3bd741e` | docs: link TODO.md items to their GitHub Issues |
| `05f2f78` | fix: clarify tenant routing is the only IT blocker |
| `359bf98` | docs: track BRIEFING.md in git |
| `8b65966` | feat: tenant diagnostic suite (whoami, list, get) |
| `f317f20` | docs(briefing): clean stale sections, add diagnostics and UI |

(Plus `6f5ff1b` from the earlier dashboard work that was already in this branch.)

## Test plan

- [ ] Pull the branch and set `PLEX_API_KEY` + `PLEX_API_SECRET` env vars
- [ ] `py app.py` and open http://localhost:5000
- [ ] Click **tenant_whoami** in the Diagnostics section — confirm the response says `match: g5` and the summary correctly identifies we're on G5 (read-only)
- [ ] Click **mdm/v1/parts** preset, hit **Send** — confirm 200 response, JSON body renders with syntax highlighting, status strip shows time + size
- [ ] Click **list_tenants** — confirm raw `mdm/v1/tenants` response
- [ ] Try a custom path like `mdm/v1/suppliers` with a query param `limit=5`
- [ ] Confirm Ctrl/Cmd+Enter sends, history populates on the rail
- [ ] Run `py plex_diagnostics.py` standalone — confirm it prints the report without unicode errors

## Follow-up

This PR has no automated tests yet — that's coming in a follow-up commit on this same branch (pytest suite covering `PlexClient`, `tenant_whoami`, `tool_library_loader`, and the Flask routes), along with a GitHub Actions workflow so CI runs on every PR. After CI lands, the branch can be auto-merged once tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)