### PR TITLE
feat: run_dev.py local launcher (overrides shell env from .env.local)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "plex-api",
       "runtimeExecutable": "py",
-      "runtimeArgs": ["app.py"],
+      "runtimeArgs": ["run_dev.py"],
       "port": 5000
     }
   ]

--- a/run_dev.py
+++ b/run_dev.py
@@ -1,0 +1,110 @@
+"""
+run_dev.py
+Local development launcher for app.py.
+======================================
+
+Forces .env.local values to OVERRIDE shell environment variables, then
+runs app.py as if it were the main entry point.
+
+Why this exists
+---------------
+bootstrap.py uses os.environ.setdefault() so that real shell env vars
+always win over .env.local. That's correct for production deployment,
+where credentials should come from the host's secure environment, not
+a file. But it's wrong for local dev where:
+
+  - A stale shell env var (e.g. an old credential set via setx in the
+    Windows registry years ago) silently shadows .env.local
+  - Debugging "why isn't it working" wastes hours
+
+This launcher forces the override for local dev only. Production
+deployments still use `py app.py` directly, which respects
+bootstrap.setdefault() and lets the host shell env take precedence.
+
+Usage
+-----
+    py run_dev.py
+
+Or via Claude Preview — .claude/launch.json points here.
+"""
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_ENV_FILE = PROJECT_ROOT / ".env.local"
+
+
+def force_override_from_env_local(path: Path | str | None = None) -> int:
+    """
+    Read .env.local and write each KEY=VALUE pair into os.environ via
+    direct assignment (NOT setdefault). Existing shell env vars with
+    the same name are OVERRIDDEN.
+
+    Parameters
+    ----------
+    path : Path | str | None
+        Override the file path. Defaults to ``<project_root>/.env.local``.
+
+    Returns
+    -------
+    int
+        The number of os.environ keys that were either added or
+        actually changed (entries already at the desired value count
+        as zero).
+    """
+    if path is None:
+        path = DEFAULT_ENV_FILE
+    else:
+        path = Path(path)
+
+    if not path.exists():
+        return 0
+
+    changed = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        # Strip matched surrounding quotes (' or ")
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+
+        if not key:
+            continue
+
+        # Direct assignment — OVERRIDE the shell value if it exists
+        if os.environ.get(key) != value:
+            os.environ[key] = value
+            changed += 1
+
+    return changed
+
+
+def main() -> None:
+    n = force_override_from_env_local()
+    if n:
+        print(
+            f"[run_dev] Loaded {n} env var(s) from .env.local "
+            f"(overriding any shell-level values)"
+        )
+    elif not DEFAULT_ENV_FILE.exists():
+        print(
+            f"[run_dev] WARNING: {DEFAULT_ENV_FILE.name} not found. "
+            f"Falling back to shell env vars only."
+        )
+
+    # Re-execute app.py as __main__ so its existing startup banner +
+    # app.run() block fires correctly. Using runpy keeps the executed
+    # module's __name__ == '__main__'.
+    import runpy
+    runpy.run_path(str(PROJECT_ROOT / "app.py"), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_run_dev.py
+++ b/tests/test_run_dev.py
@@ -1,0 +1,155 @@
+"""
+Tests for run_dev.py — local dev launcher with force-override semantics.
+
+The whole point of run_dev.py is the OPPOSITE of bootstrap.py:
+bootstrap uses setdefault (real shell wins), run_dev uses direct
+assignment (file wins). These tests pin down that contract.
+"""
+import os
+
+import pytest
+
+from run_dev import force_override_from_env_local
+
+
+# ─────────────────────────────────────────────
+# Missing file is a no-op
+# ─────────────────────────────────────────────
+class TestMissingFile:
+    def test_missing_file_returns_zero(self, tmp_path):
+        missing = tmp_path / "does-not-exist.env"
+        assert force_override_from_env_local(missing) == 0
+
+    def test_missing_file_does_not_raise(self, tmp_path):
+        nowhere = tmp_path / "nope" / "alsonope" / ".env.local"
+        force_override_from_env_local(nowhere)  # no exception
+
+
+# ─────────────────────────────────────────────
+# Override behavior — the whole point
+# ─────────────────────────────────────────────
+class TestOverrideSemantics:
+    def test_overrides_existing_env_var(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=from-file\n")
+        monkeypatch.setenv("FOO", "from-shell")
+
+        changed = force_override_from_env_local(f)
+
+        assert changed == 1
+        assert os.environ["FOO"] == "from-file"
+
+    def test_sets_var_when_unset(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=from-file\n")
+        monkeypatch.delenv("FOO", raising=False)
+
+        changed = force_override_from_env_local(f)
+
+        assert changed == 1
+        assert os.environ["FOO"] == "from-file"
+
+    def test_no_change_count_when_already_correct(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=already-correct\n")
+        monkeypatch.setenv("FOO", "already-correct")
+
+        changed = force_override_from_env_local(f)
+
+        # The shell already has the right value — counts as zero changes
+        assert changed == 0
+        assert os.environ["FOO"] == "already-correct"
+
+    def test_partial_override_multiple_vars(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO=new-foo\nBAR=new-bar\nBAZ=new-baz\n")
+        monkeypatch.setenv("FOO", "old-foo")  # will be overridden
+        monkeypatch.setenv("BAR", "new-bar")  # already correct
+        monkeypatch.delenv("BAZ", raising=False)  # unset
+
+        changed = force_override_from_env_local(f)
+
+        # FOO: changed, BAR: no-op, BAZ: added → 2 changes
+        assert changed == 2
+        assert os.environ["FOO"] == "new-foo"
+        assert os.environ["BAR"] == "new-bar"
+        assert os.environ["BAZ"] == "new-baz"
+
+
+# ─────────────────────────────────────────────
+# Parsing — comments, blanks, quotes
+# ─────────────────────────────────────────────
+class TestParsing:
+    def test_skips_comments(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("# comment\nFOO=bar\n# another\n")
+        monkeypatch.delenv("FOO", raising=False)
+
+        changed = force_override_from_env_local(f)
+
+        assert changed == 1
+        assert os.environ["FOO"] == "bar"
+
+    def test_skips_blank_lines(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("\n\nFOO=bar\n\n\n")
+        monkeypatch.delenv("FOO", raising=False)
+
+        changed = force_override_from_env_local(f)
+        assert changed == 1
+
+    def test_skips_lines_without_equals(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("not-a-pair\nFOO=bar\n")
+        monkeypatch.delenv("FOO", raising=False)
+
+        changed = force_override_from_env_local(f)
+        assert changed == 1
+
+    def test_strips_double_quotes(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text('FOO="bar baz"\n')
+        monkeypatch.delenv("FOO", raising=False)
+
+        force_override_from_env_local(f)
+        assert os.environ["FOO"] == "bar baz"
+
+    def test_strips_single_quotes(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("FOO='bar baz'\n")
+        monkeypatch.delenv("FOO", raising=False)
+
+        force_override_from_env_local(f)
+        assert os.environ["FOO"] == "bar baz"
+
+    def test_handles_value_with_equals(self, tmp_path, monkeypatch):
+        f = tmp_path / ".env"
+        f.write_text("URL=https://example.com/?a=1&b=2\n")
+        monkeypatch.delenv("URL", raising=False)
+
+        force_override_from_env_local(f)
+        assert os.environ["URL"] == "https://example.com/?a=1&b=2"
+
+
+# ─────────────────────────────────────────────
+# Contract: run_dev opposite of bootstrap
+# ─────────────────────────────────────────────
+class TestRunDevVsBootstrap:
+    def test_run_dev_overrides_where_bootstrap_would_not(self, tmp_path, monkeypatch):
+        """
+        Pin down the differing semantics. With the same .env.local content
+        and pre-existing shell env, bootstrap.setdefault keeps the shell
+        value while run_dev.force_override replaces it.
+        """
+        f = tmp_path / ".env"
+        f.write_text("CRED=from-file\n")
+        monkeypatch.setenv("CRED", "from-shell")
+
+        # bootstrap.load_env_local is the SAFE path: shell wins
+        from bootstrap import load_env_local
+        load_env_local(f)
+        assert os.environ["CRED"] == "from-shell"
+
+        # run_dev.force_override is the DEV path: file wins
+        force_override_from_env_local(f)
+        assert os.environ["CRED"] == "from-file"


### PR DESCRIPTION
## Why this exists

`bootstrap.py` uses `os.environ.setdefault()` so a real shell env var **always** wins over `.env.local`. That's correct for production deployment (host secrets should beat a file). But it's wrong for the local dev loop, where a stale shell env var (e.g. an old `PLEX_API_KEY` set via `setx` in the Windows registry years ago) silently shadows `.env.local`. We just spent a couple hours debugging exactly this.

`run_dev.py` is the **opposite** of `bootstrap.py`: it loads `.env.local` with **direct assignment** (overriding the shell), then runs `app.py` via `runpy` so the existing `__main__` block (production warning banner, `app.run`) fires correctly.

**Production deployment is unchanged** — it still uses `py app.py` directly, which respects `bootstrap.setdefault()` and lets the host shell env take precedence.

## Files

| File | Change |
|---|---|
| `run_dev.py` | New ~100-line launcher with `force_override_from_env_local(path=None)` (mirrors `bootstrap.load_env_local`'s API) and `main()` that runs app.py via `runpy.run_path` |
| `.claude/launch.json` | Claude Preview now points at `run_dev.py` instead of `app.py` |
| `tests/test_run_dev.py` | 13 new tests |

## Tests — 141 pass locally, 13 net new

| Class | Coverage |
|---|---|
| `TestMissingFile` | Missing file is a no-op (no exception) |
| `TestOverrideSemantics` | Overrides existing var, sets when unset, returns 0 changes when already correct, partial override of multiple vars |
| `TestParsing` | Comments, blank lines, lines without `=`, double quotes, single quotes, value with `=` |
| `TestRunDevVsBootstrap` | **Pin down the differing semantics** by exercising both `load_env_local` (setdefault) and `force_override_from_env_local` (direct assignment) on the same fixture file with the same pre-existing shell value, asserting they give opposite results |

## Test plan

- [ ] CI green
- [ ] After merge: restart Claude Preview, click `tenant_whoami`, expect `match: "grace"` (the override means `.env.local` wins, so the correct Fusion2Plex key gets sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)