### PR TITLE
docs: correct subscription-not-tenant hypothesis, add access matrix

### DIFF
--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -22,28 +22,31 @@ Forked from just-shane/plex-api. Grace Engineering's working copy.
 
 ## Current situation
 
-- Connected and authenticating successfully — but to the WRONG tenant (G5)
-- G5 is real production data belonging to another company — READ ONLY, no writes
-- IT (Courtney) is resolving tenant access for Grace Engineering
-- No new credentials needed — switching tenants = enabling one header
+- Courtney issued a new dev portal app: **Fusion2Plex** (April 2026)
+- Key + Secret live in `.env.local` (gitignored). Loaded by `bootstrap.py`.
+- The new key **expires every 31 days** — we need a rotation reminder
+- The Fusion2Plex app has been approved for **Tooling** and **Standalone MES** API products only — Common APIs, Purchasing, and Production Control are still pending Courtney's approval
+- We do not yet know which tenant the new app is bound to, because `mdm/v1/tenants` requires Common APIs (currently 401)
 - Use https://test.connect.plex.com (test. prefix) for all development
+
+> **Earlier (now superseded) belief:** we thought the 403 → 401 errors on tooling endpoints were tenant scoping. They were not. The original `Plex_API_Reference.md` was right: it's per-product subscription approval in the dev portal. The `Fusion2Plex` access matrix (see Plex_API_Reference §3) confirms this empirically — tooling endpoints now return 404 (auth ok, no resource), MDM endpoints return 401 (not subscribed).
 
 ---
 
-## Auth — three headers required
-X-Plex-Connect-Api-Key:    <key>      # identifies the app
-X-Plex-Connect-Api-Secret: <secret>   # second factor, same credential
-X-Plex-Connect-Tenant-Id:  <uuid>     # tenant routing — omit = defaults to G5
+## Auth — header model
+X-Plex-Connect-Api-Key:    <key>      # identifies the app, scoped to subscribed API products
+X-Plex-Connect-Api-Secret: <secret>   # second factor, paired with the key
+X-Plex-Connect-Tenant-Id:  <uuid>     # optional — omit to use the app's default tenant
 
-Keys and secrets are managed here in Claude Code via environment variables.
+Keys and secrets are loaded from `.env.local` via `bootstrap.py` at startup.
 Never hardcode credentials. Never commit credentials.
 
-### Tenants
+### Tenants (historical reference — may be re-verified once Common APIs is enabled)
 
 | Name            | Tenant ID                              | Status                        |
 |-----------------|----------------------------------------|-------------------------------|
-| Grace Eng.      | a6af9c99-bce5-4938-a007-364dc5603d08  | Target — waiting on IT        |
-| G5              | b406c8c4-cef0-4d62-862c-1758b702cd02  | Currently connected — READ ONLY |
+| Grace Eng.      | a6af9c99-bce5-4938-a007-364dc5603d08  | Target tenant for sync writes |
+| G5              | b406c8c4-cef0-4d62-862c-1758b702cd02  | Old app's bound tenant — read-only, another company |
 
 ---
 
@@ -80,16 +83,30 @@ Fusion 360 .json (network share, via ADC)
 | GET purchasing/v1/purchase-orders      | URL-encode spaces in filter values             |
 | GET production/v1/control/workcenters  | Target for pocket/turret assignment pushes     |
 
-### 403 responses — suspected tenant routing, not subscription
+### Access matrix — Fusion2Plex app (verified empirically)
 
-- tooling/v1/tools
-- tooling/v1/tool-assemblies
-- tooling/v1/tool-inventory
+Plex returns **HTTP 401 `REQUEST_NOT_AUTHENTICATED`** for any endpoint
+whose API product the app is NOT subscribed to. The same 401 also covers
+genuinely bad credentials, so the only way to tell the two apart is by
+comparing across endpoints.
 
