### PR TITLE
docs: fix stale content drift in BRIEFING, Plex_API_Reference, TODO, spec

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 
 ## Phase 3: Plex API Source-of-Truth Implementation
 
-- [ ] Implement API call to retrieve current tooling inventory — `inventory/v1/inventory-definitions/supply-items` returns 2,516 records, of which 1,109 are `category="Tools & Inserts"`. Filter client-side. → [#2](https://github.com/grace-shane/plex-api/issues/2)
+- [x] **DONE (PR #21).** Implement API call to retrieve current tooling inventory — `extract_supply_items(client)` in `plex_api.py` hits `inventory/v1/inventory-definitions/supply-items` (2,516 records), filters to `category="Tools & Inserts"` (1,109 records), and writes a CSV snapshot to `outputs/`. Verified live: 30 KB response, 1.4s round trip. → [#2](https://github.com/grace-shane/plex-api/issues/2) *(closed)*
 - [ ] Implement API call to upsert supply-items — `build_supply_item_payload(fusion_tool)` writes to `inventory/v1/inventory-definitions/supply-items` with `supplyItemNumber=<vendor part-id>`. Drafting can begin against the verified read path. → [#3](https://github.com/grace-shane/plex-api/issues/3)
 - [ ] Implement Tool Assembly handling — Plex's supply-item schema is identity-only (no holder linkage). Tool assemblies as a separate concept may not exist in this app's API surface. **Investigate or descope.** → [#4](https://github.com/grace-shane/plex-api/issues/4)
 - [ ] Implement API call to link tools to Routings/Operations — `mdm/v1/operations` exposes only `code, id, inventoryType, type` with no FK to tools. **Linkage may not be possible via API**; may require CSV upload or different approach. → [#5](https://github.com/grace-shane/plex-api/issues/5)

--- a/docs/BRIEFING.md
+++ b/docs/BRIEFING.md
@@ -79,12 +79,12 @@ Tenant IDs are not secrets — they are committed as defaults in
 ```
 Fusion 360 .json (network share, via Autodesk Desktop Connector)
   └── tool_library_loader.py    reads + validates JSON, stale-file guard
-  └── transform layer           build_part_payload, build_assembly_payload
+  └── validate_library.py       pre-sync validation gate (spec only, #25)
+  └── transform layer           build_supply_item_payload (in progress, #3)
   └── plex_api.py / PlexClient  pushes to Plex REST API
-        ├── mdm/v1/parts                consumable tools
-        ├── mdm/v1/suppliers            resolve vendor UUIDs
-        ├── tooling/v1/tool-assemblies  see History §3 below
-        └── production/v1/control/workcenters  see History §3 below
+        ├── inventory/v1/inventory-definitions/supply-items   cutting tools (category="Tools & Inserts")
+        ├── mdm/v1/suppliers                                  resolve vendor UUIDs
+        └── production/v1/production-definitions/workcenters  machine setup docs (per-id write shape TBD, #6)
 ```
 
 ### Industry hierarchy (Plex data model)
@@ -262,7 +262,7 @@ Sync filter: include only `type != "holder" AND type != "probe"`
 - `pytest` suite in `tests/`. CI on PRs to `master` via
   `.github/workflows/test.yml`. Branch protection on master requires the
   `pytest` check to pass before merge. Auto-merge enabled.
-- Currently 119+ tests, all green.
+- Currently 156 tests, all green.
 
 ---
 

--- a/docs/Plex_API_Reference.md
+++ b/docs/Plex_API_Reference.md
@@ -2,7 +2,7 @@
 
 ## 1. Overview
 
-This reference document synthesizes the discoveries from preliminary API testing and aligns them with the **Fusion 360 Tool Library Synchronization** architectural goals. It serves as the master guide for developers interacting with the Grace Engineering Plex instance (`plexonline.com`).
+This reference document synthesizes the discoveries from preliminary API testing and aligns them with the **Fusion 360 Tool Library Synchronization** architectural goals. It serves as the master guide for developers interacting with the Grace Engineering Plex instance via the `connect.plex.com` REST API gateway.
 
 *Note: Grace Engineering runs Plex Classic, MES+ enabled, supporting Prime Archery and Montana Rifle Company.*
 
@@ -132,18 +132,19 @@ does nothing and use real filters or accept the full DB pull.**
 
 ## 4. Current Tooling Data Flow (Fusion 360 to Plex)
 
-While waiting for the Tooling APIs to be activated, data can be managed in two ways:
+Data flows from Fusion 360 to Plex via the REST API. The `tooling/v1/*` path namespace referenced in earlier drafts of this document does NOT exist on the Fusion2Plex app — see Section 3 and [`BRIEFING.md` History §3](./BRIEFING.md) for the postmortem.
 
 1. **REST API Automation (Target State)**
-   - A scheduled script parses the network share `BROTHER SPEEDIO ALUMINUM.json` library.
-   - Extracts `product-id`, `vendor`, and geometry.
-   - Pushes payloads to `tooling/v1/tool-assemblies` to update the master inventory list.
-   - Pushes payload to `production/v1/control/workcenters` utilizing the `post-process.number` to ensure correct turret/pocket placement.
+   - A scheduled script parses the network share Fusion 360 tool library JSON files.
+   - Extracts `product-id`, `vendor`, `description`, and `geometry`.
+   - Pre-sync validation gate runs via `validate_library.py` (spec only, see [`validate_library_spec.md`](./validate_library_spec.md), implementation issue #25).
+   - Pushes payloads to `inventory/v1/inventory-definitions/supply-items` with `category="Tools & Inserts"`, `group="Machining"`, and `supplyItemNumber=<vendor part-id>` as the dedup key. Read path verified (1,109 records); write logic in progress (issue #3).
+   - Pushes payloads to `production/v1/production-definitions/workcenters/{id}` utilizing `post-process.number` for turret/pocket placement. Read path verified; write shape TBD (issue #6).
 
-2. **CSV Upload System (Interim State)**
-   - Without API access, engineering relies on bulk CSV uploads.
+2. **CSV Upload System (Historical Fallback)**
+   - Prior to API access being verified, engineering used bulk CSV uploads.
    - Sequence: **Tool Assembly Upload** ➔ **Tool Inventory Upload** ➔ **Tool BOM Upload** ➔ **Routing Upload**.
-   - Ensure the *Tool Assembly Type* picklist exists in Plex before attempting uploads.
+   - The supply-items REST path above is the target state and supersedes this workflow once issues #3, #6, and #7 land.
 
 ---
 

--- a/docs/validate_library_spec.md
+++ b/docs/validate_library_spec.md
@@ -2,7 +2,7 @@
 
 **Project:** Fusion 360 → Plex tooling sync — Grace Engineering
 **Repo:** https://github.com/grace-shane/plex-api
-**Status:** Spec only — implementation tracked as GitHub issue #XX
+**Status:** Spec only — implementation tracked as GitHub issue [#25](https://github.com/grace-shane/plex-api/issues/25)
 
 ---
 


### PR DESCRIPTION
## Summary

Cleanup pass on the drift items flagged in the last doc review. All content-only; no code changes. 156/156 pytest still green locally.

## Changes

| File | Line(s) | Before | After |
|---|---|---|---|
| `docs/BRIEFING.md` | 84–87 | Architecture diagram showed `mdm/v1/parts`, `tooling/v1/tool-assemblies`, `production/v1/control/workcenters` — all discredited by History §3 | Now shows the verified paths (`inventory/v1/inventory-definitions/supply-items`, `production/v1/production-definitions/workcenters`) and adds the validate_library gate referencing #25 |
| `docs/BRIEFING.md` | 265 | "Currently 119+ tests, all green" | "Currently 156 tests, all green" (matches README and reality) |
| `docs/Plex_API_Reference.md` | 5 | `plexonline.com` (classic UI, wrong) | `connect.plex.com` REST API gateway |
| `docs/Plex_API_Reference.md` | 133–146 | Section 4 "Target State" still referenced `tooling/v1/tool-assemblies` and `production/v1/control/workcenters` | Rewritten to reference the verified supply-items + workcenters definition paths, link to issues #3 and #6, add the validation gate step |
| `docs/validate_library_spec.md` | 5 | `implementation tracked as GitHub issue #XX` | `implementation tracked as GitHub issue #25` |
| `TODO.md` | 23 | Phase 3 item #1 checkbox still `[ ]` | Flipped to `[x]` with "DONE (PR #21)" note |

## What's still deferred

- BRIEFING.md line 209 (`TODO (issue #XX): confirm real shop floor bounds`) and lines 442–444 ("GitHub Issues to Open" table) inside the validate_library spec — those reference FUTURE follow-up issues that don't exist yet. Leaving as placeholders until the implementation work on #25 starts.
- BRIEFING.md session log and other historical sections — intentionally frozen-in-time; don't touch.

## Test plan

- [x] `py -m pytest` locally — 156 passed
- [ ] CI `pytest` check passes on PR
- [ ] Branch protection allows auto-merge once check is green