### PR TITLE
feat: .env.local loader + Claude Preview launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "plex-api",
+      "runtimeExecutable": "py",
+      "runtimeArgs": ["app.py"],
+      "port": 5000
+    }
+  ]
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# .env.example
+#
+# Copy this file to .env.local (which is gitignored) and fill in real values.
+# bootstrap.py loads .env.local at startup so you don't have to set these
+# variables in every shell. Real shell environment variables always win.
+#
+# Get your Consumer Key and Consumer Secret from:
+#   https://developers.plex.com/  →  My Apps  →  <your app>
+
+PLEX_API_KEY=your-consumer-key-here
+PLEX_API_SECRET=your-consumer-secret-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
 __pycache__/
 *.pyc
+
+# dotenv — local secrets, NEVER commit
+.env
+.env.local
+.env.*.local
+
+# editor / IDE
+.vscode/
+.idea/
+*.swp
+
+# Python tooling
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+*.egg-info/
+build/
+dist/

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,79 @@
+"""
+bootstrap.py
+.env.local loader
+==================
+Optional dotenv-style loader for credentials and other environment
+configuration. Imported at the very top of plex_api.py so that
+PLEX_API_KEY / PLEX_API_SECRET can come from a gitignored .env.local
+file in the project root, instead of requiring the user to set them
+in every shell.
+
+Behavior
+--------
+- If .env.local exists in the project root, parse KEY=VALUE pairs
+  and inject them into os.environ via setdefault — meaning any
+  variable already set in the real environment WINS, never overridden.
+- Lines starting with # are comments. Blank lines are ignored.
+- Surrounding single or double quotes on values are stripped.
+- Missing file is a no-op (no error).
+
+Why setdefault, not direct assignment
+-------------------------------------
+A real shell environment variable should always override .env.local —
+that lets CI, production deployments, and ad-hoc shell exports take
+precedence over local dev defaults without anyone having to remember
+to delete the file.
+"""
+import os
+from pathlib import Path
+
+# Project root = directory containing this file (bootstrap.py lives at the root)
+_PROJECT_ROOT = Path(__file__).resolve().parent
+
+
+def load_env_local(path: Path | str | None = None) -> int:
+    """
+    Load KEY=VALUE pairs from a .env.local file into os.environ via setdefault.
+
+    Parameters
+    ----------
+    path : Path | str | None
+        Override the file path. Defaults to ``<project_root>/.env.local``.
+
+    Returns
+    -------
+    int
+        Number of variables actually injected into os.environ
+        (i.e. that were not already present).
+    """
+    if path is None:
+        path = _PROJECT_ROOT / ".env.local"
+    else:
+        path = Path(path)
+
+    if not path.exists():
+        return 0
+
+    injected = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        # Strip matched surrounding quotes (' or ")
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+
+        if key and key not in os.environ:
+            os.environ[key] = value
+            injected += 1
+
+    return injected
+
+
+# Auto-load on import — no-op if .env.local does not exist.
+load_env_local()

