### PR TITLE
docs: Plex tooling lives in inventory/v1/inventory-definitions/supply-items

### DIFF
--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -101,22 +101,65 @@ Fusion 360 .json (network share, via Autodesk Desktop Connector)
 
 Verified empirically against `connect.plex.com` with the Grace tenant.
 
-| Status | Path                                  | Notes                                       |
-|--------|---------------------------------------|---------------------------------------------|
-| **200**| `mdm/v1/tenants`                      | 62 B — tenant list                          |
-| **200**| `mdm/v1/parts?limit=1`                | **19.6 MB** — `limit` IGNORED, full DB dump |
-| **200**| `mdm/v1/suppliers?limit=1`            | 708 KB — same, no server-side pagination    |
-| **200**| `purchasing/v1/purchase-orders?limit=1` | **44 MB** — full PO history                |
-| 404    | `production/v1/control/workcenters`   | Path doesn't exist on this app — see History §3 |
-| 404    | `tooling/v1/tools`                    | Path doesn't exist — see History §3         |
-| 404    | `tooling/v1/tool-assemblies`          | Path doesn't exist — see History §3         |
-| 404    | `tooling/v1/tool-inventory`           | Path doesn't exist — see History §3         |
-| 404    | `manufacturing/v1/operations`         | Path doesn't exist — see History §3         |
+### URL pattern convention
 
-**The 404 endpoints either use a different URL pattern in this product
-set, or aren't available to the Fusion2Plex app at all.** The user will
-need to share working URLs from Insomnia for those endpoints to make
-progress on issues #4, #5, #6.
+Plex uses two URL shapes for read endpoints:
+
+- **Master data, flat**: `<namespace>/v1/<resource>`
+  → `mdm/v1/parts`, `mdm/v1/suppliers`, `mdm/v1/operations`
+- **Definitions, nested**: `<namespace>/v1/<namespace>-definitions/<resource>`
+  → `production/v1/production-definitions/workcenters`
+  → `inventory/v1/inventory-definitions/supply-items`
+
+### Verified working endpoints
+
+| Path | Records | What it is |
+|---|---|---|
+| `mdm/v1/tenants` | 1 | Grace tenant only |
+| `mdm/v1/parts` | 16,913 | **Finished products + raw materials only.** types: Finished Good, Raw Material, Sub Assembly. Tools are NOT here. |
+| `mdm/v1/suppliers` | — | Supplier master |
+| `mdm/v1/customers` | — | |
+| `mdm/v1/contacts` | — | |
+| `mdm/v1/buildings` | — | |
+| `mdm/v1/employees` | — | |
+| `mdm/v1/operations` | 122 | Process steps. Minimal schema. No FK to tools/parts/routings — see Gotchas. |
+| `purchasing/v1/purchase-orders` | — | 44 MB unfiltered |
+| `production/v1/production-definitions/workcenters` | 143 | Includes 21 MILLs. **Codes 879/880 = Brother Speedio FTP IPs.** |
+| `inventory/v1/inventory-definitions/supply-items` | 2,516 | **WHERE TOOLS LIVE.** Filter `category="Tools & Inserts"` for the 1,109 cutting tools and inserts. |
+| `inventory/v1/inventory-definitions/locations` | — | Inventory location master |
+
+### Where tooling data actually lives
+
+Cutting tools and inserts are **`inventory/v1/inventory-definitions/supply-items`**
+records with `category="Tools & Inserts"` and `group="Machining"`. There are
+already 1,109 tools/inserts tracked in Plex Grace. The schema is:
+
+  - `category` (e.g. "Tools & Inserts")
+  - `description`
+  - `group` (e.g. "Machining", "Tool Room")
+  - `id` (UUID)
+  - `inventoryUnit`
+  - `supplyItemNumber` (vendor part number — the dedup key)
+  - `type` (e.g. SUPPLY, OFFICE)
+
+This is **identity-only**: vendor + part number + description. Geometry
+(DC, OAL, NOF, holder) stays in Fusion as the source of truth — Plex
+stores the vendor reference and the inventory tracking. The Fusion sync
+will write to `inventory/v1/inventory-definitions/supply-items`, not to
+`mdm/v1/parts` (which is for finished products).
+
+### Workcenter ↔ machine mapping
+
+The 21 MILL workcenter records map directly to physical machines via
+`workcenterCode` (which equals the machine number / DNC IP last octet):
+
+| Brother Speedio | FTP IP | Plex workcenterCode | Plex workcenterId |
+|---|---|---|---|
+| 879 | 192.168.25.79 | `879` | `0b6cf62b-2809-4d3d-ab24-369cd0171f62` |
+| 880 | 192.168.25.80 | `880` | `8e262d5a-3ce8-4597-8726-d2b979b1b6b7` |
+
+Full mill list: 814, 825, 827, 830, 834-841, 845, 848, 851, 865, 873,
+879, 880, DEFLECT.
 
 ### How to read 401 vs 404 from Plex
 
