### PR TITLE
fix: stdout UTF-8 reconfigure + ASCII arrows so prints don't crash Flask

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,19 @@
 from flask import Flask, render_template, jsonify, request
 import os
+import sys
 import json
 import time
 import traceback
 import requests
+
+# Force stdout to UTF-8 so prints with non-ASCII characters (em dashes,
+# arrows, summary glyphs) don't blow up Flask request handlers on a
+# Windows cp1252 console. Without this, any print() containing → or —
+# raises UnicodeEncodeError mid-request and turns into a 500.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except Exception:
+    pass
 
 # Import our existing scripts
 from plex_api import (

--- a/plex_api.py
+++ b/plex_api.py
@@ -259,7 +259,7 @@ def extract_purchase_orders(client, supplier=None, date_from=None):
     if results:
         out = os.path.join(OUTPUT_DIR, "plex_purchase_orders.csv")
         write_csv(results, out)
-        print(f"  Saved {len(results)} POs → {out}")
+        print(f"  Saved {len(results)} POs -> {out}")
     return results
 
 
@@ -278,7 +278,7 @@ def extract_parts(client, part_type=None):
     if results:
         out = os.path.join(OUTPUT_DIR, "plex_parts.csv")
         write_csv(results, out)
-        print(f"  Saved {len(results)} parts → {out}")
+        print(f"  Saved {len(results)} parts -> {out}")
     return results
 
 
@@ -293,7 +293,7 @@ def extract_workcenters(client):
     if results:
         out = os.path.join(OUTPUT_DIR, "plex_workcenters.csv")
         write_csv(results, out)
-        print(f"  Saved {len(results)} workcenters → {out}")
+        print(f"  Saved {len(results)} workcenters -> {out}")
     return results
 
 
@@ -308,7 +308,7 @@ def extract_operations(client):
     if results:
         out = os.path.join(OUTPUT_DIR, "plex_operations.csv")
         write_csv(results, out)
-        print(f"  Saved {len(results)} operations → {out}")
+        print(f"  Saved {len(results)} operations -> {out}")
     return results
 
 
@@ -378,7 +378,7 @@ def extract_supply_items(client, category=None):
     if records:
         out = os.path.join(OUTPUT_DIR, "plex_supply_items.csv")
         write_csv(records, out)
-        print(f"  Saved {len(records)} supply-items → {out}")
+        print(f"  Saved {len(records)} supply-items -> {out}")
 
     return records
 
@@ -465,7 +465,7 @@ def discover_all(client):
 
     out = os.path.join(OUTPUT_DIR, "plex_api_discovery.csv")
     write_csv(report, out)
-    print(f"\nDiscovery report saved → {out}")
+    print(f"\nDiscovery report saved -> {out}")
     return report
 
 
@@ -504,7 +504,7 @@ def explore_parts(client):
     os.makedirs(os.path.dirname(out), exist_ok=True)
     with open(out, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
-    print(f"\n  Full response saved → {out}")
+    print(f"\n  Full response saved -> {out}")
 
     return data
 

--- a/run_dev.py
+++ b/run_dev.py
@@ -31,6 +31,14 @@ import os
 import sys
 from pathlib import Path
 
+# Force stdout to UTF-8 before importing app — same reason as in app.py:
+# Windows cp1252 console can't encode em-dashes / arrows / etc., and a
+# print() failure mid-Flask-request turns into a 500.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEFAULT_ENV_FILE = PROJECT_ROOT / ".env.local"
 

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -466,3 +466,44 @@ class TestFusionToolsConsumables:
             body = rv.get_json()
             assert "product_id" in body["data"][0]  # NOT product-id
             assert body["data"][0]["product_id"] == "X-1"
+
+
+# ─────────────────────────────────────────────
+# Stdout encoding regression test
+# ─────────────────────────────────────────────
+class TestStdoutEncoding:
+    """
+    Pin down the fix for the cp1252 print() bug.
+
+    Without sys.stdout.reconfigure(encoding='utf-8') at startup, any
+    print() containing a non-ASCII character (like → or —) inside a
+    Flask request handler raises UnicodeEncodeError on a Windows
+    cp1252 console and turns into a 500 from the route's exception
+    handler. The fix lives at the top of app.py.
+
+    These tests verify both the reconfigure call and that
+    plex_api.py's extract_* functions no longer print Unicode
+    arrows in their summary lines.
+    """
+
+    def test_app_module_attempts_stdout_reconfigure(self):
+        # The reconfigure call is wrapped in try/except so it can't
+        # raise even on Python builds that don't expose the method,
+        # but the call itself should be present in the source.
+        import inspect
+        src = inspect.getsource(app_module)
+        assert "sys.stdout.reconfigure" in src
+        assert 'encoding="utf-8"' in src or "encoding='utf-8'" in src
+
+    def test_no_unicode_arrows_in_plex_api_print_statements(self):
+        import plex_api
+        import inspect
+        src = inspect.getsource(plex_api)
+        # The Unicode right-arrow → (U+2192) crashes Windows cp1252.
+        # Use ASCII -> instead. This is a belt-and-suspenders check
+        # in addition to the stdout reconfigure.
+        assert "\u2192" not in src, (
+            "plex_api.py contains a Unicode arrow (U+2192) which will "
+            "raise UnicodeEncodeError on Windows cp1252 stdout. Replace "
+            "with ASCII '->'."
+        )


### PR DESCRIPTION
## Bug caught at runtime

While verifying PR #21 live in the preview server, clicking `extract_supply_items` returned **HTTP 500** with:

\`\`\`
'charmap' codec can't encode character '\u2192' in position N
\`\`\`

The Unicode arrow `→` (U+2192) in `print()` statements isn't representable in Windows cp1252. When Flask captures stdout from a request handler, the encode failure raises `UnicodeEncodeError` mid-request, which the route's exception handler turns into a 500.

**pytest never caught this** because pytest's `capsys` uses UTF-8 by default. Only the live Flask process under cp1252 stdout hits it.

## Fix

Two layers of defence:

1. **`app.py` and `run_dev.py`**: `sys.stdout.reconfigure(encoding="utf-8")` at the very top, wrapped in try/except for safety. Same approach we already use in `plex_diagnostics.py`'s `__main__`.
2. **`plex_api.py`**: replace all 7 occurrences of `→` with ASCII `->` in print statements (`extract_purchase_orders`, `extract_parts`, `extract_workcenters`, `extract_operations`, `extract_supply_items`, `discover_all`, `explore_parts`).

## Tests — 156 pass, 2 net new

| Test | What it locks down |
|---|---|
| `test_app_module_attempts_stdout_reconfigure` | Asserts the `sys.stdout.reconfigure` call is present in `app.py` source |
| `test_no_unicode_arrows_in_plex_api_print_statements` | Scans `plex_api.py` for U+2192 and fails the build if any reappear |

These are source-inspection tests rather than runtime tests because the actual bug manifests only on Windows under Flask, which we can't easily reproduce in CI on ubuntu-latest.

## Test plan

- [ ] CI green
- [ ] After merge: restart preview server, click `extract_supply_items`, expect a real 200 with the actual record count from Plex Grace (~1,109 cutting tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)