### PR TITLE
docs: end-of-session wrap-up — README rewrite + CLAUDE memory file

### DIFF
--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -275,16 +275,17 @@ https://github.com/grace-shane/plex-api/issues for live status.
 2. ~~Find the real Plex tooling endpoint~~ DONE — it's
    `inventory/v1/inventory-definitions/supply-items` with
    `category="Tools & Inserts"`. 1,109 records already exist.
-3. Read baseline tooling inventory from supply-items — issue #2.
-   Filter client-side by `category="Tools & Inserts"` since query
-   filters are mostly ignored. Save snapshot to `outputs/`.
+3. ~~Read baseline tooling inventory from supply-items~~ DONE (PR #21,
+   issue #2 closed). `extract_supply_items(client)` in plex_api.py
+   returns the filtered list and writes a CSV snapshot. Verified
+   live: 1,109 records, 30 KB response, 1.4s round trip.
 4. `build_supply_item_payload(fusion_tool: dict) -> dict` — issue #3.
    Maps Fusion tool to a supply-item POST body with
    `category="Tools & Inserts"`, `group="Machining"`,
    `supplyItemNumber=<vendor part-id>`, `description=<fusion description>`.
 5. Match-and-upsert logic by `supplyItemNumber` — issue #3.
-   Read existing supply-items, match by vendor part number, decide
-   POST (new) vs PUT (update existing).
+   Read existing supply-items via extract_supply_items(), match by
+   vendor part number, decide POST (new) vs PUT (update existing).
 6. Workcenter doc push — issue #6. Use the verified path
    `production/v1/production-definitions/workcenters/{id}` and the
    workcenterCode → Brother Speedio mapping (codes 879, 880).
@@ -292,6 +293,15 @@ https://github.com/grace-shane/plex-api/issues for live status.
 7. Core sync logic — upsert with `supplyItemNumber` dedup — issue #7.
    Dry-run by default. Real writes require `PLEX_ALLOW_WRITES=1`.
 8. Error handling + logging to network share text file — issue #8.
+
+### Architectural decisions still pending (issues #4 and #5)
+
+- **#4 — Tool Assemblies**: Plex's supply-item schema is identity-only
+  (no holder linkage). Four options listed in the issue body —
+  descope / encode in description / CSV upload / ask Plex for a
+  different product. Needs the user's call before any code work.
+- **#5 — Routing/Operation linkage**: `mdm/v1/operations` exists but
+  has no FK to tools. Same kind of decision needed as #4.
 
 ---
 
@@ -427,3 +437,75 @@ point in the project's life.
 key value (first 8 chars + length + first-source — env var or .env.local)
 is being used. We should also probably make `bootstrap.py` log when
 `.env.local` is being shadowed by an existing env var.
+
+---
+
+## Session log
+
+Reverse chronological. Each entry: what was the goal, what landed, what's left.
+
+### 2026-04-07 — full project bootstrap + Phase 3 read side
+
+**Started with:**
+- Hardcoded API key in `plex_api.py` (still in git history)
+- Old "gradient/glass dashboard" UI
+- TODO.md as the only project tracker
+- No tests, no CI, no .env.local concept
+- BRIEFING claiming tenant routing was the IT blocker
+
+**Ended with:**
+- 11 PRs merged, all via auto-merge after CI passes
+- 156 pytest tests, all green, branch protection enforces them on master
+- `.env.local` loader (`bootstrap.py`) + dev override (`run_dev.py`)
+- Production write guard (`/api/plex/raw` refuses POST/PUT/PATCH/DELETE
+  unless `PLEX_ALLOW_WRITES=1`)
+- Verified working credentials (`Fusion2Plex` Consumer Key) on
+  production with the real Grace tenant `58f781ba-...`
+- **Issue #2 closed** — `extract_supply_items()` returns 1,109
+  cutting tools and inserts from
+  `inventory/v1/inventory-definitions/supply-items` in 1.4s
+- Brother Speedio mapping verified — workcenters 879/880 = FTP IPs
+  192.168.25.79/.80
+- BRIEFING + Plex_API_Reference + TODO all rewritten to match
+  empirical reality (with the "History of incorrect hypotheses"
+  postmortem above documenting four wrong turns)
+
+**Pull requests merged this session** (newest first):
+- #22 fix: stdout UTF-8 reconfigure + ASCII arrows
+- #21 feat: extract_supply_items + Fusion testing-harness endpoints (closes #2)
+- #20 docs: Plex tooling lives in inventory/v1/inventory-definitions/supply-items
+- #19 feat: run_dev.py local launcher
+- #18 feat: migrate to PROD Plex environment + verified Grace tenant
+- #17 feat: production write guard at the proxy
+- #16 docs: correct subscription-not-tenant hypothesis (later corrected by #20)
+- #15 fix: surface HTTP errors instead of swallowing them as None
+- #14 feat: .env.local loader + Claude Preview launch config
+- #13 Endpoint tester UI, tenant diagnostics, env-var credentials, GH issue tracking
+
+**What's left to do tomorrow** (in order):
+1. **Issue #3** — `build_supply_item_payload(fusion_tool)` writing to
+   `inventory/v1/inventory-definitions/supply-items`. We have the verified
+   read path and 1,109 records to learn the schema from.
+2. **Architectural decision on issues #4 and #5** — descope or pivot.
+   Both are blocked on a real product question, not a code question.
+3. **Issue #6** — probe write support on workcenters (carefully, with
+   `PLEX_ALLOW_WRITES=1` enabled deliberately).
+4. **Issue #12** — key rotation deadline 2026-05-08.
+
+**Lessons** (additions to "History of incorrect hypotheses" if any
+session goes sideways the same way again):
+1. Never read credentials from images. Always have the user paste
+   them as text or via Insomnia "Generate Code" output.
+2. Status codes from Plex are misleading on their own. 401 means
+   "bad creds OR unsubscribed product"; 404 means "wrong URL OR
+   unsubscribed namespace". Compare across endpoints to disambiguate.
+3. Plex's URL convention is `<namespace>/v1/<namespace>-definitions/<resource>`
+   for definition data — not the bare `<namespace>/v1/<resource>` we
+   kept guessing. Tools live at `inventory/v1/inventory-definitions/supply-items`,
+   not `tooling/v1/tools` or `mdm/v1/parts`.
+4. Server-side filters on Plex endpoints are mostly silently ignored.
+   `?limit=1` on `mdm/v1/parts` returns 19.6 MB. Filter client-side.
+5. pytest's `capsys` uses UTF-8, so stdout encoding bugs only show
+   up under live Flask. Add `sys.stdout.reconfigure(encoding="utf-8")`
+   at the top of any process whose stdout might end up captured by
+   Flask request handlers on Windows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Claude memory file
+
+This is the entry point for Claude Code (or any AI agent) working on this
+repository. **Read these files in this order before doing anything**:
+
+1. **[`BRIEFING.md`](./BRIEFING.md)** — primary context document. Project
+   purpose, current credentials, current Plex environment, verified
+   endpoint matrix, gotchas, immediate TODO, "History of incorrect
+   hypotheses" postmortem, and a session log of what's been done. **This
+   is the most important file in the repo for AI context.**
+
+2. **[`Plex_API_Reference.md`](./Plex_API_Reference.md)** — verified URL
+   patterns, the 401-vs-404 reading guide, and the no-pagination gotcha.
+   Read this before writing any new Plex API call.
+
+3. **[`Fusion360_Tool_Library_Reference.md`](./Fusion360_Tool_Library_Reference.md)**
+   — Fusion JSON schema and field-to-Plex mapping. Read this before
+   writing anything that consumes the local Fusion library files.
+
+4. **[`TODO.md`](./TODO.md)** — project roadmap, links to GitHub Issues
+   for live status.
+
+## Hard rules
+
+- **Never read credentials from images.** Always have the user paste them
+  as text or via Insomnia "Generate Code" output. We learned this the
+  hard way (see BRIEFING.md "History of incorrect hypotheses §1").
+- **Never hardcode credentials.** They live in `.env.local` (gitignored),
+  loaded by `bootstrap.py`. Production deploy uses real shell env vars.
+- **Never bypass the production write guard.** Mutating HTTP methods on
+  `connect.plex.com` are refused at `/api/plex/raw` unless
+  `PLEX_ALLOW_WRITES=1` is explicitly set in the environment.
+- **Always run `pytest` before committing.** Branch protection on master
+  requires the `pytest` GitHub Actions check to pass before any merge.
+- **Use the `claude/<short-name>` branch naming convention** for new
+  branches off master, then auto-merge with `gh pr merge --auto --squash`.
+
+## Quick commands
+
+```powershell
+# Run the local endpoint tester (overrides shell env from .env.local)
+py run_dev.py
+
+# Run tests
+py -m pytest
+
+# Open a PR with auto-merge
+gh pr create --base master --head claude/my-branch --title "..." --body "..."
+gh pr merge <number> --auto --squash
+```
+
+## Things this repo does NOT have
+
+- A test environment for the Fusion2Plex Plex app — production is the
+  only environment we have credentials for. Be cautious.
+- A scheduled deploy yet (Phase 5 work, issues #9-#11)
+- A CI badge or release versioning yet
+- Any tooling-API endpoints — Plex's tool data lives under
+  `inventory/v1/inventory-definitions/supply-items`, NOT
+  `tooling/v1/*` or `mdm/v1/parts`. See BRIEFING.md.
+
+## When in doubt
+
+- The repo is small and the context fits in one read of BRIEFING.md +
+  Plex_API_Reference.md. Read them; don't guess.
+- Claude Code has a built-in `tenant_whoami` diagnostic at
+  `/api/diagnostics/tenant` — run that first whenever the connection
+  state is unclear.
+- Open a PR. CI is fast (~10s) and branch protection guarantees you
+  can't break master.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,119 @@
-# Plex API Integration: Fusion 360 Tool Sync
+# plex-api — Fusion 360 → Plex tooling sync for Grace Engineering
 
-`plex-api` is a project designed to automate the synchronization of tooling data between Autodesk Fusion 360 and the Plex Manufacturing Cloud (Rockwell Automation) for **Grace Engineering**.
+Nightly automation that syncs Autodesk Fusion 360 tool library data into Rockwell Automation Plex
+Manufacturing Cloud (ERP). Fusion 360 JSON files on a local network share are the absolute source
+of truth; the script reads them and pushes tooling data to Plex via REST API every night at midnight.
 
-## 🎯 Architecture & Primary Goal
+## Status
 
-The overarching goal of this project is to maintain an up-to-date tooling inventory without manual data entry. **Crucially, the Autodesk Fusion 360 tool library files act as the single source of truth for all tooling data entering Plex.**
+| | |
+|---|---|
+| **Plex environment** | `connect.plex.com` (production) — there is no test environment for this app |
+| **Plex app** | `Fusion2Plex` Consumer Key, expires every 31 days |
+| **Plex tenant** | `58f781ba-1691-4f32-b1db-381cdb21300c` (Grace Engineering) |
+| **Tooling endpoint** | `inventory/v1/inventory-definitions/supply-items` filtered to `category="Tools & Inserts"` (1,109 records currently) |
+| **Workcenters** | `production/v1/production-definitions/workcenters` (143 records, including 21 mills mapping directly to Brother Speedio FTP IPs) |
+| **Phase** | Phase 3 — read baseline complete (#2 closed). Write-side drafting next (#3) |
+| **Tests** | 156 pytest tests, all green. CI on PRs to master via GitHub Actions. Branch protection requires the check to pass. |
 
-**The 30,000-Foot View & Industry Standard Data Flow:**
+## Architecture
 
-1. **Source Data (Source of Truth)**: Autodesk Fusion 360 maintains a tool library stored as `.json` files on a local network share.
-2. **Component Hierarchy (Consumables First)**: In standard tooling management, Tool Assemblies are made up of purchased components. The script's initial focus is on the **consumable cutting tools** (e.g., end mills, drills) purchased from suppliers (tracked as purchased parts via POs).
-3. **Plex Linkage & Traceability**: These consumable purchased parts are linked to Tool Assemblies. Tool Assemblies are then linked to specific Routings/Operations. When an operation runs on the shop floor, it generates a Job, which ultimately produces the manufactured Part.
-4. **Scheduled Sync**: A script runs automatically every day at midnight.
-5. **Plex Updates**: The script reads the Fusion 360 JSON files and pushes the data to Plex via its REST API, performing key actions:
-   - Updates the tooling inventory in the master list, focusing on connecting purchased consumables to assemblies.
-   - Updates the tooling in the respective workcenter document (`production/v1/control/workcenters`).
-6. **Data Management**: For simplicity, state management and data files are maintained on the network shares using file overwriting.
+```
+Fusion 360 .json (network share, via Autodesk Desktop Connector)
+  └── tool_library_loader.py    reads + validates JSON, stale-file guard
+  └── transform layer           build_supply_item_payload (in progress, issue #3)
+  └── plex_api.py / PlexClient  pushes to Plex REST API
+        ├── inventory/v1/inventory-definitions/supply-items   (cutting tools)
+        └── production/v1/production-definitions/workcenters  (machine setup docs)
+```
 
-## 📚 Resources
+The original plan to write to `mdm/v1/parts` and `tooling/v1/tool-assemblies` was incorrect — see
+[BRIEFING.md "History of incorrect hypotheses"](./BRIEFING.md) for the postmortem.
 
-The Plex API is a modern, RESTful service utilizing JSON for data exchange. This integration will map local JSON structures to the cloud API. Note: Due to explicit IAM role permissions, certain Tooling endpoints are hidden from the developer portal until subscribed.
+## Quick start (local development)
 
-- **Official Documentation**: [Plex Manufacturing Cloud API](https://www.rockwellautomation.com/en-us/support/plex-manufacturing-cloud/api.html)
-- **Project Roadmap**: See [TODO.md](./TODO.md) for step-by-step implementation tasks.
-- **Reference**: See [Plex API Reference](./Plex_API_Reference.md) for endpoints, auth routing, and DNC details.
-- **Data Mapping**: See [Fusion360 Reference](./Fusion360_Tool_Library_Reference.md) for data extraction rules.
+1. **Clone and create your `.env.local`**
 
-## 🚀 Postman Testing
+   ```powershell
+   git clone https://github.com/grace-shane/plex-api.git
+   cd plex-api
+   copy .env.example .env.local
+   # Edit .env.local with your Fusion2Plex Consumer Key + Secret
+   ```
 
-We use **[Postman](https://www.postman.com/)** for upfront API discovery and management demonstrations.
+   `.env.local` is gitignored. Get the Consumer Key from
+   [developers.plex.com](https://developers.plex.com/) → My Apps → Fusion2Plex.
 
-By saving queries to a Postman Collection, we can manually verify the exact structure needed to push inventory updates and workcenter document updates to Plex before writing the final automation script.
+2. **Install dependencies**
+
+   ```powershell
+   py -m pip install -r requirements-dev.txt
+   ```
+
+3. **Run the local endpoint tester**
+
+   ```powershell
+   py run_dev.py
+   ```
+
+   Opens on http://localhost:5000. The left rail has buttons for:
+   - **Diagnostics** — `tenant_whoami` (run this first to verify connection)
+   - **Plex presets** — verified Plex API URLs as one-click hits
+   - **Extractors** — `extract_supply_items` (1,109 cutting tools), `extract_parts`, `extract_purchase_orders`, etc.
+   - **Fusion 360 local** — `tools_stats` and `consumables_only` for verifying the local Fusion library load
+
+   `run_dev.py` overrides shell environment variables with `.env.local` (the opposite of
+   `bootstrap.py`'s production-safe `setdefault` semantics), so a stale system env var won't
+   silently shadow your real key.
+
+4. **Run tests**
+
+   ```powershell
+   py -m pytest
+   ```
+
+## Production safety
+
+This codebase reads from real Grace Engineering production data on every API call. Two guard rails
+protect against accidental writes:
+
+- **`PlexClient.get_envelope()`** returns structured success/error envelopes so HTTP failures
+  are visible (PR #15 fixed an earlier "swallow on error" bug).
+- **`/api/plex/raw` proxy refuses POST/PUT/PATCH/DELETE** when running against
+  `connect.plex.com` unless `PLEX_ALLOW_WRITES=1` is set in the environment (PR #17). Read-only
+  is always allowed. To enable writes:
+
+   ```powershell
+   $env:PLEX_ALLOW_WRITES = "1"
+   py run_dev.py
+   ```
+
+  The UI shows a red `WRITES ON` chip when the guard is disabled. Rotate the env var off as soon
+  as you're done.
+
+## Key references
+
+- [`BRIEFING.md`](./BRIEFING.md) — primary context document for AI-assisted dev sessions and the
+  source of truth for current status, current credentials, gotchas, and project history
+- [`Plex_API_Reference.md`](./Plex_API_Reference.md) — verified endpoint access matrix and URL
+  pattern conventions
+- [`Fusion360_Tool_Library_Reference.md`](./Fusion360_Tool_Library_Reference.md) — Fusion JSON
+  schema and field-to-Plex mapping
+- [`TODO.md`](./TODO.md) — project roadmap mirrored to GitHub Issues
+- [GitHub Issues](https://github.com/grace-shane/plex-api/issues) — live status of every Phase 3-5
+  work item with dependencies and blockers
+- [Plex Manufacturing Cloud API docs](https://www.rockwellautomation.com/en-us/support/plex-manufacturing-cloud/api.html)
+
+## Contributing workflow
+
+1. Branch from `master`
+2. Push to a `claude/<short-name>` branch (or any branch — naming is convention, not enforced)
+3. Open a PR to `master`
+4. CI runs `pytest` automatically
+5. Branch protection blocks merge until the check is green
+6. Use `gh pr merge --auto --squash` to enable auto-merge — it lands the PR the moment CI passes
+
+## License
+
+Internal Grace Engineering project. Forked from
+[`just-shane/plex-api`](https://github.com/just-shane/plex-api).


### PR DESCRIPTION
## Final cleanup so the repo state matches reality and the next agent session has a clean entry point

### `README.md` — full rewrite

Replaces the original generic project description with the current verified state:

- **Status table**: Plex environment, app, tenant, tooling endpoint, current phase, test count
- **Architecture diagram** updated to show the verified URLs (`inventory/v1/inventory-definitions/supply-items`, `production/v1/production-definitions/workcenters`)
- **Quick-start** instructions: clone → `.env.local` → `py run_dev.py`
- **Production safety** section explaining the write guard and how to enable writes
- **Key references** linking to BRIEFING.md, Plex_API_Reference.md, TODO.md, and GitHub Issues
- **Contributing workflow** describing the `claude/<name>` branch convention and the auto-merge flow

### `BRIEFING.md`

- Immediate TODO #3 marked DONE — PR #21 closed issue #2; lists the verified extract_supply_items result (1,109 records, 30 KB, 1.4s)
- New "Architectural decisions still pending" callout for issues #4 and #5
- **New "Session log" section** at the bottom — first entry covers today's full session: 11 PRs merged, what changed, what's left for tomorrow, and 5 lessons distilled

### `CLAUDE.md` (NEW)

A thin entry-point file telling any AI agent (or new human dev) what to read first and in what order. Hard rules, quick command reference, "when in doubt" section. The point is that a fresh Claude session should read CLAUDE.md → BRIEFING.md and immediately have full context.

## No code changes

156 pytest tests still pass.

## Test plan

- [ ] CI green
- [ ] Visual: hit https://github.com/grace-shane/plex-api on the web and confirm the new README renders well
- [ ] After merge: I'll update the GitHub repo's "About" description via the API as a separate non-PR action

🤖 Generated with [Claude Code](https://claude.com/claude-code)