### PR TITLE
feat: production write guard at the proxy

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,47 @@ client = PlexClient(
     use_test=USE_TEST,
 )
 
+# ─────────────────────────────────────────────
+# Production write guard
+# ─────────────────────────────────────────────
+# Read-only methods are always allowed. Mutating methods (POST/PUT/PATCH/
+# DELETE) are blocked when running against a non-test Plex environment
+# (connect.plex.com), unless the operator explicitly opts in by setting
+# PLEX_ALLOW_WRITES=1 in the environment.
+#
+# This guard exists because the Fusion2Plex app currently has read access
+# to real Grace Engineering production data. A casual write — even one
+# triggered by a stray click in the UI — could affect actual manufacturing
+# operations.
+#
+# To enable writes:
+#   $env:PLEX_ALLOW_WRITES = "1"     # PowerShell
+#   export PLEX_ALLOW_WRITES=1        # bash
+# Then restart the server. The /api/config endpoint will reflect the change.
+WRITES_ALLOWED = os.environ.get("PLEX_ALLOW_WRITES", "").strip().lower() in (
+    "1", "true", "yes", "on", "enabled",
+)
+IS_PRODUCTION = "test." not in client.base
+WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def _is_write_blocked(method: str) -> tuple[bool, str]:
+    """
+    Returns (blocked, reason). True if a write request should be refused.
+    """
+    if method.upper() not in WRITE_METHODS:
+        return False, ""
+    if not IS_PRODUCTION:
+        return False, ""
+    if WRITES_ALLOWED:
+        return False, ""
+    return True, (
+        f"Write blocked: {method} requests to {client.base} are refused "
+        f"because the server is running against a production Plex environment "
+        f"and PLEX_ALLOW_WRITES is not set. To enable writes, set "
+        f"PLEX_ALLOW_WRITES=1 in the environment and restart the server."
+    )
+
 
 @app.route('/')
 def index():
@@ -62,11 +103,26 @@ def api_plex_raw():
             "message": "Missing required 'path' query param (e.g. mdm/v1/parts)",
         }), 400
 
+    method = request.method.upper()
+
+    # Production write guard — refuse mutating methods unless explicitly enabled
+    blocked, reason = _is_write_blocked(method)
+    if blocked:
+        return jsonify({
+            "status": "error",
+            "http_status": 0,
+            "method": method,
+            "url": f"{client.base}/{path}",
+            "message": reason,
+            "guard": "PLEX_ALLOW_WRITES",
+            "is_production": IS_PRODUCTION,
+            "writes_allowed": WRITES_ALLOWED,
+        }), 403
+
     # Forward all query params EXCEPT our own 'path' marker.
     forwarded_params = {k: v for k, v in request.args.items() if k != 'path'}
 
     url = f"{client.base}/{path}"
-    method = request.method.upper()
 
     body = None
     if method in ('POST', 'PUT', 'PATCH'):
