### PR TITLE
feat(supabase): fusion2plex_* staging layer + Fusion JSON ingest (closes #31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,11 @@ PLEX_API_SECRET=your-consumer-secret-here
 # manufacturing data. Set to 1 only when you intentionally want to write,
 # and unset it as soon as you're done.
 # PLEX_ALLOW_WRITES=1
+
+# ── SUPABASE — fusion2plex_* ingest layer (issue #31) ──────────────
+# bulletforge project, us-east-2. Service role key bypasses RLS and is
+# used by sync_supabase.py to populate the fusion2plex_libraries,
+# fusion2plex_tools, and fusion2plex_cutting_presets tables.
+# NEVER ship the service role key to a browser.
+SUPABASE_URL=https://uhmpkprcxrajbtkvqmwg.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-jwt-here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,15 @@ repository. **Read these files in this order before doing anything**:
    that block + appending one line to the Decision Log. See the
    "Notion pages" section in `docs/BRIEFING.md` for details.
 
+6. **Supabase staging layer** — Fusion JSON is ingested into the
+   `fusion2plex_*` tables in the `bulletforge` Supabase project
+   (`uhmpkprcxrajbtkvqmwg`, us-east-2) before anything pushes to Plex.
+   Schema spec: [Notion · Supabase Schema Design](https://www.notion.so/33c3160a3abf814c885cc174cda76d17).
+   Code: `supabase_client.py`, `sync_supabase.py`, `scripts/load_sample.py`.
+   Credentials: `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` in `.env.local`.
+   Issue #31. Downstream (`build_supply_item_payload`, #3) reads from
+   `fusion2plex_tools`, not raw JSON.
+
 ## Hard rules
 
 - **Never read credentials from images.** Always have the user paste them
@@ -40,6 +49,8 @@ repository. **Read these files in this order before doing anything**:
   requires the `pytest` GitHub Actions check to pass before any merge.
 - **Use the `claude/<short-name>` branch naming convention** for new
   branches off master, then auto-merge with `gh pr merge --auto --squash`.
+- **Never ship the Supabase service role key to a browser.** It bypasses
+  RLS. Server-side ingest scripts only.
 
 ## Quick commands
 

--- a/scripts/load_sample.py
+++ b/scripts/load_sample.py
@@ -1,0 +1,95 @@
+"""
+scripts/load_sample.py
+Smoke test — ingest BROTHER SPEEDIO ALUMINUM.json into Supabase
+================================================================
+Loads the committed sample Fusion library file into the
+``fusion2plex_*`` tables and prints a row-count report.
+
+Run from the repo root::
+
+    py scripts/load_sample.py
+
+Expected output with a fresh database (28 total entries in the sample,
+minus 6 holders + 1 probe = 21 tools, ~25 presets)::
+
+    Library upserted: BROTHER SPEEDIO ALUMINUM → id=...
+    Tools upserted:   21
+    Presets inserted: 25
+
+Re-running the script should be idempotent — tool counts stay the
+same, presets are flushed and re-inserted. Requires SUPABASE_URL
+and SUPABASE_SERVICE_ROLE_KEY in .env.local (or the shell env).
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+# Make the repo root importable when running ``py scripts/load_sample.py``.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from supabase_client import SupabaseClient, SupabaseConfigError  # noqa: E402
+from sync_supabase import hash_file, sync_library  # noqa: E402
+
+
+SAMPLE_FILE = ROOT / "BROTHER SPEEDIO ALUMINUM.json"
+LIBRARY_NAME = "BROTHER SPEEDIO ALUMINUM"
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if not SAMPLE_FILE.exists():
+        print(f"ERROR: sample file not found at {SAMPLE_FILE}", file=sys.stderr)
+        return 2
+
+    # Load tools from disk without going through the stale-file guard —
+    # the committed sample is always older than 25h, but we still want to
+    # exercise the ingest pipeline against it.
+    import json
+
+    with open(SAMPLE_FILE, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    tools = raw.get("data", [])
+    print(f"Loaded {len(tools)} entries from {SAMPLE_FILE.name}")
+
+    try:
+        client = SupabaseClient()
+    except SupabaseConfigError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        print(
+            "\nAdd these to .env.local:\n"
+            "  SUPABASE_URL=https://uhmpkprcxrajbtkvqmwg.supabase.co\n"
+            "  SUPABASE_SERVICE_ROLE_KEY=<service role JWT>\n",
+            file=sys.stderr,
+        )
+        return 3
+
+    file_hash = hash_file(SAMPLE_FILE)
+    print(f"File hash (sha256): {file_hash[:16]}...")
+
+    result = sync_library(
+        LIBRARY_NAME,
+        tools,
+        client=client,
+        file_path=str(SAMPLE_FILE),
+        file_hash=file_hash,
+    )
+
+    print()
+    print("=" * 56)
+    print(f"  Tools upserted:    {result['tools']:4d}")
+    print(f"  Presets inserted:  {result['presets']:4d}")
+    print("=" * 56)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -1,0 +1,241 @@
+"""
+supabase_client.py
+Thin Supabase REST client for the fusion2plex_* ingest layer
+Grace Engineering — plex-api project
+=============================================================
+Minimal PostgREST wrapper that talks to Supabase over plain HTTP.
+Deliberately avoids the `supabase-py` SDK because its transitive
+dependency tree (pyiceberg etc.) requires MSVC on Windows + Python
+3.14 and is overkill for the three tables we touch.
+
+Why a hand-rolled client
+------------------------
+- Same HTTP pattern as ``plex_api.py`` — one library to understand
+- No compiled deps, installs cleanly on any platform
+- Easy to stub in tests (patch ``requests.Session``)
+- We only need five verbs: select, insert, upsert, delete, rpc-free
+
+Credentials come from environment variables loaded via ``bootstrap.py``:
+
+  SUPABASE_URL                e.g. ``https://uhmpkprcxrajbtkvqmwg.supabase.co``
+  SUPABASE_SERVICE_ROLE_KEY   service role JWT (bypasses RLS — server-side only)
+
+**Never ship the service role key to a browser.** It is intended for
+back-end ingest scripts and should never leave the server.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Iterable, Mapping
+
+import requests
+
+import bootstrap  # noqa: F401 — loads .env.local into os.environ on import
+
+DEFAULT_TIMEOUT = 30  # seconds
+
+
+class SupabaseConfigError(RuntimeError):
+    """Raised when SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is missing."""
+
+
+class SupabaseHTTPError(RuntimeError):
+    """Raised when PostgREST returns a non-2xx response."""
+
+    def __init__(self, status: int, body: Any, url: str):
+        self.status = status
+        self.body = body
+        self.url = url
+        super().__init__(f"Supabase {status} on {url}: {body}")
+
+
+class SupabaseClient:
+    """
+    Minimal PostgREST client.
+
+    Parameters
+    ----------
+    url : str | None
+        Supabase project URL, e.g. ``https://<ref>.supabase.co``. Defaults
+        to the ``SUPABASE_URL`` env var.
+    service_role_key : str | None
+        Service role JWT. Defaults to ``SUPABASE_SERVICE_ROLE_KEY``.
+    timeout : int
+        Per-request timeout in seconds. Defaults to 30.
+
+    The service role key bypasses RLS. Do not pass it to the browser.
+    """
+
+    def __init__(
+        self,
+        url: str | None = None,
+        service_role_key: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        self.url = (url or os.environ.get("SUPABASE_URL", "")).rstrip("/")
+        self.key = service_role_key or os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+        self.timeout = timeout
+
+        if not self.url:
+            raise SupabaseConfigError(
+                "SUPABASE_URL is not set. Add it to .env.local or the shell env."
+            )
+        if not self.key:
+            raise SupabaseConfigError(
+                "SUPABASE_SERVICE_ROLE_KEY is not set. Add it to .env.local "
+                "(the service role key is server-side only — never ship it "
+                "to the browser)."
+            )
+
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "apikey": self.key,
+                "Authorization": f"Bearer {self.key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
+
+    # ─────────────────────────────────────────────
+    # URL building
+    # ─────────────────────────────────────────────
+    def _table_url(self, table: str) -> str:
+        return f"{self.url}/rest/v1/{table}"
+
+    # ─────────────────────────────────────────────
+    # Response handling
+    # ─────────────────────────────────────────────
+    def _handle(self, response: requests.Response) -> Any:
+        if not response.ok:
+            try:
+                body = response.json()
+            except ValueError:
+                body = response.text
+            raise SupabaseHTTPError(response.status_code, body, response.url)
+
+        # 204 No Content (e.g. delete with no return) → empty list
+        if not response.content:
+            return []
+
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    # ─────────────────────────────────────────────
+    # Operations
+    # ─────────────────────────────────────────────
+    def select(
+        self,
+        table: str,
+        *,
+        columns: str = "*",
+        filters: Mapping[str, str] | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """
+        GET /rest/v1/{table}?select=...&<filters>&limit=...
+
+        ``filters`` is a mapping of PostgREST filter clauses, e.g.
+        ``{"library_id": "eq.abc-123"}``.
+        """
+        params: dict[str, str] = {"select": columns}
+        if filters:
+            params.update(filters)
+        if limit is not None:
+            params["limit"] = str(limit)
+
+        response = self._session.get(
+            self._table_url(table), params=params, timeout=self.timeout
+        )
+        return self._handle(response) or []
+
+    def insert(
+        self,
+        table: str,
+        rows: Mapping[str, Any] | Iterable[Mapping[str, Any]],
+        *,
+        returning: str = "representation",
+    ) -> list[dict]:
+        """
+        POST /rest/v1/{table} — insert one row or many.
+
+        ``returning`` is passed through as the ``Prefer: return=<value>``
+        header. Defaults to "representation" (return inserted rows).
+        """
+        if isinstance(rows, Mapping):
+            body = [dict(rows)]
+        else:
+            body = [dict(r) for r in rows]
+
+        headers = {"Prefer": f"return={returning}"}
+        response = self._session.post(
+            self._table_url(table),
+            data=json.dumps(body),
+            headers=headers,
+            timeout=self.timeout,
+        )
+        return self._handle(response) or []
+
+    def upsert(
+        self,
+        table: str,
+        rows: Mapping[str, Any] | Iterable[Mapping[str, Any]],
+        *,
+        on_conflict: str,
+        returning: str = "representation",
+    ) -> list[dict]:
+        """
+        POST with ``Prefer: resolution=merge-duplicates``.
+
+        Parameters
+        ----------
+        on_conflict : str
+            Column name (or comma-separated columns) that backs a UNIQUE
+            constraint to resolve against, e.g. ``"fusion_guid"``.
+        """
+        if isinstance(rows, Mapping):
+            body = [dict(rows)]
+        else:
+            body = [dict(r) for r in rows]
+
+        headers = {
+            "Prefer": f"resolution=merge-duplicates,return={returning}",
+        }
+        params = {"on_conflict": on_conflict}
+        response = self._session.post(
+            self._table_url(table),
+            data=json.dumps(body),
+            headers=headers,
+            params=params,
+            timeout=self.timeout,
+        )
+        return self._handle(response) or []
+
+    def delete(
+        self,
+        table: str,
+        *,
+        filters: Mapping[str, str],
+    ) -> list[dict]:
+        """
+        DELETE /rest/v1/{table}?<filters>
+
+        ``filters`` is REQUIRED — PostgREST refuses unfiltered deletes by
+        default and we want to keep it that way to avoid wiping tables.
+        """
+        if not filters:
+            raise ValueError(
+                "delete() requires at least one filter — refusing to "
+                "issue an unfiltered DELETE."
+            )
+        headers = {"Prefer": "return=representation"}
+        response = self._session.delete(
+            self._table_url(table),
+            params=dict(filters),
+            headers=headers,
+            timeout=self.timeout,
+        )
+        return self._handle(response) or []

--- a/sync_supabase.py
+++ b/sync_supabase.py
@@ -1,0 +1,509 @@
+"""
+sync_supabase.py
+Fusion 360 JSON → Supabase fusion2plex_* ingest
+Grace Engineering — plex-api project
+=============================================================
+Reads Fusion 360 tool-library JSON files, applies the eight
+normalization rules documented in the Supabase Schema Design
+(Notion · 2026-04-08), and upserts the three ``fusion2plex_*``
+tables in the bulletforge Supabase project.
+
+Pipeline
+--------
+1. Load a library (filename → list of raw tool dicts) with
+   ``tool_library_loader.load_library``.
+2. Filter out holders and probes (Rule 6).
+3. For each remaining tool, build a normalized row:
+   - Unit convert inches → mm on all FLOAT geometry (Rule 1).
+   - Strip leading/trailing whitespace on ``product_id``; preserve
+     internal characters (Rule 2).
+   - Carry JSON nulls through as SQL NULL (Rule 5).
+   - Carry ``shaft.segments`` as JSONB passthrough, NULL if absent
+     (Rule 7).
+   - Use ``.get("comment")`` for post-process comment (Rule 8).
+4. Upsert the library row on ``library_name``, capture its id.
+5. Upsert all tool rows on ``fusion_guid`` in one batch, capture ids
+   keyed by fusion_guid.
+6. For each tool, flush its existing presets (DELETE WHERE tool_id),
+   then bulk-insert the freshly normalized preset rows. This is a
+   cleaner model than trying to upsert per-preset when the vendor
+   doesn't provide a stable preset identity.
+
+The module is pure data — it does not touch Plex. Downstream,
+``build_supply_item_payload`` (#3) will read normalized rows from
+``fusion2plex_tools`` and push them to Plex.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from supabase_client import SupabaseClient
+
+log = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────
+INCHES_TO_MM = 25.4
+
+EXCLUDED_TYPES = frozenset({"holder", "probe"})
+
+# Geometry fields that are dimensional (convert inches → mm) vs dimensionless
+# (counts, flags, angles — carry as-is).
+GEOMETRY_LENGTH_FIELDS = {
+    "DC": "geo_dc",
+    "OAL": "geo_oal",
+    "LCF": "geo_lcf",
+    "LB": "geo_lb",
+    "SFDM": "geo_sfdm",
+    "RE": "geo_re",
+    "tip-diameter": "geo_tip_diameter",
+    "tip-length": "geo_tip_length",
+    "tip-offset": "geo_tip_offset",
+    "assemblyGaugeLength": "geo_assembly_gauge_length",
+    "shoulder-diameter": "geo_shoulder_diameter",
+    "shoulder-length": "geo_shoulder_length",
+}
+
+# Dimensionless geometry fields (counts, angles, booleans, etc.) — never
+# scaled by unit conversion.
+GEOMETRY_DIMENSIONLESS_FIELDS = {
+    "NOF": "geo_nof",
+    "SIG": "geo_sig",          # point angle in degrees
+    "NT": "geo_nt",
+    "TA": "geo_ta",            # taper angle in degrees
+    "TA2": "geo_ta2",
+    "TP": "geo_tp",
+    "thread-profile-angle": "geo_thread_profile_angle",
+}
+
+GEOMETRY_BOOL_FIELDS = {
+    "HAND": "geo_hand",
+    "CSP": "geo_csp",
+}
+
+# Post-process field map (int/bool/text, never unit-scaled).
+POST_PROCESS_INT_FIELDS = {
+    "number": "pp_number",
+    "turret": "pp_turret",
+    "diameter-offset": "pp_diameter_offset",
+    "length-offset": "pp_length_offset",
+}
+
+POST_PROCESS_BOOL_FIELDS = {
+    "live": "pp_live",
+    "break-control": "pp_break_control",
+    "manual-tool-change": "pp_manual_tool_change",
+}
+
+# Preset FLOAT fields — all nullable, carry JSON null through unchanged.
+# Keys are Fusion JSON field names, values are Supabase column names.
+PRESET_FLOAT_FIELDS = {
+    "v_c": "v_c",
+    "v_f": "v_f",
+    "f_z": "f_z",
+    "f_n": "f_n",
+    "n": "n",
+    "n_ramp": "n_ramp",
+    "ramp-angle": "ramp_angle",
+    "v_f_plunge": "v_f_plunge",
+    "v_f_ramp": "v_f_ramp",
+    "v_f_leadIn": "v_f_lead_in",
+    "v_f_leadOut": "v_f_lead_out",
+    "v_f_retract": "v_f_retract",
+    "v_f_transition": "v_f_transition",
+}
+
+PRESET_BOOL_FIELDS = {
+    "use-feed-per-revolution": "use_feed_per_revolution",
+    "use-stepdown": "use_stepdown",
+    "use-stepover": "use_stepover",
+}
+
+
+# ─────────────────────────────────────────────
+# Normalization primitives
+# ─────────────────────────────────────────────
+def normalize_product_id(raw: Any) -> str | None:
+    """
+    Rule 2 — strip leading/trailing whitespace only. Never strip
+    internal characters. Sandvik ships ``"RA216.33-0845-CK04P 1640"``
+    with a real internal space that must be preserved.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raw = str(raw)
+    stripped = raw.strip()
+    return stripped or None
+
+
+def normalize_preset_guid(raw: Any) -> str | None:
+    """
+    Rule 3 — strip surrounding curly braces from Sandvik preset GUIDs:
+    ``"{6a2d224-...}"`` → ``"6a2d224-..."``. Leave everything else
+    alone.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raw = str(raw)
+    s = raw.strip()
+    if len(s) >= 2 and s.startswith("{") and s.endswith("}"):
+        s = s[1:-1]
+    return s or None
+
+
+def unit_scale(value: Any, is_inches: bool) -> float | None:
+    """
+    Rule 1 — multiply dimensional values by 25.4 when the library
+    declares ``unit == "inches"``. Pass JSON nulls through unchanged.
+    Booleans and non-numeric strings return None (not a dimensional
+    value).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        # bool is a subclass of int in Python — reject explicitly.
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return None
+    if is_inches:
+        return as_float * INCHES_TO_MM
+    return as_float
+
+
+def _maybe_float(value: Any) -> float | None:
+    """Coerce to float or return None (for dimensionless geometry + presets)."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _maybe_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return str(value)
+    return value
+
+
+# ─────────────────────────────────────────────
+# Tool row builder
+# ─────────────────────────────────────────────
+def build_tool_row(tool: dict) -> dict:
+    """
+    Map one raw Fusion tool dict to a ``fusion2plex_tools`` row dict.
+    Does NOT include ``library_id`` — caller fills that in after the
+    library row has been upserted and has a real id.
+
+    Applies Rules 1, 2, 7, 8. Rules 5 and 6 are applied at the batch
+    level (see ``sync_library``).
+    """
+    unit_raw = tool.get("unit")
+    is_inches = isinstance(unit_raw, str) and unit_raw.lower() == "inches"
+
+    row: dict[str, Any] = {
+        "fusion_guid": _maybe_str(tool.get("guid")),
+        "vendor": _maybe_str(tool.get("vendor")) or "",
+        "product_id": normalize_product_id(tool.get("product-id")) or "",
+        "description": _maybe_str(tool.get("description")) or "",
+        "type": _maybe_str(tool.get("type")) or "",
+        "bmc": _maybe_str(tool.get("BMC")),
+        "grade": _maybe_str(tool.get("GRADE")),
+        # reference_guid is observed as integer 0 in Harvey/Helical — store as string
+        "reference_guid": (
+            str(tool["reference_guid"]) if "reference_guid" in tool else None
+        ),
+        "unit_original": _maybe_str(unit_raw),
+        "product_link": _maybe_str(tool.get("product-link")),
+        "tapered_type": _maybe_str(tool.get("tapered-type")),
+    }
+
+    # Geometry — length fields go through unit_scale; dimensionless pass through.
+    geometry = tool.get("geometry") or {}
+    for fusion_key, col in GEOMETRY_LENGTH_FIELDS.items():
+        row[col] = unit_scale(geometry.get(fusion_key), is_inches)
+    for fusion_key, col in GEOMETRY_DIMENSIONLESS_FIELDS.items():
+        row[col] = _maybe_float(geometry.get(fusion_key))
+    for fusion_key, col in GEOMETRY_BOOL_FIELDS.items():
+        row[col] = _maybe_bool(geometry.get(fusion_key))
+
+    # Post-process — Rule 8: use .get("comment"), not direct key access.
+    pp = tool.get("post-process") or {}
+    for fusion_key, col in POST_PROCESS_INT_FIELDS.items():
+        row[col] = _maybe_int(pp.get(fusion_key))
+    for fusion_key, col in POST_PROCESS_BOOL_FIELDS.items():
+        row[col] = _maybe_bool(pp.get(fusion_key))
+    row["pp_comment"] = _maybe_str(pp.get("comment"))
+
+    # Rule 7 — shaft.segments as JSONB passthrough, NULL if absent. Do not error.
+    shaft = tool.get("shaft")
+    if isinstance(shaft, dict) and "segments" in shaft:
+        row["shaft_segments"] = shaft["segments"]
+    else:
+        row["shaft_segments"] = None
+
+    return row
+
+
+# ─────────────────────────────────────────────
+# Preset row builder
+# ─────────────────────────────────────────────
+def build_preset_rows(tool: dict, tool_id: str) -> list[dict]:
+    """
+    Map ``tool.start-values.presets`` → list of preset row dicts.
+    ``tool_id`` is the Supabase UUID of the parent tool row.
+
+    Applies Rules 3 (brace strip) and 5 (JSON nulls).
+    """
+    start_values = tool.get("start-values") or {}
+    presets = start_values.get("presets") or []
+    if not isinstance(presets, list):
+        return []
+
+    rows: list[dict] = []
+    for raw in presets:
+        if not isinstance(raw, dict):
+            continue
+        material = raw.get("material") or {}
+        if not isinstance(material, dict):
+            material = {}
+
+        # Preset GUID can appear under either 'guid' or 'presetGuid' across vendors.
+        preset_guid = raw.get("presetGuid") or raw.get("guid")
+
+        row: dict[str, Any] = {
+            "tool_id": tool_id,
+            "preset_guid": normalize_preset_guid(preset_guid),
+            "name": _maybe_str(raw.get("name")),
+            "description": _maybe_str(raw.get("description")),
+            "material_category": _maybe_str(material.get("category")),
+            "material_query": _maybe_str(material.get("query")),
+            "material_use_hardness": _maybe_bool(material.get("useHardness")),
+            "tool_coolant": _maybe_str(raw.get("tool-coolant")),
+        }
+
+        for fusion_key, col in PRESET_FLOAT_FIELDS.items():
+            # Rule 5 — preserve explicit JSON null, do not substitute 0.
+            if fusion_key in raw:
+                row[col] = _maybe_float(raw.get(fusion_key))
+            else:
+                row[col] = None
+
+        for fusion_key, col in PRESET_BOOL_FIELDS.items():
+            if fusion_key in raw:
+                row[col] = _maybe_bool(raw.get(fusion_key))
+            else:
+                row[col] = None
+
+        rows.append(row)
+
+    return rows
+
+
+# ─────────────────────────────────────────────
+# File hashing
+# ─────────────────────────────────────────────
+def hash_file(path: Path) -> str:
+    """SHA-256 of file contents, used for change detection on libraries."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ─────────────────────────────────────────────
+# Top-level ingest
+# ─────────────────────────────────────────────
+def _pick_vendor(tools: list[dict]) -> str | None:
+    """
+    Rule 4 — preserve raw vendor casing. Most libraries are single-vendor,
+    so we take the first tool's vendor string as-is. Job-specific libraries
+    (e.g. BROTHER SPEEDIO ALUMINUM) may be mixed; that's fine — the
+    library-level ``vendor`` is a hint, the per-tool ``vendor`` column
+    is the source of truth.
+    """
+    for t in tools:
+        v = t.get("vendor")
+        if isinstance(v, str) and v.strip():
+            return v
+    return None
+
+
+def _pick_unit_original(tools: list[dict]) -> str | None:
+    """First declared unit wins for the library metadata."""
+    for t in tools:
+        u = t.get("unit")
+        if isinstance(u, str) and u.strip():
+            return u
+    return None
+
+
+def sync_library(
+    library_name: str,
+    tools: list[dict],
+    *,
+    client: SupabaseClient,
+    file_path: str | None = None,
+    file_hash: str | None = None,
+) -> dict[str, int]:
+    """
+    Upsert one library worth of Fusion tools into Supabase.
+
+    Parameters
+    ----------
+    library_name : str
+        Filename stem or other unique name. UPSERT key on libraries.
+    tools : list[dict]
+        Raw ``data`` array from a Fusion JSON file. Holders/probes are
+        filtered out inside this function (Rule 6).
+    client : SupabaseClient
+        Configured Supabase client.
+    file_path : str | None
+        Full on-disk path. Stored for audit; not required.
+    file_hash : str | None
+        SHA-256 of the source file. Stored on the library row so future
+        runs can skip unchanged files.
+
+    Returns
+    -------
+    dict
+        ``{"tools": <count>, "presets": <count>}``.
+    """
+    # Rule 6 — sync filter.
+    filtered = [t for t in tools if t.get("type") not in EXCLUDED_TYPES]
+
+    vendor = _pick_vendor(filtered)
+    unit_original = _pick_unit_original(filtered)
+
+    # ── 1. Library row upsert ──────────────────────────────────────
+    library_row = {
+        "library_name": library_name,
+        "vendor": vendor,
+        "file_path": file_path,
+        "file_hash": file_hash,
+        "tool_count": len(filtered),
+        "unit_original": unit_original,
+        "ingested_at": datetime.now(timezone.utc).isoformat(),
+    }
+    lib_result = client.upsert(
+        "fusion2plex_libraries",
+        library_row,
+        on_conflict="library_name",
+    )
+    if not lib_result:
+        raise RuntimeError(f"Library upsert returned no rows for {library_name!r}")
+    library_id = lib_result[0]["id"]
+    log.info(
+        "Library upserted: %s → id=%s (%d tools after filter)",
+        library_name,
+        library_id,
+        len(filtered),
+    )
+
+    # ── 2. Tool rows upsert ────────────────────────────────────────
+    tool_rows: list[dict] = []
+    for raw in filtered:
+        row = build_tool_row(raw)
+        if not row.get("fusion_guid"):
+            log.warning(
+                "Skipping tool with no guid in %s: %s",
+                library_name,
+                row.get("product_id") or row.get("description") or "<unknown>",
+            )
+            continue
+        row["library_id"] = library_id
+        tool_rows.append(row)
+
+    if not tool_rows:
+        log.info("No tool rows to upsert for %s", library_name)
+        return {"tools": 0, "presets": 0}
+
+    tools_result = client.upsert(
+        "fusion2plex_tools",
+        tool_rows,
+        on_conflict="fusion_guid",
+    )
+    # Build a guid → db id lookup for preset parenting.
+    guid_to_id = {r["fusion_guid"]: r["id"] for r in tools_result}
+    log.info("Tools upserted: %d rows for %s", len(tools_result), library_name)
+
+    # ── 3. Presets: flush + bulk insert per tool ───────────────────
+    total_presets = 0
+    for raw in filtered:
+        guid = raw.get("guid")
+        if guid not in guid_to_id:
+            continue
+        tool_id = guid_to_id[guid]
+        # Flush existing presets for this tool so a re-sync never double-inserts.
+        client.delete(
+            "fusion2plex_cutting_presets",
+            filters={"tool_id": f"eq.{tool_id}"},
+        )
+        preset_rows = build_preset_rows(raw, tool_id=tool_id)
+        if preset_rows:
+            client.insert("fusion2plex_cutting_presets", preset_rows)
+            total_presets += len(preset_rows)
+
+    log.info("Presets inserted: %d rows for %s", total_presets, library_name)
+    return {"tools": len(tools_result), "presets": total_presets}
+
+
+def sync_library_file(
+    path: Path,
+    *,
+    client: SupabaseClient,
+    library_name: str | None = None,
+) -> dict[str, int]:
+    """
+    Convenience — load a single ``.json`` file from disk, apply the
+    stale-file guard via ``tool_library_loader.load_library``, and
+    sync it into Supabase.
+    """
+    from tool_library_loader import load_library
+
+    tools = load_library(path)
+    if tools is None:
+        raise RuntimeError(f"load_library returned None for {path}")
+
+    name = library_name or path.stem
+    file_hash = hash_file(path)
+    return sync_library(
+        name,
+        tools,
+        client=client,
+        file_path=str(path),
+        file_hash=file_hash,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,12 @@ if str(ROOT) not in sys.path:
 os.environ.setdefault("PLEX_API_KEY", "test-key-do-not-use")
 os.environ.setdefault("PLEX_API_SECRET", "test-secret-do-not-use")
 
+# Dummy Supabase credentials so supabase_client imports cleanly under pytest.
+# Tests NEVER hit the real Supabase project — they use FakeSupabaseClient or
+# patch ``requests.Session``.
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-supabase-key-do-not-use")
+
 
 # ─────────────────────────────────────────────
 # Shared fixtures

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -1,0 +1,176 @@
+"""
+Tests for supabase_client.py — thin PostgREST wrapper.
+
+Focuses on the contract:
+  - Config errors when env vars are missing
+  - Headers are set correctly on the session
+  - URL building routes to /rest/v1/<table>
+  - delete() refuses unfiltered calls
+  - HTTP errors surface as SupabaseHTTPError
+
+All HTTP traffic is patched — no real network calls.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from supabase_client import (
+    SupabaseClient,
+    SupabaseConfigError,
+    SupabaseHTTPError,
+)
+
+
+# ─────────────────────────────────────────────
+# Config errors
+# ─────────────────────────────────────────────
+class TestConfigErrors:
+    def test_missing_url_raises(self, monkeypatch):
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        with pytest.raises(SupabaseConfigError, match="SUPABASE_URL"):
+            SupabaseClient()
+
+    def test_missing_key_raises(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+        with pytest.raises(SupabaseConfigError, match="SUPABASE_SERVICE_ROLE_KEY"):
+            SupabaseClient()
+
+    def test_explicit_args_override_env(self, monkeypatch):
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+        client = SupabaseClient(
+            url="https://explicit.supabase.co",
+            service_role_key="explicit-key",
+        )
+        assert client.url == "https://explicit.supabase.co"
+        assert client.key == "explicit-key"
+
+
+# ─────────────────────────────────────────────
+# Session headers
+# ─────────────────────────────────────────────
+class TestHeaders:
+    def test_both_apikey_and_bearer_set(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "abc123")
+        client = SupabaseClient()
+        assert client._session.headers["apikey"] == "abc123"
+        assert client._session.headers["Authorization"] == "Bearer abc123"
+
+    def test_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co/")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        client = SupabaseClient()
+        assert client.url == "https://x.supabase.co"
+
+
+# ─────────────────────────────────────────────
+# URL building
+# ─────────────────────────────────────────────
+class TestTableUrl:
+    def test_table_url_format(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        client = SupabaseClient()
+        assert (
+            client._table_url("fusion2plex_tools")
+            == "https://x.supabase.co/rest/v1/fusion2plex_tools"
+        )
+
+
+# ─────────────────────────────────────────────
+# Delete safety guard
+# ─────────────────────────────────────────────
+class TestDeleteSafety:
+    def test_delete_without_filters_raises(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        client = SupabaseClient()
+        with pytest.raises(ValueError, match="at least one filter"):
+            client.delete("fusion2plex_tools", filters={})
+
+
+# ─────────────────────────────────────────────
+# HTTP error surfacing
+# ─────────────────────────────────────────────
+class TestErrorHandling:
+    def test_non_2xx_raises_supabase_http_error(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        client = SupabaseClient()
+
+        class FakeResponse:
+            ok = False
+            status_code = 400
+            url = "https://x.supabase.co/rest/v1/foo"
+            content = b'{"message": "bad request"}'
+
+            def json(self):
+                return {"message": "bad request"}
+
+        with patch.object(client._session, "get", return_value=FakeResponse()):
+            with pytest.raises(SupabaseHTTPError) as exc_info:
+                client.select("foo")
+            assert exc_info.value.status == 400
+            assert exc_info.value.body == {"message": "bad request"}
+
+    def test_2xx_with_empty_body_returns_empty_list(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        client = SupabaseClient()
+
+        class FakeResponse:
+            ok = True
+            status_code = 204
+            content = b""
+
+        with patch.object(client._session, "delete", return_value=FakeResponse()):
+            result = client.delete("foo", filters={"id": "eq.1"})
+            assert result == []
+
+
+# ─────────────────────────────────────────────
+# Upsert request shape
+# ─────────────────────────────────────────────
+class TestUpsertRequestShape:
+    def test_upsert_sends_merge_duplicates_and_on_conflict(self, monkeypatch):
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "k")
+        client = SupabaseClient()
+
+        captured = {}
+
+        class FakeResponse:
+            ok = True
+            status_code = 201
+            content = b"[]"
+
+            def json(self):
+                return []
+
+        def fake_post(url, data=None, headers=None, params=None, timeout=None):
+            captured["url"] = url
+            captured["data"] = data
+            captured["headers"] = headers
+            captured["params"] = params
+            return FakeResponse()
+
+        with patch.object(client._session, "post", side_effect=fake_post):
+            client.upsert(
+                "fusion2plex_tools",
+                {"fusion_guid": "abc", "vendor": "V"},
+                on_conflict="fusion_guid",
+            )
+
+        assert captured["url"].endswith("/rest/v1/fusion2plex_tools")
+        assert "resolution=merge-duplicates" in captured["headers"]["Prefer"]
+        assert captured["params"] == {"on_conflict": "fusion_guid"}
+        # Body is JSON-serialized list
+        assert json.loads(captured["data"]) == [
+            {"fusion_guid": "abc", "vendor": "V"}
+        ]

--- a/tests/test_sync_supabase.py
+++ b/tests/test_sync_supabase.py
@@ -1,0 +1,389 @@
+"""
+Tests for sync_supabase.py — Fusion → Supabase normalization.
+
+Covers all eight normalization rules from the Supabase Schema Design
+(Notion · 2026-04-08):
+
+  1. Unit conversion (inches → mm) on dimensional geometry
+  2. product_id whitespace cleanup (external only)
+  3. Preset GUID curly-brace strip
+  4. Raw vendor casing preserved
+  5. JSON null passthrough in presets (do not substitute 0)
+  6. Sync filter excludes holder / probe
+  7. shaft.segments JSONB passthrough, absent = NULL
+  8. post_process.comment uses .get, never direct access
+
+Also covers the batch-level sync_library flow via a fake Supabase
+client so no network traffic happens in the test suite.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sync_supabase import (
+    INCHES_TO_MM,
+    build_preset_rows,
+    build_tool_row,
+    normalize_preset_guid,
+    normalize_product_id,
+    sync_library,
+    unit_scale,
+)
+
+
+# ─────────────────────────────────────────────
+# Rule 1 — unit conversion
+# ─────────────────────────────────────────────
+class TestUnitScale:
+    def test_inches_value_is_multiplied(self):
+        # 0.5 in → 12.7 mm
+        assert unit_scale(0.5, is_inches=True) == pytest.approx(12.7)
+
+    def test_millimeters_value_is_unchanged(self):
+        assert unit_scale(12.7, is_inches=False) == pytest.approx(12.7)
+
+    def test_integer_value_is_coerced_and_scaled(self):
+        assert unit_scale(1, is_inches=True) == pytest.approx(25.4)
+
+    def test_none_passes_through(self):
+        assert unit_scale(None, is_inches=True) is None
+        assert unit_scale(None, is_inches=False) is None
+
+    def test_bool_is_rejected_as_non_dimensional(self):
+        # Python bool is a subclass of int — we want it rejected, not scaled.
+        assert unit_scale(True, is_inches=True) is None
+        assert unit_scale(False, is_inches=True) is None
+
+    def test_non_numeric_string_returns_none(self):
+        assert unit_scale("banana", is_inches=True) is None
+
+
+# ─────────────────────────────────────────────
+# Rule 2 — product_id cleanup
+# ─────────────────────────────────────────────
+class TestNormalizeProductId:
+    def test_strips_leading_and_trailing_whitespace(self):
+        assert normalize_product_id("  990910  ") == "990910"
+
+    def test_preserves_internal_space_sandvik(self):
+        # Sandvik real example — the space between CK04P and 1640 must survive.
+        raw = "RA216.33-0845-CK04P 1640"
+        assert normalize_product_id(raw) == raw
+
+    def test_preserves_internal_dots_and_dashes(self):
+        assert normalize_product_id("RA216.33-0845") == "RA216.33-0845"
+
+    def test_none_returns_none(self):
+        assert normalize_product_id(None) is None
+
+    def test_all_whitespace_returns_none(self):
+        assert normalize_product_id("   ") is None
+
+    def test_non_string_is_coerced(self):
+        assert normalize_product_id(990910) == "990910"
+
+
+# ─────────────────────────────────────────────
+# Rule 3 — preset GUID brace strip
+# ─────────────────────────────────────────────
+class TestNormalizePresetGuid:
+    def test_strips_matched_braces(self):
+        assert normalize_preset_guid("{6a2d224-abc-def}") == "6a2d224-abc-def"
+
+    def test_leaves_plain_guid_alone(self):
+        assert normalize_preset_guid("6a2d224-abc-def") == "6a2d224-abc-def"
+
+    def test_unmatched_left_brace_kept(self):
+        assert normalize_preset_guid("{6a2d224") == "{6a2d224"
+
+    def test_unmatched_right_brace_kept(self):
+        assert normalize_preset_guid("6a2d224}") == "6a2d224}"
+
+    def test_none_returns_none(self):
+        assert normalize_preset_guid(None) is None
+
+    def test_empty_braces_returns_none(self):
+        assert normalize_preset_guid("{}") is None
+
+
+# ─────────────────────────────────────────────
+# Rule 4 — vendor casing preserved
+# ─────────────────────────────────────────────
+class TestVendorCasing:
+    def test_uppercase_vendor_preserved(self):
+        tool = _tool(vendor="HARVEY TOOL")
+        assert build_tool_row(tool)["vendor"] == "HARVEY TOOL"
+
+    def test_lowercase_vendor_preserved(self):
+        tool = _tool(vendor="deltamill")
+        assert build_tool_row(tool)["vendor"] == "deltamill"
+
+    def test_titlecase_vendor_preserved(self):
+        tool = _tool(vendor="Garr Tool")
+        assert build_tool_row(tool)["vendor"] == "Garr Tool"
+
+
+# ─────────────────────────────────────────────
+# Rule 5 — JSON null passthrough
+# ─────────────────────────────────────────────
+class TestPresetNullPassthrough:
+    def test_explicit_null_becomes_sql_null(self):
+        tool = _tool(
+            presets=[
+                {
+                    "guid": "p1",
+                    "name": "Default",
+                    "f_n": None,
+                    "f_z": None,
+                    "v_c": None,
+                }
+            ]
+        )
+        rows = build_preset_rows(tool, tool_id="tool-uuid")
+        assert len(rows) == 1
+        assert rows[0]["f_n"] is None
+        assert rows[0]["f_z"] is None
+        assert rows[0]["v_c"] is None
+
+    def test_real_values_preserved(self):
+        tool = _tool(
+            presets=[{"guid": "p1", "name": "D", "v_c": 120.5, "n": 12000.0}]
+        )
+        rows = build_preset_rows(tool, tool_id="tool-uuid")
+        assert rows[0]["v_c"] == 120.5
+        assert rows[0]["n"] == 12000.0
+
+    def test_absent_field_becomes_null(self):
+        tool = _tool(presets=[{"guid": "p1", "name": "D"}])
+        rows = build_preset_rows(tool, tool_id="tool-uuid")
+        assert rows[0]["f_n"] is None
+        assert rows[0]["v_c"] is None
+
+
+# ─────────────────────────────────────────────
+# Rule 6 — sync filter (holder + probe excluded)
+# ─────────────────────────────────────────────
+class TestSyncFilter:
+    def test_holders_excluded_from_tool_rows(self, fake_supabase):
+        tools = [
+            _tool(guid="t1", type="flat end mill"),
+            _tool(guid="h1", type="holder"),
+            _tool(guid="p1", type="probe"),
+            _tool(guid="t2", type="drill"),
+        ]
+        result = sync_library("sample", tools, client=fake_supabase)
+        assert result["tools"] == 2
+
+        tool_inserts = fake_supabase.inserts_for("fusion2plex_tools")
+        guids = sorted(r["fusion_guid"] for r in tool_inserts)
+        assert guids == ["t1", "t2"]
+
+    def test_library_tool_count_reflects_filter(self, fake_supabase):
+        tools = [
+            _tool(guid="t1", type="flat end mill"),
+            _tool(guid="h1", type="holder"),
+        ]
+        sync_library("sample", tools, client=fake_supabase)
+        lib_row = fake_supabase.inserts_for("fusion2plex_libraries")[0]
+        assert lib_row["tool_count"] == 1
+
+
+# ─────────────────────────────────────────────
+# Rule 7 — shaft segments passthrough
+# ─────────────────────────────────────────────
+class TestShaftPassthrough:
+    def test_missing_shaft_is_null(self):
+        tool = _tool()
+        tool.pop("shaft", None)
+        row = build_tool_row(tool)
+        assert row["shaft_segments"] is None
+
+    def test_shaft_without_segments_is_null(self):
+        tool = _tool()
+        tool["shaft"] = {"type": "shaft"}
+        row = build_tool_row(tool)
+        assert row["shaft_segments"] is None
+
+    def test_shaft_with_segments_is_passthrough(self):
+        segments = [{"lower": 0.0, "upper": 10.0, "diameter": 6.0}]
+        tool = _tool()
+        tool["shaft"] = {"type": "shaft", "segments": segments}
+        row = build_tool_row(tool)
+        assert row["shaft_segments"] == segments
+
+    def test_empty_segments_list_is_preserved_not_nulled(self):
+        # Helical ships stubs with segments=[] — we store the empty list,
+        # not NULL, so we can distinguish "stub present" from "no shaft key".
+        tool = _tool()
+        tool["shaft"] = {"type": "shaft", "segments": []}
+        row = build_tool_row(tool)
+        assert row["shaft_segments"] == []
+
+
+# ─────────────────────────────────────────────
+# Rule 8 — pp comment .get access
+# ─────────────────────────────────────────────
+class TestPostProcessCommentSafe:
+    def test_missing_comment_does_not_raise(self):
+        # Sandvik omits post-process.comment entirely.
+        tool = _tool()
+        tool["post-process"] = {"number": 0}
+        row = build_tool_row(tool)
+        assert row["pp_comment"] is None
+
+    def test_comment_present(self):
+        tool = _tool()
+        tool["post-process"] = {"number": 0, "comment": "(Corner Chamfer 0.2x45°)"}
+        row = build_tool_row(tool)
+        assert row["pp_comment"] == "(Corner Chamfer 0.2x45°)"
+
+    def test_missing_post_process_does_not_raise(self):
+        tool = _tool()
+        tool.pop("post-process", None)
+        row = build_tool_row(tool)
+        assert row["pp_comment"] is None
+        assert row["pp_number"] is None
+
+
+# ─────────────────────────────────────────────
+# Geometry unit conversion end-to-end
+# ─────────────────────────────────────────────
+class TestBuildToolRowGeometry:
+    def test_inches_library_converts_length_fields(self):
+        tool = _tool(
+            unit="inches",
+            geometry={"DC": 0.25, "OAL": 2.0, "NOF": 4, "HAND": True, "SIG": 118},
+        )
+        row = build_tool_row(tool)
+        assert row["geo_dc"] == pytest.approx(0.25 * INCHES_TO_MM)
+        assert row["geo_oal"] == pytest.approx(2.0 * INCHES_TO_MM)
+        # NOF and SIG are dimensionless — must not scale.
+        assert row["geo_nof"] == 4.0
+        assert row["geo_sig"] == 118.0
+        assert row["geo_hand"] is True
+
+    def test_millimeters_library_preserves_length_fields(self):
+        tool = _tool(
+            unit="millimeters",
+            geometry={"DC": 6.0, "OAL": 60.0, "NOF": 3, "HAND": True},
+        )
+        row = build_tool_row(tool)
+        assert row["geo_dc"] == 6.0
+        assert row["geo_oal"] == 60.0
+        assert row["geo_nof"] == 3.0
+
+    def test_missing_geometry_field_is_null(self):
+        tool = _tool(unit="millimeters", geometry={"DC": 6.0})
+        row = build_tool_row(tool)
+        assert row["geo_dc"] == 6.0
+        assert row["geo_oal"] is None
+        assert row["geo_re"] is None
+
+
+# ─────────────────────────────────────────────
+# Idempotent re-sync
+# ─────────────────────────────────────────────
+class TestIdempotency:
+    def test_rerun_flushes_presets_before_reinsert(self, fake_supabase):
+        tools = [
+            _tool(
+                guid="t1",
+                presets=[
+                    {"guid": "p1", "name": "Aluminum", "n": 12000},
+                    {"guid": "p2", "name": "Steel", "n": 8000},
+                ],
+            )
+        ]
+        sync_library("lib1", tools, client=fake_supabase)
+        sync_library("lib1", tools, client=fake_supabase)
+
+        # Each run issues one delete per tool BEFORE inserting its presets.
+        deletes = [op for op in fake_supabase.ops if op["kind"] == "delete"]
+        assert len(deletes) == 2
+        assert deletes[0]["table"] == "fusion2plex_cutting_presets"
+        assert deletes[0]["filters"]["tool_id"].startswith("eq.")
+
+
+# ─────────────────────────────────────────────
+# Test helpers
+# ─────────────────────────────────────────────
+def _tool(**overrides) -> dict:
+    """Build a minimal valid tool dict with sensible defaults."""
+    base = {
+        "guid": overrides.pop("guid", "default-guid"),
+        "type": overrides.pop("type", "flat end mill"),
+        "description": overrides.pop("description", "test tool"),
+        "product-id": overrides.pop("product_id", "TEST-001"),
+        "vendor": overrides.pop("vendor", "Test Vendor"),
+        "unit": overrides.pop("unit", "millimeters"),
+        "BMC": overrides.pop("bmc", "carbide"),
+        "geometry": overrides.pop("geometry", {"DC": 6.0, "OAL": 60.0, "NOF": 3}),
+        "post-process": overrides.pop(
+            "post_process", {"number": 0, "comment": ""}
+        ),
+        "start-values": {"presets": overrides.pop("presets", [])},
+    }
+    base.update(overrides)
+    return base
+
+
+class FakeSupabaseClient:
+    """
+    In-memory stand-in for SupabaseClient used by sync_library tests.
+    Records every call and returns synthesized ids so the ingest
+    pipeline can complete end-to-end without any network traffic.
+    """
+
+    def __init__(self):
+        self.ops: list[dict] = []
+        self._next_id = 0
+
+    def _make_id(self, prefix: str) -> str:
+        self._next_id += 1
+        return f"{prefix}-{self._next_id:04d}"
+
+    def inserts_for(self, table: str) -> list[dict]:
+        """All rows sent to ``table`` across insert + upsert ops."""
+        rows: list[dict] = []
+        for op in self.ops:
+            if op["kind"] in ("insert", "upsert") and op["table"] == table:
+                rows.extend(op["rows"])
+        return rows
+
+    # ── SupabaseClient interface ───────────────────────────────────
+    def upsert(self, table, rows, *, on_conflict, returning="representation"):
+        if isinstance(rows, dict):
+            rows = [rows]
+        rows = [dict(r) for r in rows]
+        self.ops.append(
+            {"kind": "upsert", "table": table, "rows": rows, "on_conflict": on_conflict}
+        )
+        # Synthesize ids mirroring the on_conflict key for deterministic
+        # lookups (guid → id).
+        echoed = []
+        for r in rows:
+            new = dict(r)
+            if "id" not in new:
+                new["id"] = self._make_id(table.split("_")[-1])
+            echoed.append(new)
+        return echoed
+
+    def insert(self, table, rows, *, returning="representation"):
+        if isinstance(rows, dict):
+            rows = [rows]
+        rows = [dict(r) for r in rows]
+        self.ops.append({"kind": "insert", "table": table, "rows": rows})
+        return [{**r, "id": self._make_id(table.split("_")[-1])} for r in rows]
+
+    def delete(self, table, *, filters):
+        self.ops.append({"kind": "delete", "table": table, "filters": dict(filters)})
+        return []
+
+    def select(self, table, **kwargs):
+        self.ops.append({"kind": "select", "table": table, "kwargs": dict(kwargs)})
+        return []
+
+
+@pytest.fixture
+def fake_supabase():
+    return FakeSupabaseClient()


### PR DESCRIPTION
## Summary

Stands up the `fusion2plex_*` Supabase staging layer per today's library analysis. This is the canonical normalized store that sits between the Fusion 360 ADC JSON files and the Plex sync — downstream (`build_supply_item_payload`, #3) reads from `fusion2plex_tools`, not raw JSON with 8 vendor schema variants.

Closes grace-shane/plex-api#31.

## What landed

**Schema** (applied to `bulletforge` via Supabase MCP, replacing the stale 7-table schema from earlier today — all rows were 0):
- `fusion2plex_libraries` — one row per ingested .json file (`file_hash`, `ingested_at`, `tool_count`)
- `fusion2plex_tools` — typed geometry columns, all lengths normalized to mm, `shaft_segments` JSONB passthrough, `fusion_guid` UNIQUE, composite index on `(product_id, vendor)`
- `fusion2plex_cutting_presets` — FK to tools ON DELETE CASCADE, all FLOAT fields nullable (Guhring ships explicit JSON null for `f_n`/`f_z`/`v_c`)

`updated_at` trigger on `fusion2plex_tools` with pinned `search_path`. RLS: service role bypasses; explicit deny-all anon on libraries; anon SELECT-only on tools + presets for the future React UI.

**Code**:
- `supabase_client.py` — thin `requests`-based PostgREST wrapper. Skips `supabase-py` because its transitive `pyiceberg` dep needs MSVC on Python 3.14 / Windows. Same HTTP pattern as `plex_api.py`. `delete()` refuses unfiltered calls as a safety guard.
- `sync_supabase.py` — ingest logic with all eight normalization rules from the Schema Design doc. `build_tool_row` and `build_preset_rows` are pure and unit-tested.
- `scripts/load_sample.py` — smoke test against the committed `BROTHER SPEEDIO ALUMINUM.json`.

**Normalization rules implemented** (all 8 from the Notion spec):

1. Unit conversion — `inches -> mm` on dimensional geometry; counts/angles/booleans unchanged
2. `product_id` whitespace — external strip only, internal spaces preserved (Sandvik `RA216.33-0845-CK04P 1640`)
3. `preset_guid` — surrounding curly braces stripped (Sandvik `{abc-123}` -> `abc-123`)
4. `vendor` casing preserved verbatim (`HARVEY TOOL` vs `Garr Tool` vs `deltamill`)
5. JSON null passthrough on all preset FLOAT fields — Guhring ships `null`, must not become 0
6. `type IN ('holder', 'probe')` filtered at ingest
7. `shaft.segments` JSONB passthrough; missing `shaft` key = NULL; empty `[]` stub preserved (Helical)
8. `post_process.comment` via `.get`, never direct access (Sandvik omits it entirely)

## Smoke test (dry-run, no network)

Against `BROTHER SPEEDIO ALUMINUM.json`:
- 28 total entries -> 21 after holder+probe filter
- 25 total presets across the filtered set
- Harvey sample tool 990910: `geo_dc = 1.5748` (= 0.062 in * 25.4), `geo_oal = 38.1`
- Fusion `v_f_leadIn` correctly maps to Supabase `v_f_lead_in` column

## Tests

- **+47 new tests** (203 total, all green, was 156 before this PR)
- `test_sync_supabase.py` has dedicated class per normalization rule
- `test_supabase_client.py` covers config errors, header setup, URL building, unfiltered-delete guard, HTTP error surfacing, upsert request shape
- `FakeSupabaseClient` stubs every ingest op so CI never touches the real project

## Out of scope

- No Plex writes. `build_supply_item_payload` (#3) consumes from `fusion2plex_tools` in a later PR.
- No bulk backfill of all 8 vendor libraries yet. Smoke test against the sample is sufficient to prove the pipe; bulk ingest is a follow-up once `.env.local` gets the real `SUPABASE_SERVICE_ROLE_KEY`.
- No React UI. The anon-role RLS is the only forward-looking piece.

## Test plan

- [x] `py -m pytest` — 203 passed, 0 failed
- [x] Dry-run `build_tool_row` + `build_preset_rows` against real sample JSON — 21 tools / 25 presets / correct mm conversion
- [x] `get_advisors security` — no new lints introduced on my objects
- [ ] Once `SUPABASE_SERVICE_ROLE_KEY` is in `.env.local`, `py scripts/load_sample.py` should insert 21 tools + 25 presets on first run, and stay idempotent on re-run (presets flushed + reinserted, tools upserted on `fusion_guid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)