@@ -127,6 +170,15 @@ progress on issues #4, #5, #6.
 - **The only way to tell apart cleanly** is to compare across many endpoints
   with the same auth, AND ideally compare against a known-good client
   (Insomnia → Generate Code) for ground truth.
+
+### Filter behavior — most query params are silently ignored
+
+Empirically verified: Plex's gateway accepts unknown query parameters
+without complaint and just returns the unfiltered set. The only filter
+we've seen actually work on `mdm/v1/parts` is `?status=Active` (reduces
+19.6 MB → 7.8 MB). The `typeName`, `type`, `category`, `limit` parameters
+all return the full unfiltered response. Always assume `limit` does
+nothing and use real filters or accept the full DB pull.
 
 ---
 
@@ -220,21 +272,26 @@ All items below are mirrored as GitHub Issues — see
 https://github.com/grace-shane/plex-api/issues for live status.
 
 1. ~~Fix PlexClient constructor — add api_secret, include header~~ DONE
-2. Read baseline tooling inventory from `mdm/v1/parts` — issue #2.
-   **Endpoint works** but `limit` is ignored (full DB pull is 19.6 MB).
-   Need to figure out the right filter parameter (`status=Active`,
-   maybe `type=...`) to get just consumable cutting tools.
-3. `build_part_payload(tool: dict) -> dict` — issue #3.
-   Maps Fusion tool object to `mdm/v1/parts` POST body. Drafting can
-   start now since we can read existing parts to learn the schema.
-4. `resolve_supplier_uuid(vendor_name: str) -> str` — issue #3.
-   Looks up supplier UUID from `mdm/v1/suppliers` (works on PROD now).
-5. `build_assembly_payload(tool: dict, holder: dict) -> dict` — issue #4.
-   `tooling/v1/tool-assemblies` returns 404 on PROD — need working URL
-   pattern from Insomnia.
-6. Core sync logic — upsert with guid-based dedup — issue #7.
+2. ~~Find the real Plex tooling endpoint~~ DONE — it's
+   `inventory/v1/inventory-definitions/supply-items` with
+   `category="Tools & Inserts"`. 1,109 records already exist.
+3. Read baseline tooling inventory from supply-items — issue #2.
+   Filter client-side by `category="Tools & Inserts"` since query
+   filters are mostly ignored. Save snapshot to `outputs/`.
+4. `build_supply_item_payload(fusion_tool: dict) -> dict` — issue #3.
+   Maps Fusion tool to a supply-item POST body with
+   `category="Tools & Inserts"`, `group="Machining"`,
+   `supplyItemNumber=<vendor part-id>`, `description=<fusion description>`.
+5. Match-and-upsert logic by `supplyItemNumber` — issue #3.
+   Read existing supply-items, match by vendor part number, decide
+   POST (new) vs PUT (update existing).
+6. Workcenter doc push — issue #6. Use the verified path
+   `production/v1/production-definitions/workcenters/{id}` and the
+   workcenterCode → Brother Speedio mapping (codes 879, 880).
+   We have READ-only verified; write endpoint shape still TBD.
+7. Core sync logic — upsert with `supplyItemNumber` dedup — issue #7.
    Dry-run by default. Real writes require `PLEX_ALLOW_WRITES=1`.