@@ -229,6 +285,8 @@ def api_config():
     return jsonify({
         "base_url": client.base,
         "environment": "test" if USE_TEST else "production",
+        "is_production": IS_PRODUCTION,
+        "writes_allowed": WRITES_ALLOWED,
         "tenant_id": TENANT_ID,
         "has_key": bool(API_KEY),
         "has_secret": bool(API_SECRET),
@@ -236,6 +294,20 @@ def api_config():
 
 
 if __name__ == '__main__':
-    # Run the server on port 5000
+    # Loud startup banner if we're connected to a production environment
+    if IS_PRODUCTION:
+        print()
+        print("=" * 70)
+        print(f"  WARNING: Connected to PRODUCTION Plex environment")
+        print(f"           {client.base}")
+        if WRITES_ALLOWED:
+            print(f"  WRITES ARE ENABLED via PLEX_ALLOW_WRITES")
+            print(f"  Every POST/PUT/PATCH/DELETE will hit real production data.")
+        else:
+            print(f"  Writes are BLOCKED at the proxy. To enable, set")
+            print(f"  PLEX_ALLOW_WRITES=1 in the environment and restart.")
+        print("=" * 70)
+        print()
+
     print("Starting UX Test Server...")
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -201,3 +201,162 @@ class TestDiscover:
             body = rv.get_json()
             assert body["status"] == "success"
             assert body["data"] == [{"endpoint": "x", "status": 200}]
+
+
+# ─────────────────────────────────────────────
+# Production write guard
+# ─────────────────────────────────────────────
+class TestProductionWriteGuard:
+    """
+    The /api/plex/raw proxy must refuse mutating methods (POST/PUT/PATCH/
+    DELETE) when running against a production Plex environment unless
+    PLEX_ALLOW_WRITES is explicitly enabled.
+
+    These tests temporarily flip the module-level IS_PRODUCTION and
+    WRITES_ALLOWED constants since they're computed at import time from
+    env vars (which conftest.py has already locked in).
+    """
+
+    def test_get_always_allowed_in_production(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.ok = True
+        mock_response.content = b"{}"
+        mock_response.json.return_value = {}
+        mock_response.headers = {}
+        mock_response.url = "https://connect.plex.com/mdm/v1/tenants"
+
+        with patch.object(app_module.requests, "request", return_value=mock_response):
+            rv = client.get("/api/plex/raw?path=mdm/v1/tenants")
+            assert rv.status_code == 200
+            assert rv.get_json()["status"] == "success"
+
+    def test_post_blocked_in_production_without_writes_allowed(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+
+        rv = client.post("/api/plex/raw?path=mdm/v1/parts", json={"foo": "bar"})
+        assert rv.status_code == 403
+        body = rv.get_json()
+        assert body["status"] == "error"
+        assert body["guard"] == "PLEX_ALLOW_WRITES"
+        assert body["is_production"] is True
+        assert body["writes_allowed"] is False
+        assert "PLEX_ALLOW_WRITES" in body["message"]
+        assert "POST" in body["message"]
+
+    def test_put_blocked_in_production_without_writes_allowed(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+
+        rv = client.put("/api/plex/raw?path=mdm/v1/parts/x", json={"foo": "bar"})
+        assert rv.status_code == 403
+        assert rv.get_json()["guard"] == "PLEX_ALLOW_WRITES"
+
+    def test_patch_blocked_in_production_without_writes_allowed(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+
+        rv = client.patch("/api/plex/raw?path=mdm/v1/parts/x", json={"foo": "bar"})
+        assert rv.status_code == 403
+
+    def test_delete_blocked_in_production_without_writes_allowed(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+
+        rv = client.delete("/api/plex/raw?path=mdm/v1/parts/x")
+        assert rv.status_code == 403
+
+    def test_post_allowed_in_production_when_writes_enabled(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", True)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.reason = "Created"
+        mock_response.ok = True
+        mock_response.content = b'{"id":"new"}'
+        mock_response.json.return_value = {"id": "new"}
+        mock_response.headers = {}
+        mock_response.url = "https://connect.plex.com/mdm/v1/parts"
+
+        with patch.object(app_module.requests, "request", return_value=mock_response):
+            rv = client.post("/api/plex/raw?path=mdm/v1/parts", json={"foo": "bar"})
+            assert rv.status_code == 200  # envelope is 200; inner http_status is 201
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["http_status"] == 201
+
+    def test_post_allowed_in_test_environment_regardless(self, client, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", False)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.ok = True
+        mock_response.content = b"{}"
+        mock_response.json.return_value = {}
+        mock_response.headers = {}
+        mock_response.url = "https://test.connect.plex.com/mdm/v1/parts"
+
+        with patch.object(app_module.requests, "request", return_value=mock_response):
+            rv = client.post("/api/plex/raw?path=mdm/v1/parts", json={"foo": "bar"})
+            assert rv.status_code == 200
+
+    def test_config_endpoint_exposes_guard_state(self, client):
+        rv = client.get("/api/config")
+        body = rv.get_json()
+        assert "is_production" in body
+        assert "writes_allowed" in body
+        assert isinstance(body["is_production"], bool)
+        assert isinstance(body["writes_allowed"], bool)
+
+
+# ─────────────────────────────────────────────
+# Helper function _is_write_blocked
+# ─────────────────────────────────────────────
+class TestIsWriteBlocked:
+    def test_get_never_blocked_in_production(self, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+        blocked, reason = app_module._is_write_blocked("GET")
+        assert blocked is False
+        assert reason == ""
+
+    def test_get_never_blocked_in_test(self, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", False)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+        blocked, reason = app_module._is_write_blocked("GET")
+        assert blocked is False
+
+    def test_post_blocked_in_production_default(self, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+        blocked, reason = app_module._is_write_blocked("POST")
+        assert blocked is True
+        assert "PLEX_ALLOW_WRITES" in reason
+
+    def test_post_unblocked_in_test(self, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", False)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+        blocked, reason = app_module._is_write_blocked("POST")
+        assert blocked is False
+
+    def test_post_unblocked_when_writes_enabled(self, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", True)
+        blocked, reason = app_module._is_write_blocked("POST")
+        assert blocked is False
+
+    def test_method_case_insensitive(self, monkeypatch):
+        monkeypatch.setattr(app_module, "IS_PRODUCTION", True)
+        monkeypatch.setattr(app_module, "WRITES_ALLOWED", False)
+        blocked, _ = app_module._is_write_blocked("post")
+        assert blocked is True
+        blocked, _ = app_module._is_write_blocked("Delete")
+        assert blocked is True


### PR DESCRIPTION
## Why this exists

This hour we discovered that the Fusion2Plex Consumer Key authenticates against `connect.plex.com` (**production**) on the **real Grace Engineering tenant** (\`58f781ba-1691-4f32-b1db-381cdb21300c\`). Every read affects nothing, but every write would affect actual manufacturing operations. There is **no test environment** for this app — production is the only environment we have.

This PR lands a hard safety guard **before** the migration that switches `USE_TEST` to `False`. When the migration lands, the guard is already in place.

## What it does

A hard refusal in `/api/plex/raw` for mutating HTTP methods (POST/PUT/PATCH/DELETE) when:
- `IS_PRODUCTION` is true (`client.base` does not contain `test.`)
- AND `WRITES_ALLOWED` is false (`PLEX_ALLOW_WRITES` env var is not set)

GET is **always** allowed. Reads are safe.

When a write is refused, the proxy returns HTTP 403 with this envelope:

\`\`\`json
{
  \"status\": \"error\",
  \"http_status\": 0,
  \"method\": \"POST\",
  \"url\": \"https://connect.plex.com/mdm/v1/parts\",
  \"message\": \"Write blocked: POST requests to https://connect.plex.com are refused because the server is running against a production Plex environment and PLEX_ALLOW_WRITES is not set. To enable writes, set PLEX_ALLOW_WRITES=1 in the environment and restart the server.\",
  \"guard\": \"PLEX_ALLOW_WRITES\",
  \"is_production\": true,
  \"writes_allowed\": false
}
\`\`\`

`/api/config` now also exposes \`is_production\` and \`writes_allowed\` so the UI can render an appropriate banner (next PR).

The Flask startup also prints a loud warning banner when connected to production, indicating whether writes are blocked or enabled.

## How to enable writes when you actually need them

\`\`\`powershell
\$env:PLEX_ALLOW_WRITES = \"1\"     # PowerShell
\`\`\`
\`\`\`bash
export PLEX_ALLOW_WRITES=1        # bash
\`\`\`
Then restart \`py app.py\`. Rotate the env var off as soon as you're done.

## Tests — 119 pass locally, 14 net new

| Test class | Count |
|---|---|
| \`TestProductionWriteGuard\` | 8 — GET always allowed, POST/PUT/PATCH/DELETE blocked in prod default, POST allowed in prod when writes enabled, POST allowed in test regardless, \`/api/config\` exposes guard state |
| \`TestIsWriteBlocked\` | 6 — direct helper tests including method case-insensitivity and explicit prod / test combinations |

## Test plan

- [ ] CI green
- [ ] Visual: confirm \`/api/config\` returns the new \`is_production\` and \`writes_allowed\` fields after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)