-Working hypothesis: these 403s will resolve once IT completes the tenant
-routing change for Grace Engineering. Cannot verify until tenant access lands,
-since G5 is another company's data and we have no authority to test writes
-there. The tenant change is the **only** open IT blocker.
+A subscribed-but-resource-missing endpoint returns **404 `RESOURCE_NOT_FOUND`**.
+
+| Path                                  | Status | Notes |
+|---------------------------------------|--------|-------|
+| mdm/v1/tenants                        | 401    | Need Common APIs |
+| mdm/v1/parts                          | 401    | Need Common APIs |
+| mdm/v1/suppliers                      | 401    | Need Common APIs |
+| purchasing/v1/purchase-orders         | 401    | Need Purchasing |
+| production/v1/control/workcenters     | 401    | Need Production Control |
+| manufacturing/v1/operations           | 404    | ✅ Standalone MES enabled |
+| tooling/v1/tools                      | 404    | ✅ Tooling enabled |
+| tooling/v1/tool-assemblies            | 404    | ✅ Tooling enabled |
+| tooling/v1/tool-inventory             | 404    | ✅ Tooling enabled |
+
+Pending IT actions: ask Courtney to also approve the `Fusion2Plex` app for
+**Common APIs**, **Purchasing**, and **Production Control** in the Plex
+developer portal.
 
 ---
 
@@ -161,14 +178,15 @@ All items below are mirrored as GitHub Issues — see
 https://github.com/grace-shane/plex-api/issues for live status.
 
 1. ~~Fix PlexClient constructor — add api_secret, include header~~ DONE
-2. Read baseline tooling inventory from mdm/v1/parts — issue #2 (unblocked,
-   read-only — can start today on G5)
+2. Read baseline tooling inventory from mdm/v1/parts — issue #2
+   BLOCKED on Common APIs subscription (currently 401)
 3. build_part_payload(tool: dict) -> dict — issue #3
-   Maps Fusion tool object to mdm/v1/parts POST body
+   Maps Fusion tool object to mdm/v1/parts POST body. Blocked on Common APIs.
 4. resolve_supplier_uuid(vendor_name: str) -> str — issue #3
-   Looks up supplier UUID from mdm/v1/suppliers (safe to test on G5 read)
+   Looks up supplier UUID from mdm/v1/suppliers. Blocked on Common APIs.
 5. build_assembly_payload(tool: dict, holder: dict) -> dict — issue #4
-   Draft only — endpoints currently 403 (suspected tenant scoping)
+   tooling/v1/tool-assemblies is now reachable (Tooling API approved).
+   Need to figure out the correct paths/payloads. NO LONGER BLOCKED.
 6. Core sync logic — upsert with guid-based dedup — issue #7
 7. Error handling + logging to network share text file — issue #8
 
@@ -176,20 +194,25 @@ https://github.com/grace-shane/plex-api/issues for live status.
 
 ## Gotchas — read before touching anything
 