-7. Error handling + logging to network share text file — issue #8.
+8. Error handling + logging to network share text file — issue #8.
 
 ---
 

--- a/Plex_API_Reference.md
+++ b/Plex_API_Reference.md
@@ -35,19 +35,73 @@ X-Plex-Connect-Api-Key: <your_consumer_key>
 > Grace tenant (`58f781ba-1691-4f32-b1db-381cdb21300c`). Reproduce by
 > running the diagnostic at `/api/diagnostics/tenant` from the local UI.
 
-### Current access matrix
+### URL pattern convention
 
-| Status | Path                                    | Notes                                                |
-|--------|------------------------------------------|------------------------------------------------------|
-| **200**| `mdm/v1/tenants`                         | Returns tenant list (62 B). Used by `tenant_whoami`. |
-| **200**| `mdm/v1/parts?limit=1`                   | **19.6 MB** — `limit` IGNORED. Filter or pay the bill. |
-| **200**| `mdm/v1/suppliers?limit=1`               | 708 KB — same no-pagination behaviour.               |
-| **200**| `purchasing/v1/purchase-orders?limit=1`  | **44 MB** — full PO history.                         |
-| 404    | `tooling/v1/tools`                       | Path doesn't exist on this app's product set.        |
-| 404    | `tooling/v1/tool-assemblies`             | Same.                                                |
-| 404    | `tooling/v1/tool-inventory`              | Same.                                                |
-| 404    | `manufacturing/v1/operations`            | Same.                                                |
-| 404    | `production/v1/control/workcenters`      | Same. Issues #4, #5, #6 are blocked on finding the right URLs. |
+Plex uses two URL shapes for read endpoints:
+
+1. **Master data — flat**: `<namespace>/v1/<resource>`
+   Example: `mdm/v1/parts`, `mdm/v1/suppliers`, `mdm/v1/operations`
+2. **Definitions — nested**: `<namespace>/v1/<namespace>-definitions/<resource>`
+   Example: `production/v1/production-definitions/workcenters`,
+   `inventory/v1/inventory-definitions/supply-items`,
+   `inventory/v1/inventory-definitions/locations`
+
+Both patterns are used in production. The bare `<namespace>/v1` root
+typically returns 404 (no resource at the root); the actual data lives
+one level deeper.
+
+### Verified working endpoints
+
+| Status | Path | Records | Notes |
+|---|---|---|---|
+| **200** | `mdm/v1/tenants` | 1 | Single tenant: Grace |
+| **200** | `mdm/v1/parts` | 16,913 | Finished products + raw materials. **No tools here** — the `type` field has only `Finished Good`, `Raw Material`, `Sub Assembly` |
+| **200** | `mdm/v1/parts/{id}` | — | Per-record GET works. Same fields as the list view (no hidden detail). |
+| **200** | `mdm/v1/suppliers` | — | 708 KB |
+| **200** | `mdm/v1/customers` | — | 96 KB |
+| **200** | `mdm/v1/contacts` | — | 202 KB |
+| **200** | `mdm/v1/buildings` | — | 1.2 KB |
+| **200** | `mdm/v1/employees` | — | 272 KB |
+| **200** | `mdm/v1/operations` | 122 | Minimal: `code, id, inventoryType, type`. No FK to tools/parts/routings. |
+| **200** | `mdm/v1/operations/{id}` | — | Per-record GET works. Same fields as list. |
+| **200** | `purchasing/v1/purchase-orders` | — | 44 MB unfiltered, full PO history |
+| **200** | `production/v1/production-definitions/workcenters` | 143 | All workcenters including the 21 MILLs (codes 879, 880 = Brother Speedio FTP IPs) |
+| **200** | `production/v1/production-definitions/workcenters/{id}` | — | Fields: `buildingCode, buildingId, ipAddress, name, plcName, productionLineId, tankSilo, workcenterCode, workcenterGroup, workcenterId, workcenterType` |
+| **200** | `inventory/v1/inventory-definitions/supply-items` | 2,516 | **TOOLS LIVE HERE.** Filter to `category="Tools & Inserts"` for the 1,109 cutting tools and inserts. Schema: `category, description, group, id, inventoryUnit, supplyItemNumber, type` |
+| **200** | `inventory/v1/inventory-definitions/locations` | — | 279 KB |
+
+### Where tooling data actually lives
+
+**Cutting tools and inserts are `inventory/v1/inventory-definitions/supply-items`
+records** with `category="Tools & Inserts"`. This is NOT what the original
+`Plex_API_Reference.md` claimed — that file referenced `tooling/v1/tools` and
+`mdm/v1/parts`, neither of which works for tooling on this app.
+
+Verified empirically: 1,109 tools/inserts already exist in Plex Grace, mostly
+in `group="Machining"` (1,039) and `group="Tool Room"` (104). The supply-item
+schema is minimal — it tracks vendor part number identity, not geometry, so
+the Fusion 360 sync will:
+
+1. Read existing tools via `GET inventory/v1/inventory-definitions/supply-items`
+2. Filter client-side or via query string to `category=Tools & Inserts`
+3. Match by `supplyItemNumber` (vendor part number, e.g. Harvey Tool's `990910`)
+4. Create new supply-items for Fusion tools that don't exist
+5. Update existing ones
+
+Geometry (DC, OAL, NOF, holder details) stays in Fusion as the source of
+truth — Plex stores only the identity, description, and group/category.
+
+### Workcenter ↔ machine mapping (verified)
+
+The 21 MILL workcenter records map directly to physical Brother Speedio
+machines via the `workcenterCode` field (which equals the machine number /
+DNC IP last octet):
+
+- Workcenter `879` → Brother Speedio 879 → FTP `192.168.25.79`
+- Workcenter `880` → Brother Speedio 880 → FTP `192.168.25.80`
+
+The full mill list: 814, 825, 827, 830, 834, 835, 836, 837, 839, 840, 841,
+845, 848, 851, 865, 873, 879, 880, DEFLECT.
 
 ### Reading Plex's status codes
 
@@ -57,20 +111,22 @@ X-Plex-Connect-Api-Key: <your_consumer_key>
   from outside.
 - **404 `RESOURCE_NOT_FOUND`** — Plex's gateway has no route at that path.
   Could mean unknown URL OR subscribed-but-no-resource. Same wire response.
-- **403** — **never observed in practice on this app**, despite earlier docs
-  claiming we were getting 403 from `tooling/v1/*`. Treat any 403 as
-  unexpected.
+- **400** — Plex recognizes the path but the request is malformed (often
+  treats a string as a UUID parameter and fails to parse).
+- **403** — **never observed in practice on this app**.
 
-The 401-vs-404 distinction is **not** a clean signal. The only reliable way
-to disambiguate is to compare against a known-good client (Insomnia "Generate
-Code" output is the gold standard).
+The 401-vs-404 distinction is **not** a clean signal on its own. The only
+reliable way to disambiguate is to compare against a known-good client
+(Insomnia "Generate Code" output is the gold standard).
 
 ### No server-side pagination
 
 `mdm/v1/parts` and `purchasing/v1/purchase-orders` **silently ignore** the
 `limit` query parameter. We learned this empirically — `?limit=1` returned
-19.6 MB and 44 MB respectively. Always use a real filter (`status=Active`,
-date range, etc.) before calling these endpoints.
+19.6 MB and 44 MB respectively. The only filter we've verified actually
+works is `?status=Active` on `mdm/v1/parts` (reduces 19.6 MB → 7.8 MB).
+The `typeName` filter is also silently ignored. **Always assume `limit`
+does nothing and use real filters or accept the full DB pull.**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,11 +20,11 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 
 ## Phase 3: Plex API Source-of-Truth Implementation
 
-- [ ] Implement API call to retrieve current tooling inventory from Plex (master list) — `mdm/v1/parts` works on PROD now, but the `limit` param is ignored so we need a real filter (`status=Active`, etc.). → [#2](https://github.com/grace-shane/plex-api/issues/2)
-- [ ] Implement API call to update/create purchased parts — `mdm/v1/parts` and `mdm/v1/suppliers` are reachable, drafting can begin. Writes are blocked at the proxy by default; opt in with `PLEX_ALLOW_WRITES=1`. → [#3](https://github.com/grace-shane/plex-api/issues/3)
-- [ ] Implement API call to create/update Tool Assemblies — `tooling/v1/tool-assemblies` returns 404 on PROD with the Fusion2Plex app. Need a working URL pattern from Insomnia. → [#4](https://github.com/grace-shane/plex-api/issues/4)
-- [ ] Implement API call to link Tool Assemblies to Routings/Operations — `manufacturing/v1/operations` returns 404 on PROD. Same problem as #4. → [#5](https://github.com/grace-shane/plex-api/issues/5)
-- [ ] Implement API call to update tooling within the specific Workcenter Document — `production/v1/control/workcenters` returns 404 on PROD. Same problem. → [#6](https://github.com/grace-shane/plex-api/issues/6)
+- [ ] Implement API call to retrieve current tooling inventory — `inventory/v1/inventory-definitions/supply-items` returns 2,516 records, of which 1,109 are `category="Tools & Inserts"`. Filter client-side. → [#2](https://github.com/grace-shane/plex-api/issues/2)
+- [ ] Implement API call to upsert supply-items — `build_supply_item_payload(fusion_tool)` writes to `inventory/v1/inventory-definitions/supply-items` with `supplyItemNumber=<vendor part-id>`. Drafting can begin against the verified read path. → [#3](https://github.com/grace-shane/plex-api/issues/3)
+- [ ] Implement Tool Assembly handling — Plex's supply-item schema is identity-only (no holder linkage). Tool assemblies as a separate concept may not exist in this app's API surface. **Investigate or descope.** → [#4](https://github.com/grace-shane/plex-api/issues/4)
+- [ ] Implement API call to link tools to Routings/Operations — `mdm/v1/operations` exposes only `code, id, inventoryType, type` with no FK to tools. **Linkage may not be possible via API**; may require CSV upload or different approach. → [#5](https://github.com/grace-shane/plex-api/issues/5)
+- [ ] Implement API call to update tooling within the specific Workcenter Document — verified read path is `production/v1/production-definitions/workcenters/{id}`. We have the workcenterCode → Brother Speedio mapping (879, 880). Write shape TBD. → [#6](https://github.com/grace-shane/plex-api/issues/6)
 - [x] **IT blocker resolved.** The Fusion2Plex app on production with the Grace tenant authenticates correctly. The earlier "tenant routing" / "subscription approvals" investigation was a red herring caused by a credential typo. See BRIEFING.md "History of incorrect hypotheses" for the postmortem. → [#1](https://github.com/grace-shane/plex-api/issues/1)
 
 ## Phase 4: Data Mapping & Sync Logic


### PR DESCRIPTION
## Discovery

After hours of probing, we now have ground truth on where Plex Grace stores tooling data. **It is not `mdm/v1/parts` and not `tooling/v1/*`. It is `inventory/v1/inventory-definitions/supply-items`** with `category="Tools & Inserts"`.

## Verified facts (live, on `connect.plex.com`, Grace tenant)

| Endpoint | Records | Notes |
|---|---|---|
| `inventory/v1/inventory-definitions/supply-items` | **2,516** | of which **1,109** have `category="Tools & Inserts"` — these are the cutting tools and inserts |
| `production/v1/production-definitions/workcenters` | **143** | including 21 MILLs. **Codes 879/880** map to the Brother Speedio FTP IPs in BRIEFING. |
| `mdm/v1/parts` | **16,913** | finished products + raw materials only — `type` is `Finished Good`, `Raw Material`, `Sub Assembly`. No tools. |
| `mdm/v1/operations` | 122 | minimal schema: `code, id, inventoryType, type`. No FK to tools/parts/routings. |
| `mdm/v1/{tenants,suppliers,customers,contacts,buildings,employees}` | various | all 200, all read-only verified |
| `inventory/v1/inventory-definitions/locations` | — | bonus discovery, 279 KB |

## URL pattern convention

Plex uses two URL shapes for read endpoints:

1. **Master data, flat**: `<namespace>/v1/<resource>` → `mdm/v1/parts`
2. **Definitions, nested**: `<namespace>/v1/<namespace>-definitions/<resource>` → `production/v1/production-definitions/workcenters`, `inventory/v1/inventory-definitions/supply-items`

This is now documented in both `Plex_API_Reference.md` and `BRIEFING.md` as a permanent reference.

## Workcenter ↔ Brother Speedio mapping

The `workcenterCode` field equals the machine number / DNC IP last octet:

| Brother Speedio | FTP IP | workcenterCode | workcenterId |
|---|---|---|---|
| 879 | 192.168.25.79 | `879` | `0b6cf62b-2809-4d3d-ab24-369cd0171f62` |
| 880 | 192.168.25.80 | `880` | `8e262d5a-3ce8-4597-8726-d2b979b1b6b7` |

Clean linkage between Fusion's network shares (which the loader reads) and Plex workcenter records.

## What this means for the project plan

| Issue | Old understanding | New understanding |
|---|---|---|
| **#2** | Read tools from `mdm/v1/parts?type=Tool` | Read from `inventory/v1/inventory-definitions/supply-items`, filter client-side to `category="Tools & Inserts"` |
| **#3** | `build_part_payload(tool)` writing to `mdm/v1/parts` | `build_supply_item_payload(fusion_tool)` writing to `inventory/v1/inventory-definitions/supply-items`. Identity-only schema (`category, description, group, supplyItemNumber, type`) — no geometry |
| **#4** | Tool assemblies via `tooling/v1/tool-assemblies` | Plex's supply-item schema is identity-only. Tool assemblies as a separate API concept may not exist in this app's surface. **Investigate or descope.** |
| **#5** | Operation linkage via `manufacturing/v1/operations` | `mdm/v1/operations` exists but exposes only `code/id/inventoryType/type` with no tool FK. Linkage may not be possible via API. |
| **#6** | `production/v1/control/workcenters` | Verified read at `production/v1/production-definitions/workcenters/{id}`. Write shape TBD. |

## Files

| File | Change |
|---|---|
| `Plex_API_Reference.md` | Section 3 rewritten with URL pattern convention, verified endpoint table, "Where tooling data actually lives" section, workcenter mapping, filter behavior caveat |
| `BRIEFING.md` | Access matrix replaced with verified facts, supply-items section added, workcenter mapping table added, Immediate TODO renumbered |
| `TODO.md` | Phase 3 entries updated to point at the verified endpoints |

**No code changes, no test changes. 141 tests still pass.**

## Test plan

- [ ] CI green
- [ ] After merge: update GitHub issues #2, #3, #4, #5, #6 to reflect the new understanding (separate post-merge cleanup)
- [ ] Then start coding `build_supply_item_payload` against the verified read path

🤖 Generated with [Claude Code](https://claude.com/claude-code)