### PR TITLE
feat: extract_supply_items + Fusion testing-harness endpoints (closes #2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,8 @@ from plex_api import (
     extract_purchase_orders,
     extract_workcenters,
     extract_operations,
+    extract_supply_items,
+    TOOLING_CATEGORY,
 )
 from tool_library_loader import load_all_libraries
 from plex_diagnostics import tenant_whoami, list_tenants, get_tenant
@@ -230,6 +232,8 @@ def api_extract(endpoint_type):
             data = extract_workcenters(client)
         elif endpoint_type == 'operations':
             data = extract_operations(client)
+        elif endpoint_type == 'supply_items':
+            data = extract_supply_items(client)
         else:
             return jsonify({"status": "error", "message": "Unknown endpoint"}), 400
 
@@ -274,6 +278,104 @@ def api_fusion_tools():
             "status": "success",
             "library_count": len(libs),
             "data": summary
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+# ─────────────────────────────────────────────
+# Fusion 360 testing-harness endpoints
+# ─────────────────────────────────────────────
+# These expose Fusion JSON data via Flask routes so the UI rail can poke
+# at the local tool libraries without re-uploading. Read-only on the
+# network share via tool_library_loader.
+
+# Tool types we exclude from the sync per BRIEFING spec — holders are
+# the geometric collision shapes, probes are measurement devices, neither
+# represent purchasable cutting tools.
+NON_CONSUMABLE_TYPES = {"holder", "probe"}
+
+
+@app.route('/api/fusion/tools/stats')
+def api_fusion_tools_stats():
+    """
+    Type and vendor distribution across all loaded Fusion libraries.
+
+    Useful for verifying load before any sync work — confirms how many
+    tools/holders/probes the loader saw and which vendors are represented.
+    """
+    try:
+        libs = load_all_libraries(abort_on_stale=True)
+
+        per_library = []
+        global_types = {}
+        global_vendors = {}
+        total_records = 0
+        consumable_count = 0
+
+        for name, tools in libs.items():
+            type_counts = {}
+            for t in tools:
+                tool_type = (t.get("type") or "unknown").strip().lower()
+                type_counts[tool_type] = type_counts.get(tool_type, 0) + 1
+                global_types[tool_type] = global_types.get(tool_type, 0) + 1
+                vendor = (t.get("vendor") or "unknown").strip()
+                global_vendors[vendor] = global_vendors.get(vendor, 0) + 1
+                total_records += 1
+                if tool_type not in NON_CONSUMABLE_TYPES:
+                    consumable_count += 1
+            per_library.append({
+                "library_name": name,
+                "tool_count": len(tools),
+                "type_counts": type_counts,
+            })
+
+        return jsonify({
+            "status": "success",
+            "library_count": len(libs),
+            "total_records": total_records,
+            "consumable_count": consumable_count,
+            "non_consumable_count": total_records - consumable_count,
+            "global_type_counts": global_types,
+            "global_vendor_counts": global_vendors,
+            "per_library": per_library,
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+@app.route('/api/fusion/tools/consumables')
+def api_fusion_tools_consumables():
+    """
+    Return the list of Fusion tools to actually push to Plex
+    (excluding holders and probes).
+
+    This is the input to ``build_supply_item_payload(fusion_tool)`` in
+    issue #3. The returned list contains only the fields the Plex sync
+    will care about: vendor, product-id, description, type, guid.
+    """
+    try:
+        libs = load_all_libraries(abort_on_stale=True)
+
+        consumables = []
+        for library_name, tools in libs.items():
+            for t in tools:
+                tool_type = (t.get("type") or "").strip().lower()
+                if tool_type in NON_CONSUMABLE_TYPES:
+                    continue
+                consumables.append({
+                    "library_name": library_name,
+                    "guid": t.get("guid"),
+                    "type": t.get("type"),
+                    "vendor": t.get("vendor"),
+                    "product_id": t.get("product-id"),
+                    "description": t.get("description"),
+                })
+
+        return jsonify({
+            "status": "success",
+            "count": len(consumables),
+            "data": consumables,
         })
     except Exception as e:
         return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500

--- a/plex_api.py
+++ b/plex_api.py
@@ -312,6 +312,77 @@ def extract_operations(client):
     return results
 
 
+# Category strings used by Plex Grace's supply-items records to identify
+# cutting tools and inserts. Verified empirically against the live API
+# on 2026-04-07. There are 1,109 such records on the Grace tenant.
+TOOLING_CATEGORY = "Tools & Inserts"
+
+
+def extract_supply_items(client, category=None):
+    """
+    Pull supply-items from Plex and (by default) filter to cutting tools.
+
+    Issue #2 — read the baseline tooling inventory from Plex.
+
+    Plex Grace stores cutting tools and inserts as ``supply-items`` under
+    ``inventory/v1/inventory-definitions/supply-items``, NOT under
+    ``mdm/v1/parts`` (which is finished products). The schema is
+    identity-only — vendor part number, description, category, group —
+    no geometry. Geometry stays in Fusion as the source of truth.
+
+    Server-side query filters on this endpoint are silently ignored, so
+    we always pull the full set (~614 KB / 2,516 records on Grace) and
+    filter client-side.
+
+    Parameters
+    ----------
+    client : PlexClient
+    category : str | None
+        If provided, keep only records whose ``category`` matches.
+        Defaults to ``"Tools & Inserts"``. Pass ``""`` (empty string)
+        to disable the filter and return everything.
+
+    Returns
+    -------
+    list[dict] | None
+        The matching supply-item records, or None on a network/auth
+        failure. Records are also written to
+        ``outputs/plex_supply_items.csv`` for diff/snapshot use.
+    """
+    if category is None:
+        category = TOOLING_CATEGORY
+
+    print("\nExtracting Supply Items...")
+    raw = client.get("inventory", "v1", "inventory-definitions/supply-items")
+
+    if raw is None:
+        print("  No response — credentials, network, or subscription issue")
+        return None
+
+    # The response shape is a bare list of dicts (verified empirically)
+    if isinstance(raw, dict):
+        records = raw.get("data") or raw.get("items") or raw.get("rows") or []
+    else:
+        records = raw or []
+
+    total = len(records)
+
+    # Client-side filter
+    if category:
+        records = [r for r in records if r.get("category") == category]
+        print(f"  Pulled {total} supply-items, filtered to {len(records)} "
+              f"with category={category!r}")
+    else:
+        print(f"  Pulled {total} supply-items (no filter)")
+
+    if records:
+        out = os.path.join(OUTPUT_DIR, "plex_supply_items.csv")
+        write_csv(records, out)
+        print(f"  Saved {len(records)} supply-items → {out}")
+
+    return records
+
+
 # ─────────────────────────────────────────────
 # UTILITY
 # ─────────────────────────────────────────────

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,11 +32,13 @@
                     <li><button class="preset" data-method="GET" data-path="mdm/v1/parts"><span class="m m-get">GET</span><span class="p">mdm/v1/parts</span></button></li>
                     <li><button class="preset" data-method="GET" data-path="mdm/v1/suppliers"><span class="m m-get">GET</span><span class="p">mdm/v1/suppliers</span></button></li>
                     <li><button class="preset" data-method="GET" data-path="mdm/v1/tenants"><span class="m m-get">GET</span><span class="p">mdm/v1/tenants</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="mdm/v1/customers"><span class="m m-get">GET</span><span class="p">mdm/v1/customers</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="mdm/v1/buildings"><span class="m m-get">GET</span><span class="p">mdm/v1/buildings</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="mdm/v1/operations"><span class="m m-get">GET</span><span class="p">mdm/v1/operations</span></button></li>
                     <li><button class="preset" data-method="GET" data-path="purchasing/v1/purchase-orders"><span class="m m-get">GET</span><span class="p">purchasing/v1/purchase-orders</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="production/v1/control/workcenters"><span class="m m-get">GET</span><span class="p">production/v1/control/workcenters</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tools"><span class="m m-get">GET</span><span class="p">tooling/v1/tools</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-assemblies"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-assemblies</span></button></li>
-                    <li><button class="preset" data-method="GET" data-path="tooling/v1/tool-inventory"><span class="m m-get">GET</span><span class="p">tooling/v1/tool-inventory</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="production/v1/production-definitions/workcenters"><span class="m m-get">GET</span><span class="p">production/v1/production-definitions/workcenters</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="inventory/v1/inventory-definitions/supply-items"><span class="m m-get">GET</span><span class="p">inventory/v1/inventory-definitions/supply-items</span></button></li>
+                    <li><button class="preset" data-method="GET" data-path="inventory/v1/inventory-definitions/locations"><span class="m m-get">GET</span><span class="p">inventory/v1/inventory-definitions/locations</span></button></li>
                 </ul>
             </section>
 
@@ -44,6 +46,7 @@
                 <div class="rail-label">Extractors</div>
                 <ul class="preset-list">
                     <li><button class="preset internal" data-internal="/api/plex/discover"><span class="m m-int">RUN</span><span class="p">discover_all</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/plex/supply_items"><span class="m m-int">RUN</span><span class="p">extract_supply_items</span></button></li>
                     <li><button class="preset internal" data-internal="/api/plex/parts"><span class="m m-int">RUN</span><span class="p">extract_parts</span></button></li>
                     <li><button class="preset internal" data-internal="/api/plex/purchase_orders"><span class="m m-int">RUN</span><span class="p">extract_purchase_orders</span></button></li>
                     <li><button class="preset internal" data-internal="/api/plex/workcenters"><span class="m m-int">RUN</span><span class="p">extract_workcenters</span></button></li>
@@ -54,6 +57,8 @@
                 <div class="rail-label">Fusion 360 local</div>
                 <ul class="preset-list">
                     <li><button class="preset internal" data-internal="/api/fusion/tools"><span class="m m-int">RUN</span><span class="p">load_all_libraries</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/fusion/tools/stats"><span class="m m-int">RUN</span><span class="p">tools_stats</span></button></li>
+                    <li><button class="preset internal" data-internal="/api/fusion/tools/consumables"><span class="m m-int">RUN</span><span class="p">consumables_only</span></button></li>
                 </ul>
                 <div class="rail-sub">
                     <button class="btn-ghost btn-xs" id="btn-pick-files">Upload files…</button>

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -360,3 +360,109 @@ class TestIsWriteBlocked:
         assert blocked is True
         blocked, _ = app_module._is_write_blocked("Delete")
         assert blocked is True
+
+
+# ─────────────────────────────────────────────
+# /api/plex/supply_items (issue #2)
+# ─────────────────────────────────────────────
+class TestSupplyItemsExtractor:
+    def test_route_calls_extract_supply_items(self, client):
+        with patch.object(app_module, "extract_supply_items") as mock_extract:
+            mock_extract.return_value = [
+                {"category": "Tools & Inserts", "supplyItemNumber": "990910"},
+                {"category": "Tools & Inserts", "supplyItemNumber": "ABC123"},
+            ]
+            rv = client.get("/api/plex/supply_items")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["count"] == 2
+            assert len(body["data"]) == 2
+            mock_extract.assert_called_once()
+
+    def test_route_returns_none_safely_when_extractor_returns_none(self, client):
+        with patch.object(app_module, "extract_supply_items", return_value=None):
+            rv = client.get("/api/plex/supply_items")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["count"] == 0
+            assert body["data"] == []
+
+
+# ─────────────────────────────────────────────
+# /api/fusion/tools/stats (testing harness)
+# ─────────────────────────────────────────────
+class TestFusionToolsStats:
+    SAMPLE_LIBS = {
+        "BROTHER 879": [
+            {"type": "flat end mill", "vendor": "HARVEY TOOL"},
+            {"type": "flat end mill", "vendor": "Garr Tool"},
+            {"type": "drill", "vendor": "OSG"},
+            {"type": "holder", "vendor": "Big Daishowa"},
+            {"type": "probe", "vendor": "Renishaw"},
+        ],
+        "BROTHER 880": [
+            {"type": "bull nose end mill", "vendor": "HARVEY TOOL"},
+            {"type": "holder", "vendor": "Big Daishowa"},
+        ],
+    }
+
+    def test_stats_aggregates_across_libraries(self, client):
+        with patch.object(app_module, "load_all_libraries", return_value=self.SAMPLE_LIBS):
+            rv = client.get("/api/fusion/tools/stats")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["library_count"] == 2
+            assert body["total_records"] == 7
+            # 2 holders + 1 probe = 3 non-consumable; 4 consumables
+            assert body["consumable_count"] == 4
+            assert body["non_consumable_count"] == 3
+            assert body["global_type_counts"]["flat end mill"] == 2
+            assert body["global_type_counts"]["holder"] == 2
+            assert body["global_type_counts"]["probe"] == 1
+            assert body["global_vendor_counts"]["HARVEY TOOL"] == 2
+
+    def test_stats_handles_empty_libraries(self, client):
+        with patch.object(app_module, "load_all_libraries", return_value={}):
+            rv = client.get("/api/fusion/tools/stats")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["library_count"] == 0
+            assert body["total_records"] == 0
+            assert body["consumable_count"] == 0
+
+
+# ─────────────────────────────────────────────
+# /api/fusion/tools/consumables (testing harness)
+# ─────────────────────────────────────────────
+class TestFusionToolsConsumables:
+    def test_excludes_holders_and_probes(self, client):
+        libs = {
+            "lib1": [
+                {"guid": "g1", "type": "flat end mill", "vendor": "HARVEY TOOL", "product-id": "990910", "description": "5/8 SQ"},
+                {"guid": "g2", "type": "drill", "vendor": "OSG", "product-id": "OSG-1234", "description": "1/4 drill"},
+                {"guid": "g3", "type": "holder", "vendor": "Big Daishowa", "product-id": "BIG-1", "description": "BT30"},
+                {"guid": "g4", "type": "probe", "vendor": "Renishaw", "product-id": "RNS-1", "description": "Probe"},
+            ],
+        }
+        with patch.object(app_module, "load_all_libraries", return_value=libs):
+            rv = client.get("/api/fusion/tools/consumables")
+            assert rv.status_code == 200
+            body = rv.get_json()
+            assert body["status"] == "success"
+            assert body["count"] == 2
+            guids = {c["guid"] for c in body["data"]}
+            assert guids == {"g1", "g2"}
+
+    def test_normalizes_field_names_to_snake_case(self, client):
+        libs = {
+            "lib1": [
+                {"guid": "g1", "type": "drill", "vendor": "OSG", "product-id": "X-1", "description": "drill"},
+            ],
+        }
+        with patch.object(app_module, "load_all_libraries", return_value=libs):
+            rv = client.get("/api/fusion/tools/consumables")
+            body = rv.get_json()
+            assert "product_id" in body["data"][0]  # NOT product-id
+            assert body["data"][0]["product_id"] == "X-1"

--- a/tests/test_plex_api.py
+++ b/tests/test_plex_api.py
@@ -10,7 +10,14 @@ import pytest
 import requests
 
 import plex_api
-from plex_api import PlexClient, BASE_URL, TEST_URL, GRACE_TENANT_ID
+from plex_api import (
+    PlexClient,
+    BASE_URL,
+    TEST_URL,
+    GRACE_TENANT_ID,
+    extract_supply_items,
+    TOOLING_CATEGORY,
+)
 
 
 # ─────────────────────────────────────────────
@@ -283,3 +290,80 @@ class TestGetLegacy:
         with patch("plex_api.requests.get", side_effect=requests.exceptions.ConnectionError("x")):
             result = c.get("mdm", "v1", "tenants")
         assert result is None
+
+
+# ─────────────────────────────────────────────
+# extract_supply_items — issue #2
+# ─────────────────────────────────────────────
+class TestExtractSupplyItems:
+    SAMPLE_TOOLS_AND_INSERTS = [
+        {"category": "Tools & Inserts", "supplyItemNumber": "990910", "description": "5/8 SQ END", "group": "Machining", "id": "u1", "inventoryUnit": "Each", "type": "SUPPLY"},
+        {"category": "Tools & Inserts", "supplyItemNumber": "ABC123", "description": "1/4 drill", "group": "Tool Room", "id": "u2", "inventoryUnit": "Each", "type": "SUPPLY"},
+    ]
+    SAMPLE_OFFICE = [
+        {"category": "Office Supplies", "supplyItemNumber": "PEN-01", "description": "Blue pen", "group": "Office", "id": "u3", "inventoryUnit": "Each", "type": "OFFICE"},
+    ]
+
+    def _full_set(self):
+        return self.SAMPLE_TOOLS_AND_INSERTS + self.SAMPLE_OFFICE
+
+    def test_default_filters_to_tools_and_inserts(self, fake_client, tmp_path, monkeypatch):
+        # Redirect OUTPUT_DIR so the CSV write goes to tmp
+        monkeypatch.setattr(plex_api, "OUTPUT_DIR", str(tmp_path))
+        fake_client.set_response("inventory-definitions/supply-items", self._full_set())
+        result = extract_supply_items(fake_client)
+        assert result is not None
+        assert len(result) == 2
+        for r in result:
+            assert r["category"] == TOOLING_CATEGORY
+
+    def test_filter_can_be_disabled_with_empty_string(self, fake_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(plex_api, "OUTPUT_DIR", str(tmp_path))
+        fake_client.set_response("inventory-definitions/supply-items", self._full_set())
+        result = extract_supply_items(fake_client, category="")
+        # All 3 records returned, no filter
+        assert len(result) == 3
+
+    def test_filter_can_be_overridden(self, fake_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(plex_api, "OUTPUT_DIR", str(tmp_path))
+        fake_client.set_response("inventory-definitions/supply-items", self._full_set())
+        result = extract_supply_items(fake_client, category="Office Supplies")
+        assert len(result) == 1
+        assert result[0]["category"] == "Office Supplies"
+
+    def test_returns_none_on_network_error(self, fake_client):
+        # No response set on the fake client → get returns None
+        result = extract_supply_items(fake_client)
+        assert result is None
+
+    def test_calls_correct_endpoint(self, fake_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(plex_api, "OUTPUT_DIR", str(tmp_path))
+        fake_client.set_response("inventory-definitions/supply-items", [])
+        extract_supply_items(fake_client)
+        # The fake client should have recorded a call to inventory/v1/inventory-definitions/supply-items
+        calls = [c for c in fake_client.calls if c[0] == "inventory" and c[1] == "v1"]
+        assert len(calls) == 1
+        assert calls[0][2] == "inventory-definitions/supply-items"
+
+    def test_normalizes_dict_data_wrapper(self, fake_client, tmp_path, monkeypatch):
+        # Some Plex endpoints wrap the list in a dict — extract_supply_items
+        # should handle either shape gracefully
+        monkeypatch.setattr(plex_api, "OUTPUT_DIR", str(tmp_path))
+        fake_client.set_response(
+            "inventory-definitions/supply-items",
+            {"data": self.SAMPLE_TOOLS_AND_INSERTS},
+        )
+        result = extract_supply_items(fake_client)
+        assert len(result) == 2
+
+    def test_writes_csv_snapshot(self, fake_client, tmp_path, monkeypatch):
+        monkeypatch.setattr(plex_api, "OUTPUT_DIR", str(tmp_path))
+        fake_client.set_response("inventory-definitions/supply-items", self._full_set())
+        extract_supply_items(fake_client)
+        csv_path = tmp_path / "plex_supply_items.csv"
+        assert csv_path.exists()
+        content = csv_path.read_text(encoding="utf-8")
+        # Should have the 2 tools-and-inserts records, not the office one
+        assert "990910" in content
+        assert "ABC123" in content
+        assert "PEN-01" not in content


### PR DESCRIPTION
## Closes #2

First real Phase 3 sync code: read the baseline tooling inventory from Plex via the verified `inventory/v1/inventory-definitions/supply-items` endpoint.

Plus two Fusion-side testing harness endpoints requested for manual exploration.

## Changes

### `plex_api.py`

- New `TOOLING_CATEGORY = "Tools & Inserts"` constant
- New `extract_supply_items(client, category=None)` — pulls supply items, normalizes the response shape (handles bare list and `{data: [...]}` wrapper), and filters client-side to `category="Tools & Inserts"` by default
- Saves a CSV snapshot to `outputs/plex_supply_items.csv`
- Server-side filters are silently ignored on this endpoint per the BRIEFING gotcha — we always pull the full ~614 KB and filter in Python

### `app.py`

- `/api/plex/supply_items` added to the existing `api_extract` switch
- **New `/api/fusion/tools/stats`** — type and vendor distribution across all loaded Fusion libraries. Returns library count, total record count, consumable vs non-consumable count, and per-library breakdowns. Useful for verifying load before any sync work.
- **New `/api/fusion/tools/consumables`** — returns the filtered list of Fusion tools that should actually go to Plex (excluding holders and probes per BRIEFING). Field names normalized to snake_case (`product-id` → `product_id`) for Python consumers.
- New `NON_CONSUMABLE_TYPES = {"holder", "probe"}` set captures the filter rule in one place

### `templates/index.html`

- **Plex presets refreshed** with verified URL patterns:
  - `production/v1/production-definitions/workcenters` (replaces dead `production/v1/control/workcenters`)
  - `inventory/v1/inventory-definitions/supply-items` (new — where tools live)
  - `inventory/v1/inventory-definitions/locations`
  - `mdm/v1/customers`, `mdm/v1/buildings`, `mdm/v1/operations`
- Removed dead `tooling/v1/*` presets
- New `extract_supply_items` button in Extractors
- New `tools_stats` and `consumables_only` buttons in Fusion 360 local

## Tests — 154 pass locally, 13 net new

| Class | Coverage |
|---|---|
| `TestExtractSupplyItems` | 7 tests — default filter, disabled filter, overridden filter, network error, correct endpoint, dict-wrapped response, CSV snapshot |
| `TestSupplyItemsExtractor` (Flask route) | 2 tests — delegates to extractor, handles None safely |
| `TestFusionToolsStats` | 2 tests — aggregates across libraries, handles empty input |
| `TestFusionToolsConsumables` | 2 tests — excludes holders/probes, normalizes field names |

Zero real network calls. All mocked through `FakePlexClient` and `patch.object`.

## Test plan

- [ ] CI green
- [ ] After merge, restart preview, click `extract_supply_items` → expect `count: 1109` (real Grace tools count)
- [ ] Click `tools_stats` → see global type distribution across the local libraries
- [ ] Click `consumables_only` → see only the records that will actually be synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)