--- a/plex_api.py
+++ b/plex_api.py
@@ -7,6 +7,12 @@ Auth:      X-Plex-Connect-Api-Key header (Consumer Key from Developer Portal)
 Rate:      200 calls/minute
 """
 
+# bootstrap MUST be imported before anything reads PLEX_API_KEY/SECRET from
+# os.environ — it injects values from .env.local (if present) so the dev
+# loop doesn't require setting env vars in every shell. Real shell env
+# always wins via setdefault semantics.
+import bootstrap  # noqa: F401
+
 import requests
 import json
 import csv

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,169 @@
+"""
+Tests for bootstrap.py — .env.local loader.
+
+Verifies the contract:
+  - missing file is a no-op
+  - KEY=VALUE pairs are parsed and injected via setdefault
+  - existing env vars are NEVER overridden
+  - blank lines and # comments are skipped
+  - matched surrounding quotes (single or double) are stripped
+  - returns the count of injected variables
+"""
+import os
+
+import pytest
+
+from bootstrap import load_env_local
+
+
+# ─────────────────────────────────────────────
+# Missing file behavior
+# ─────────────────────────────────────────────
+class TestMissingFile:
+    def test_missing_file_is_noop(self, tmp_path):
+        missing = tmp_path / "does-not-exist.env"
+        result = load_env_local(missing)
+        assert result == 0
+
+    def test_missing_file_does_not_raise(self, tmp_path):
+        # Should not raise even if directory itself does not exist
+        nowhere = tmp_path / "nope" / "alsonope" / ".env.local"
+        load_env_local(nowhere)  # no exception
+
+
+# ─────────────────────────────────────────────
+# Basic parsing
+# ─────────────────────────────────────────────
+class TestBasicParsing:
+    def test_simple_key_value(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=bar\n")
+        monkeypatch.delenv("FOO", raising=False)
+        injected = load_env_local(f)
+        assert injected == 1
+        assert os.environ["FOO"] == "bar"
+
+    def test_multiple_pairs(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=bar\nBAZ=qux\nHELLO=world\n")
+        for k in ("FOO", "BAZ", "HELLO"):
+            monkeypatch.delenv(k, raising=False)
+        injected = load_env_local(f)
+        assert injected == 3
+        assert os.environ["FOO"] == "bar"
+        assert os.environ["BAZ"] == "qux"
+        assert os.environ["HELLO"] == "world"
+
+    def test_value_can_contain_equals(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("URL=https://example.com/?a=1&b=2\n")
+        monkeypatch.delenv("URL", raising=False)
+        load_env_local(f)
+        assert os.environ["URL"] == "https://example.com/?a=1&b=2"
+
+
+# ─────────────────────────────────────────────
+# Comments and blank lines
+# ─────────────────────────────────────────────
+class TestCommentsAndBlanks:
+    def test_skips_comments(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("# this is a comment\nFOO=bar\n# another comment\n")
+        monkeypatch.delenv("FOO", raising=False)
+        injected = load_env_local(f)
+        assert injected == 1
+        assert os.environ["FOO"] == "bar"
+
+    def test_skips_blank_lines(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("\n\nFOO=bar\n\n\nBAZ=qux\n")
+        for k in ("FOO", "BAZ"):
+            monkeypatch.delenv(k, raising=False)
+        injected = load_env_local(f)
+        assert injected == 2
+
+    def test_skips_lines_without_equals(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("not-a-pair\nFOO=bar\nalso-not-a-pair\n")
+        monkeypatch.delenv("FOO", raising=False)
+        injected = load_env_local(f)
+        assert injected == 1
+
+
+# ─────────────────────────────────────────────
+# Quote stripping
+# ─────────────────────────────────────────────
+class TestQuoteStripping:
+    def test_strips_double_quotes(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text('FOO="bar baz"\n')
+        monkeypatch.delenv("FOO", raising=False)
+        load_env_local(f)
+        assert os.environ["FOO"] == "bar baz"
+
+    def test_strips_single_quotes(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO='bar baz'\n")
+        monkeypatch.delenv("FOO", raising=False)
+        load_env_local(f)
+        assert os.environ["FOO"] == "bar baz"
+
+    def test_does_not_strip_mismatched_quotes(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=\"bar'\n")
+        monkeypatch.delenv("FOO", raising=False)
+        load_env_local(f)
+        assert os.environ["FOO"] == "\"bar'"
+
+    def test_preserves_internal_quotes(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text('FOO=bar"baz\n')
+        monkeypatch.delenv("FOO", raising=False)
+        load_env_local(f)
+        assert os.environ["FOO"] == 'bar"baz'
+
+
+# ─────────────────────────────────────────────
+# setdefault semantics — real env always wins
+# ─────────────────────────────────────────────
+class TestSetdefaultBehavior:
+    def test_existing_env_var_is_not_overridden(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=from-file\n")
+        monkeypatch.setenv("FOO", "from-shell")
+        injected = load_env_local(f)
+        # Was already set, so injected count is 0
+        assert injected == 0
+        assert os.environ["FOO"] == "from-shell"
+
+    def test_partial_override_only_sets_missing(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=from-file\nBAZ=from-file\n")
+        monkeypatch.setenv("FOO", "from-shell")
+        monkeypatch.delenv("BAZ", raising=False)
+        injected = load_env_local(f)
+        assert injected == 1
+        assert os.environ["FOO"] == "from-shell"
+        assert os.environ["BAZ"] == "from-file"
+
+
+# ─────────────────────────────────────────────
+# Whitespace handling
+# ─────────────────────────────────────────────
+class TestWhitespace:
+    def test_strips_whitespace_around_key_and_value(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("  FOO  =  bar  \n")
+        monkeypatch.delenv("FOO", raising=False)
+        load_env_local(f)
+        assert os.environ["FOO"] == "bar"
+
+    def test_handles_crlf_line_endings(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_bytes(b"FOO=bar\r\nBAZ=qux\r\n")
+        monkeypatch.delenv("FOO", raising=False)
+        monkeypatch.delenv("BAZ", raising=False)
+        injected = load_env_local(f)
+        assert injected == 2
+        assert os.environ["FOO"] == "bar"
+        assert os.environ["BAZ"] == "qux"


### PR DESCRIPTION
## Summary

Two small additions so the local dev loop is friction-free.

### `bootstrap.py` — `.env.local` loader

A tiny dotenv-style loader. Reads `KEY=VALUE` pairs from a gitignored `.env.local` and injects them into `os.environ` via `setdefault`, so the real shell environment always wins. Imported at the very top of `plex_api.py` before its module-level credential reads.

This solves a concrete problem: spawned subprocesses (the Claude Preview server, scheduled tasks, anything launched outside an interactive shell) couldn't reliably inherit `PLEX_API_KEY` / `PLEX_API_SECRET`. Now there's one per-machine source of truth that survives shell restarts and is invisible to git.

### `.claude/launch.json` — Claude Preview launch config

So `preview_start plex-api` works out of the box. This was the loose end from PR #13.

## Files

| File | Change |
|---|---|
| `bootstrap.py` | new — 65 lines including docstring |
| `plex_api.py` | added `import bootstrap` at the very top, before the `os.environ.get()` reads |
| `.gitignore` | added `.env`, `.env.local`, `.env.*.local`, plus editor/IDE noise and Python tooling caches |
| `.env.example` | new committed template showing expected variable names |
| `.claude/launch.json` | new launch config (the PR #13 loose end) |
| `tests/test_bootstrap.py` | new — 16 tests |

## Tests

**81 passed locally (65 existing + 16 new):**

- missing file is a no-op (no exception)
- simple `KEY=VALUE` pair
- multiple pairs
- value containing `=` (URL with query string)
- `# comments` skipped
- blank lines skipped
- lines without `=` skipped
- double-quoted values stripped
- single-quoted values stripped
- mismatched quotes preserved verbatim
- internal quotes preserved
- existing env vars are NEVER overridden (`setdefault` semantics)
- partial override (one var set, another from file)
- whitespace around key and value stripped
- CRLF line endings tolerated
- returns the count of injected vars

CI will run on this PR via the workflow merged in PR #13.

## Test plan

- [ ] CI green
- [ ] Pull the branch, copy `.env.example` → `.env.local`, fill in real key + secret
- [ ] `py app.py` (no need to export anything)
- [ ] Open http://localhost:5000 → click `tenant_whoami` → expect `match: "g5"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)