-- **G5 is production data. Read only. No writes, no mutations.**
-- PLEX_API_KEY and PLEX_API_SECRET must be set in the environment before
-  running plex_api.py or app.py — both will hard-fail with a clear message
-  if they are missing
-- The previously hardcoded API key (k3SmLW3y…) is still in git history on
-  master and must be rotated before production deployment — see issue #12
+- **G5 is another company's data. Reads we got there were tied to the OLD
+  app key — not the current Fusion2Plex app. The old key is dead.**
+- PLEX_API_KEY and PLEX_API_SECRET come from `.env.local` via `bootstrap.py`.
+  A real shell env var with the same name will OVERRIDE `.env.local` (by
+  design) — clear stale shell vars if you have them.
+- **The previously hardcoded API key (k3SmLW3y…) is dead.** It's still in
+  git history but no longer authenticates. The current key is the
+  Fusion2Plex Consumer Key in `.env.local`, which expires every 31 days.
+  See issue #12 for the rotation cadence.
+- **Plex returns 401 `REQUEST_NOT_AUTHENTICATED` for both bad credentials
+  AND endpoints under unsubscribed API products.** The only way to tell
+  them apart is to compare across multiple endpoints — if SOME calls
+  return 200/404 and OTHERS return 401, the 401s are subscription, not
+  auth. See the access matrix above.
 - mdm/v1/parts has NO server-side pagination — unfiltered = entire DB pulled
 - supplierId in responses is a UUID, not a supplier code (MSC != "MSC001")
 - URL-encode spaces in filter strings (MRO SUPPLIES -> MRO%20SUPPLIES)
 - API key must be in header — URL parameter returns 401
 - PowerShell: use Invoke-RestMethod, not curl (alias doesn't pass headers)
-- Tooling 403s on tooling/v1/* are SUSPECTED to be tenant scoping, not API
-  collection subscription. Working hypothesis only — cannot verify until
-  tenant routing lands. See issue #1.
 - Fusion Tool objects from CAM API are copies, not references
 - ADC stale file guard will abort sync if network share files are > 25h old
 - BROTHER SPEEDIO ALUMINUM.json is committed to repo for reference only —

--- a/Plex_API_Reference.md
+++ b/Plex_API_Reference.md
@@ -40,16 +40,28 @@ The target architecture requires pushing Fusion 360 data to the Tooling/Workcent
 | Purchasing | `purchasing/v1/purchase-orders` | Returns full PO headers (e.g., tooling orders from MSC). |
 | Production | `production/v1/control/workcenters` | Discovered on Dev Portal. Replaces old 404 manufacturing endpoint. |
 
-### ⚠️ 403 Responses — Tenant Routing Suspected
+### API Product Subscription Model
 
 > [!IMPORTANT]
-> **ACTION REQUIRED**: IT (Courtney) must complete the tenant routing change so Grace Engineering credentials land on the Grace tenant (`a6af9c99-bce5-4938-a007-364dc5603d08`) instead of G5 (`b406c8c4-cef0-4d62-862c-1758b702cd02`). This is the **only** open IT blocker.
+> Plex requires each Consumer Key to be **explicitly subscribed** to API products in the developer portal before any URI under that product is reachable. An unsubscribed product returns **HTTP 401 `REQUEST_NOT_AUTHENTICATED`** at the gateway, *not* 403 — same wire response as bad credentials, which makes diagnosing this without an access matrix surprisingly hard.
 >
-> The 403s observed on the endpoints below are suspected to be tenant-scoping rather than API collection subscription. **This is a working hypothesis** — we cannot verify it until tenant access is resolved, because G5 is another company's production data and we have no authority to test writes there. Re-run `discover_all()` once tenant routing lands to confirm.
+> Verified empirically against the Grace `Fusion2Plex` app (April 2026): `tooling/v1/*` returns `404 RESOURCE_NOT_FOUND` (auth ok, just no resource at that path), while unsubscribed products like `mdm/v1/*` return `401 REQUEST_NOT_AUTHENTICATED`. The 401-vs-404 distinction is the only way to tell from outside the portal whether a product is enabled.
 
-- `tooling/v1/tools`
-- `tooling/v1/tool-assemblies`
-- `tooling/v1/tool-inventory`
+#### Current access matrix for the `Fusion2Plex` app
+
+| Path                                  | Status | Subscribed? |
+|---------------------------------------|--------|-------------|
+| `mdm/v1/tenants`                      | 401    | ❌ Common APIs not approved |
+| `mdm/v1/parts`                        | 401    | ❌ Common APIs not approved |
+| `mdm/v1/suppliers`                    | 401    | ❌ Common APIs not approved |
+| `purchasing/v1/purchase-orders`       | 401    | ❌ Purchasing not approved |
+| `production/v1/control/workcenters`   | 401    | ❌ Production Control not approved |
+| `manufacturing/v1/operations`         | 404    | ✅ Standalone MES approved |
+| `tooling/v1/tools`                    | 404    | ✅ Tooling approved |
+| `tooling/v1/tool-assemblies`          | 404    | ✅ Tooling approved |
+| `tooling/v1/tool-inventory`           | 404    | ✅ Tooling approved |
+
+**Pending IT action**: ask Courtney to also approve the `Fusion2Plex` app for **Common APIs**, **Purchasing**, and **Production Control** so we can read parts/suppliers, look up POs, and push workcenter docs.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 - [ ] Implement API call to create/update Tool Assemblies, assigning the purchased consumable parts to them. → [#4](https://github.com/grace-shane/plex-api/issues/4)
 - [ ] Implement API call to link Tool Assemblies to Routings/Operations. → [#5](https://github.com/grace-shane/plex-api/issues/5)
 - [ ] Implement API call to update tooling within the specific Workcenter Document (`production/v1/control/workcenters`). → [#6](https://github.com/grace-shane/plex-api/issues/6)
-- [ ] **BLOCKED**: Waiting on IT (Courtney) to complete tenant routing so credentials land on Grace Engineering instead of G5. Hypothesis: the 403s on `tooling/v1/*` endpoints will resolve once tenant access is fixed. → [#1](https://github.com/grace-shane/plex-api/issues/1)
+- [ ] **PARTIALLY BLOCKED**: New `Fusion2Plex` app from Courtney is approved for **Tooling** and **Standalone MES** API products (those endpoints now return 404 instead of 403 — auth ok). Still waiting on Courtney to also approve **Common APIs**, **Purchasing**, and **Production Control** for the same app. The earlier "tenant routing" hypothesis was wrong; this was per-product subscription all along. → [#1](https://github.com/grace-shane/plex-api/issues/1)
 
 ## Phase 4: Data Mapping & Sync Logic
 


### PR DESCRIPTION
## What this PR does

Reconciles the project docs with what we just learned testing Courtney's new `Fusion2Plex` Consumer Key against `test.connect.plex.com`.

## The mistake I made earlier

When we first saw 403s on `tooling/v1/*`, the original `Plex_API_Reference.md` said "IT must enable Tooling & Manufacturing collections in the dev portal." I overrode that with a "tenant routing scoping" hypothesis based on a misread of the BRIEFING — that was wrong, and this PR corrects it.

## Empirical evidence with the new key

Same headers, varying paths, all against `test.connect.plex.com`:

| Path | Status | Subscribed? |
|---|---|---|
| `mdm/v1/tenants` | `401 REQUEST_NOT_AUTHENTICATED` | ❌ Common APIs not approved |
| `mdm/v1/parts` | `401 REQUEST_NOT_AUTHENTICATED` | ❌ Common APIs not approved |
| `mdm/v1/suppliers` | `401 REQUEST_NOT_AUTHENTICATED` | ❌ Common APIs not approved |
| `purchasing/v1/purchase-orders` | `401 REQUEST_NOT_AUTHENTICATED` | ❌ Purchasing not approved |
| `production/v1/control/workcenters` | `401 REQUEST_NOT_AUTHENTICATED` | ❌ Production Control not approved |
| `manufacturing/v1/operations` | `404 RESOURCE_NOT_FOUND` | ✅ Standalone MES enabled |
| `tooling/v1/tools` | `404 RESOURCE_NOT_FOUND` | ✅ Tooling enabled |
| `tooling/v1/tool-assemblies` | `404 RESOURCE_NOT_FOUND` | ✅ Tooling enabled |
| `tooling/v1/tool-inventory` | `404 RESOURCE_NOT_FOUND` | ✅ Tooling enabled |

The 401 vs 404 distinction is the only signal that tells "unsubscribed product" apart from "bad credentials" — both return the same wire response at the gateway. That subtlety is what fooled me on the previous PR.

## Files

| File | Change |
|---|---|
| `Plex_API_Reference.md` | Replaced the "Tenant Routing Suspected" callout with an accurate "API Product Subscription Model" section. Added the access matrix as a permanent reference. Spelled out the 401-vs-404 rule. |
| `BRIEFING.md` | `Current situation` rewritten — Fusion2Plex app, 31-day expiration, partial subscription state. Tenants table reframed as historical. Replaced the 403-tenant block with the verified access matrix. Gotchas section updated. Immediate TODO unblocks issue #4 (tooling now reachable). |
| `TODO.md` | Phase 3 `BLOCKED` line rewritten — partial subscription, corrected hypothesis. |

## What I'll do after this lands

Update the GitHub Issues to match — this PR is docs only, the issue updates are the post-merge cleanup:

- **#1**: retitle from "tenant routing" → "API product subscription". Body explains the corrected understanding. Stays open until Common APIs / Purchasing / Production Control are approved.
- **#3**: blocker text changes from "tenant routing" → "Common APIs subscription"
- **#4**: **remove `blocked` label.** `tooling/v1/tool-assemblies` is now reachable. Body updated with "auth ok, need to figure out the correct path/payload"
- **#5**: **remove `blocked` label.** Same as #4 for routing linkage
- **#6**: blocker text changes from "tenant routing" → "Production Control API subscription"
- **#12**: rewritten — the previously-hardcoded `k3SmLW3y…` key is dead anyway. New tracking concern is the 31-day rotation cycle of the new Fusion2Plex key.

## Tests

No code changes. 105 tests still pass locally. CI will confirm.

## Test plan

- [ ] CI green
- [ ] After merge, I update the 6 issues above to match the doc state

🤖 Generated with [Claude Code](https://claude.com/claude-code)