### PR TITLE
docs: 2026-04-09 Plex connectivity sweep + cross-ref findings

### DIFF
--- a/docs/BRIEFING.md
+++ b/docs/BRIEFING.md
@@ -147,40 +147,68 @@ Plex uses two URL shapes for read endpoints:
 
 ### Verified working endpoints
 
+Record counts are as of **2026-04-09** unless noted. For the full schema
+of every resource + cross-reference discussion, see
+[`docs/Plex_API_Reference.md`](./Plex_API_Reference.md) §3.
+
 | Path | Records | What it is |
-|---|---|---|
-| `mdm/v1/tenants` | 1 | Grace tenant only |
-| `mdm/v1/parts` | 16,913 | **Finished products + raw materials only.** types: Finished Good, Raw Material, Sub Assembly. Tools are NOT here. |
-| `mdm/v1/suppliers` | — | Supplier master |
-| `mdm/v1/customers` | — | |
-| `mdm/v1/contacts` | — | |
-| `mdm/v1/buildings` | — | |
-| `mdm/v1/employees` | — | |
-| `mdm/v1/operations` | 122 | Process steps. Minimal schema. No FK to tools/parts/routings — see Gotchas. |
-| `purchasing/v1/purchase-orders` | — | 44 MB unfiltered |
-| `production/v1/production-definitions/workcenters` | 143 | Includes 21 MILLs. **Codes 879/880 = Brother Speedio FTP IPs.** |
-| `inventory/v1/inventory-definitions/supply-items` | 2,516 | **WHERE TOOLS LIVE.** Filter `category="Tools & Inserts"` for the 1,109 cutting tools and inserts. |
-| `inventory/v1/inventory-definitions/locations` | — | Inventory location master |
+|---|---:|---|
+| `mdm/v1/tenants` | 1 | Grace tenant only. Auth canary. |
+| `mdm/v1/parts` | 16,921 | +8 since 2026-04-07. **Finished products + raw materials only.** Tools are NOT here. |
+| `mdm/v1/parts/{id}` | — | Per-id verified 2026-04-09. Same fields as list. |
+| `mdm/v1/suppliers` | 1,575 | Supplier master. Has `parentSupplierId` self-FK. Mixed material + carrier types. |
+| `mdm/v1/suppliers/{id}` | — | Per-id verified 2026-04-09. |
+| `mdm/v1/customers` | 109 | 35-field schema. FKs to employees, contacts, suppliers. |
+| `mdm/v1/customers/{id}` | — | Per-id verified 2026-04-09. |
+| `mdm/v1/contacts` | 299 | |
+| `mdm/v1/buildings` | 4 | Provides `buildingCode`/`buildingId` referenced by workcenters. |
+| `mdm/v1/employees` | 641 | UUIDs here appear as `createdById`/`modifiedById` across every resource. |
+| `mdm/v1/operations` | 122 | Process steps. Minimal schema (4 fields). No FK to tools/parts/routings — see Gotchas. |
+| `mdm/v1/operations/{id}` | — | Per-id verified 2026-04-09. |
+| `purchasing/v1/purchase-orders` | — | 44.2 MB unfiltered. `?updatedAfter` filter confirmed silent no-op 2026-04-09. |
+| `production/v1/production-definitions/workcenters` | 143 | Includes 21 MILLs. **Codes 879/880 = Brother Speedio FTP IPs.** ⚠️ Primary key is `workcenterId`, not `id`. |
+| `production/v1/production-definitions/workcenters/{id}` | — | Per-id verified 2026-04-09. |
+| `inventory/v1/inventory-definitions/supply-items` | 2,516 | **WHERE TOOLS LIVE.** Filter `category="Tools & Inserts"` for the 1,109 cutting tools. **⚠️ No supplier FK, no cross-references of any kind — identity-only. See §3.5 of Plex_API_Reference.md.** |
+| `inventory/v1/inventory-definitions/supply-items/{id}` | — | Per-id verified 2026-04-09. Same 7 fields, no hidden detail. |
+| `inventory/v1/inventory-definitions/locations` | 1,270 | Inventory location master. Not referenced from supply-item. |
+| `scheduling/v1/jobs` | TBD | **NEW — discovered 2026-04-09.** Returns 200 but ~15.8s response time (large body). Schema TBD. Potentially relevant to #5 if jobs carry tool references. |
 
 ### Where tooling data actually lives
 
 Cutting tools and inserts are **`inventory/v1/inventory-definitions/supply-items`**
 records with `category="Tools & Inserts"` and `group="Machining"`. There are
-already 1,109 tools/inserts tracked in Plex Grace. The schema is:
+already 1,109 tools/inserts tracked in Plex Grace (verified 2026-04-09).
+The schema is just 7 fields:
 
   - `category` (e.g. "Tools & Inserts")
-  - `description`
+  - `description` (free-text, human-readable)
   - `group` (e.g. "Machining", "Tool Room")
-  - `id` (UUID)
-  - `inventoryUnit`
-  - `supplyItemNumber` (vendor part number — the dedup key)
-  - `type` (e.g. SUPPLY, OFFICE)
+  - `id` (UUID — Plex primary key)
+  - `inventoryUnit` (e.g. "Ea")
+  - `supplyItemNumber` (**legacy: free-text, not vendor part numbers**)
+  - `type` (e.g. "SUPPLY")
 
-This is **identity-only**: vendor + part number + description. Geometry
-(DC, OAL, NOF, holder) stays in Fusion as the source of truth — Plex
-stores the vendor reference and the inventory tracking. The Fusion sync
-will write to `inventory/v1/inventory-definitions/supply-items`, not to
-`mdm/v1/parts` (which is for finished products).
+**⚠️ CRITICAL: supply-items have NO cross-references to any other resource (verified 2026-04-09).** This is identity-only — Plex stores no link from a tool to:
+
+- its vendor (no `supplierId`)
+- its physical location (no `locationId`)
+- the part it helps produce (no `partId`)
+- the machine it belongs to (no `workcenterId`)
+- the operation it performs (no `operationId`)
+
+**Implication for the Datum architecture:** vendor/supplier data for tools MUST live in Supabase as the source of truth. The Fusion JSON carries `vendor` and `product-id` → those get written to the `tools` table in Supabase → and `build_supply_item_payload()` (issue #3) constructs the Plex POST body using only the 7 identity fields listed above. Plex never learns who the vendor is, because Plex doesn't model that relationship for tools.
+
+This kills the "use PO lines as a back-channel for the vendor link" hypothesis that was implicit earlier — `purchasing/v1/purchase-orders-lines` returned 404 on 2026-04-09.
+
+The Fusion sync will write to `inventory/v1/inventory-definitions/supply-items`, not to `mdm/v1/parts` (which is for finished products).
+
+**Sample existing `supplyItemNumber` values captured 2026-04-09** (confirming the legacy free-text nature of these records):
+
+- `"Insert  HM90 AXCR 150508 IC28"` (description, not a part number)
+- `"Screw Indexable Face Mill F75"`
+- `"Tap #8-32 H3 Spiral Point"`
+
+Fusion writes will use clean vendor part numbers like `"990910"`, so expect ~100% INSERTs with zero collisions on first sync.
 
 ### Workcenter ↔ machine mapping
 
@@ -486,6 +514,35 @@ is being used. We should also probably make `bootstrap.py` log when
 ## Session log
 
 Reverse chronological. Each entry: what was the goal, what landed, what's left.
+
+### 2026-04-09 — Postman buildout + connectivity sweep + supply-item cross-ref finding
+
+**Goal:** Build out the Postman collections to full known scope, then actually run a connectivity sweep to stop hedging about "verified vs unverified" and get ground truth on every endpoint.
+
+**Done:**
+
+- **Postman collections expanded** (PR #38): Plex collection 12 → 33 requests + `[SCHED] List Jobs` + 2 new `[PROBE]` entries = 36 total. Fusion collection 10 → 14 requests. Organized via `[NS]` name prefixes (Postman MCP minimal tier has no folder creation). New `docs/Postman_Collections.md` as the day-to-day reference.
+- **Connectivity sweep** (23 requests, 2026-04-09): 18/23 returned 200, 5/23 returned 404, **zero 401s**. Clean ground truth on the full subscription scope.
+- **Get-by-ID chain test** (6 requests): all 6 per-id endpoints work. **Every per-id view returns exactly the same fields as the list view** — no hidden detail on any resource.
+- **Fresh record counts captured** for every list endpoint (see §3 table above).
+- **Full field schemas captured** for every resource (see Plex_API_Reference.md §3).
+- **New endpoint discovered:** `scheduling/v1/jobs` returns 200 (15.8s response — large body, schema TBD). Potentially relevant to issue #5.
+- **Critical architectural finding:** `inventory/v1/inventory-definitions/supply-items` has **NO cross-references to any other resource**. Supply-items are identity-only — Plex does not model tool→vendor, tool→location, tool→part, tool→workcenter, or tool→operation. This resolves the question the user asked about "how do we get the supplier from a supply-item": **you can't, not from Plex alone.** Vendor data has to live in Supabase as the source of truth. (Also killed the "use PO lines as a back-channel" hypothesis — `purchasing/v1/purchase-orders-lines` returns 404.)
+- **Filter no-op confirmed on POs:** unfiltered and `?updatedAfter=2025-01-01` both returned byte-identical 44.2 MB responses. The filter is silently ignored (same behavior as `?limit=N`).
+- **Postman descriptions updated** for all 23 sweep endpoints + the 6 per-id endpoints + the 5 `[PROBE]` entries. Historical dates preserved (2026-04-07 initial / 2026-04-09 re-verification).
+
+**Key facts for the next session:**
+
+- The legacy `PLEX_API_KEY=uP4G...` stale shell env var is **still set** in `HKCU\Environment`. It shadows `.env.local` due to `bootstrap.setdefault()` semantics. User cannot permanently unset it in this environment — every session must `unset PLEX_API_KEY && export PLEX_API_KEY='<current>'` before running anything that hits Plex. Document this as a project foot-gun (it's already in History §4 but the env var never got cleaned up).
+- This worktree (`charming-hamilton`) does **not** have a `.env.local`. Per the `Bootstrap.py worktree foot-gun` memory, every worktree needs its own until issue #36 lands.
+- The `scheduling/v1/jobs` endpoint is the highest-value follow-up — if its records carry tool references, we get the operation→tool mapping that issue #5 is blocked on without needing the `manufacturing/v1/routings` endpoint to ever become available.
+
+**What's left:**
+
+1. Deep-dive `scheduling/v1/jobs` — pull once, sample shape, document fields. Look specifically for `toolId`, `supplyItemId`, `workcenterId`, `operationId` references.
+2. Issue #3 — `build_supply_item_payload` reading from Supabase `tools` table, now with full confidence that Plex never needs to know about vendors.
+3. Issue #5 / #4 — architectural decisions remain blocked on product questions (not code questions).
+4. Clean up the stale shell `PLEX_API_KEY=uP4G...` when the user gets admin access.
 
 ### 2026-04-09 — project rename + key rotation
 

--- a/docs/Plex_API_Reference.md
+++ b/docs/Plex_API_Reference.md
@@ -38,9 +38,22 @@ X-Plex-Connect-Api-Key: <your_consumer_key>
 
 > [!IMPORTANT]
 > All values below were verified empirically against `connect.plex.com`
-> (production) on **2026-04-07** with the `Fusion2Plex` Consumer Key on the
-> Grace tenant (`58f781ba-1691-4f32-b1db-381cdb21300c`). Reproduce by
-> running the diagnostic at `/api/diagnostics/tenant` from the local UI.
+> (production) on the Grace tenant
+> (`58f781ba-1691-4f32-b1db-381cdb21300c`). Reproduce by running the
+> diagnostic at `/api/diagnostics/tenant` from the local UI, or by
+> running the Postman `[AUTH] List All Tenants — Auth Canary` request.
+>
+> **Verification history:**
+>
+> - **2026-04-07** — first full sweep with the `Fusion2Plex` Consumer
+>   Key. Discovered that tools live at `inventory/v1/inventory-definitions/supply-items`
+>   (not `tooling/v1/tools` as earlier docs claimed).
+> - **2026-04-09** — re-verified with the rotated `Datum` Consumer Key
+>   after the project rename. 23-request connectivity sweep + 6-request
+>   Get-by-ID chain test. Captured full field schemas + discovered that
+>   **supply-items have no foreign key to suppliers, parts, locations,
+>   or any other resource** (see §3.5 below). Also discovered the
+>   `scheduling/v1/jobs` endpoint (new — not in any earlier doc).
 
 ### URL pattern convention
 
@@ -52,6 +65,9 @@ Plex uses two URL shapes for read endpoints:
    Example: `production/v1/production-definitions/workcenters`,
    `inventory/v1/inventory-definitions/supply-items`,
    `inventory/v1/inventory-definitions/locations`
+3. **Flat with sub-namespace** (new 2026-04-09): `<namespace>/v1/<resource>`
+   — the `scheduling/v1/jobs` endpoint uses the first pattern but lives
+   under a namespace that wasn't previously catalogued.
 
 Both patterns are used in production. The bare `<namespace>/v1` root
 typically returns 404 (no resource at the root); the actual data lives
@@ -59,23 +75,86 @@ one level deeper.
 
 ### Verified working endpoints
 
-| Status | Path | Records | Notes |
-|---|---|---|---|
-| **200** | `mdm/v1/tenants` | 1 | Single tenant: Grace |
-| **200** | `mdm/v1/parts` | 16,913 | Finished products + raw materials. **No tools here** — the `type` field has only `Finished Good`, `Raw Material`, `Sub Assembly` |
-| **200** | `mdm/v1/parts/{id}` | — | Per-record GET works. Same fields as the list view (no hidden detail). |
-| **200** | `mdm/v1/suppliers` | — | 708 KB |
-| **200** | `mdm/v1/customers` | — | 96 KB |
-| **200** | `mdm/v1/contacts` | — | 202 KB |
-| **200** | `mdm/v1/buildings` | — | 1.2 KB |
-| **200** | `mdm/v1/employees` | — | 272 KB |
-| **200** | `mdm/v1/operations` | 122 | Minimal: `code, id, inventoryType, type`. No FK to tools/parts/routings. |
-| **200** | `mdm/v1/operations/{id}` | — | Per-record GET works. Same fields as list. |
-| **200** | `purchasing/v1/purchase-orders` | — | 44 MB unfiltered, full PO history |
-| **200** | `production/v1/production-definitions/workcenters` | 143 | All workcenters including the 21 MILLs (codes 879, 880 = Brother Speedio FTP IPs) |
-| **200** | `production/v1/production-definitions/workcenters/{id}` | — | Fields: `buildingCode, buildingId, ipAddress, name, plcName, productionLineId, tankSilo, workcenterCode, workcenterGroup, workcenterId, workcenterType` |
-| **200** | `inventory/v1/inventory-definitions/supply-items` | 2,516 | **TOOLS LIVE HERE.** Filter to `category="Tools & Inserts"` for the 1,109 cutting tools and inserts. Schema: `category, description, group, id, inventoryUnit, supplyItemNumber, type` |
-| **200** | `inventory/v1/inventory-definitions/locations` | — | 279 KB |
+Record counts are as of **2026-04-09** unless noted. Schemas captured
+2026-04-09 by the Get-by-ID chain test.
+
+| Status | Path | Records | Schema / Notes |
+|---|---|---:|---|
+| **200** | `mdm/v1/tenants` | 1 | Single tenant: Grace. Auth canary — run first in any session. |
+| **200** | `mdm/v1/parts` | **16,921** | +8 since 2026-04-07. 19.6 MB unfiltered. Tools are **NOT** here. Fields: `buildingCode, createdById, createdDate, description, group, id, leadTimeDays, modifiedById, modifiedDate, name, note, number, productType, revision, source, status, type`. `type` ∈ {`Finished Good`, `Raw Material`, `Sub Assembly`}. |
+| **200** | `mdm/v1/parts?status=Active` | — | 7.8 MB — only verified working filter. All other query params silently ignored. |
+| **200** | `mdm/v1/parts/{id}` | — | Same 17 fields as list view — no hidden detail. |
+| **200** | `mdm/v1/suppliers` | **1,575** | 709 KB. Fields: `category, code, contactNote, createdById, createdDate, id, language, modifiedById, modifiedDate, name, note, oldCode, parentSupplierId, status, type, webAddress`. `parentSupplierId` is a self-referential FK. First record is a `Carrier` — list mixes material suppliers, carriers, etc. |
+| **200** | `mdm/v1/suppliers/{id}` | — | Same 16 fields as list view. |
+| **200** | `mdm/v1/customers` | **109** | 96 KB. 35 fields. FKs to employees (`assignedToId`, `assignedTo2Id`, `assignedTo3Id`), contacts (`contactResourceId`), suppliers (`defaultCarrierIds` array, `supplierCode`). |
+| **200** | `mdm/v1/customers/{id}` | — | Same 35 fields as list view. |
+| **200** | `mdm/v1/contacts` | **299** | 202 KB. |
+| **200** | `mdm/v1/buildings` | **4** | 1.2 KB. Referenced from workcenters via `buildingCode`/`buildingId`. |
+| **200** | `mdm/v1/employees` | **641** | 272 KB. UUIDs appear as `createdById`/`modifiedById` across essentially every other resource. |
+| **200** | `mdm/v1/operations` | **122** | Minimal 4-field schema: `code, id, inventoryType, type`. **No FK to tools, parts, or routings** — the reason issue #5 is blocked. |
+| **200** | `mdm/v1/operations/{id}` | — | Same 4 fields as list view. |
+| **200** | `inventory/v1/inventory-definitions/supply-items` | **2,516** | 614 KB. Full unfiltered. |
+| **200** | `inventory/v1/inventory-definitions/supply-items?category=Tools%20%26%20Inserts` | **1,109** | **TOOLS LIVE HERE.** Fields: `category, description, group, id, inventoryUnit, supplyItemNumber, type`. **No supplier FK. No cross-references of any kind.** See §3.5. |
+| **200** | `inventory/v1/inventory-definitions/supply-items/{id}` | — | Same 7 fields as list view. |
+| **200** | `inventory/v1/inventory-definitions/locations` | **1,270** | 279 KB. Not cross-referenced from supply-item. |
+| **200** | `production/v1/production-definitions/workcenters` | **143** | 21 MILLs. ⚠️ **Primary key is `workcenterId`, not `id`.** Fields: `buildingCode, buildingId, ipAddress, name, plcName, productionLineId, tankSilo, workcenterCode, workcenterGroup, workcenterId, workcenterType`. |
+| **200** | `production/v1/production-definitions/workcenters/{id}` | — | Same 11 fields as list view. |
+| **200** | `purchasing/v1/purchase-orders` | — | **44.2 MB** unfiltered. Full PO history. `?updatedAfter=` filter confirmed as a silent no-op on 2026-04-09 (byte-identical response). |
+| **200** | `scheduling/v1/jobs` | TBD | **NEW — discovered 2026-04-09.** Returns 200 but **15.8s response time**, so the body is large. Schema, record count, and whether it carries tool/operation/workcenter FKs all TBD. Worth a deep-dive as follow-up to issue #5 (routing/operation linkage) — if jobs link to tools, we get the missing operation→tool mapping for free. |
+
+### Probed — returned 404 (not subscribed or doesn't exist)
+
+All of the following were probed on 2026-04-09 and returned `404 RESOURCE_NOT_FOUND`. Kept here so future sessions know they've been checked and don't waste a cycle re-testing them blindly. Re-probe periodically to detect subscription changes.
+
+| Path | First checked | Notes |
+|---|---|---|
+| `tooling/v1/tools` | 2026-04-07 (re-check 2026-04-09) | In original pre-Datum docs. Blocks #4. |
+| `tooling/v1/tool-assemblies` | 2026-04-07 (re-check 2026-04-09) | Blocks #4. |
+| `tooling/v1/assemblies` | 2026-04-09 | Alternate spelling, also 404. |
+| `manufacturing/v1/routings` | 2026-04-07 (re-check 2026-04-09) | Blocks #5. |
+| `quality/v1/inspections` | 2026-04-09 | Speculative probe. |
+| `sales/v1/sales-orders` | 2026-04-09 | Speculative probe. |
+| `inventory/v1/on-hand` | 2026-04-09 | Would have given tool stock levels. |
+| `inventory/v1/containers` | 2026-04-09 | |
+| `inventory/v1/inventory-definitions/container-types` | 2026-04-09 | |
+| `mdm/v1/parts-buckets` | 2026-04-09 | |
+| `production/v1/production-definitions/assets` | 2026-04-09 | |
+| `production/v1/production-definitions/assemblies` | 2026-04-09 | |
+| `purchasing/v1/purchase-orders-lines` | 2026-04-09 | Would have given supply-item → PO → supplier linkage. |
+
+### §3.5 — Supply-item cross-references: the critical finding
+
+**The `inventory/v1/inventory-definitions/supply-items` resource is identity-only.** Its 7 fields are:
+
+- `category` (string, e.g. `"Tools & Inserts"`)
+- `description` (free-text, human-readable)
+- `group` (string, e.g. `"Machining"`)
+- `id` (UUID — Plex primary key)
+- `inventoryUnit` (string, e.g. `"Ea"`)
+- `supplyItemNumber` (string — see below)
+- `type` (string, e.g. `"SUPPLY"`)
+
+**There is no field on this resource that references another resource.** Specifically:
+
+- No `supplierId` or `preferredSupplierId` — **you cannot derive the vendor for a tool from Plex alone.**
+- No `locationId` or `warehouseId` — you cannot ask "where is this tool right now?" via this endpoint.
+- No `partId` — supply-items are not linked to `mdm/v1/parts`.
+- No `workcenterId` — supply-items are not assigned to machines.
+- No `operationId` — supply-items are not linked to operations.
+
+**Implication for Datum sync architecture:** vendor/supplier data for tools MUST live in Supabase as the source of truth. The Fusion JSON carries `vendor` and `product-id`, those get written to the `tools` table in Supabase, and when `build_supply_item_payload()` (issue #3) constructs the Plex POST body it uses only the 7 identity fields. Plex never learns who the vendor is, because Plex doesn't model that relationship for tools.
+
+This finding also kills the hypothesis that PO lines could be used as a back-channel for the vendor link — `purchasing/v1/purchase-orders-lines` returned 404 on 2026-04-09.
+
+**Sample `supplyItemNumber` values captured 2026-04-09** (confirming the
+"legacy free-text descriptions, not vendor part numbers" observation
+from the 2026-04-08 Decision Log):
+
+- `"Insert  HM90 AXCR 150508 IC28"`
+- `"Screw Indexable Face Mill F75"`
+- `"Tap #8-32 H3 Spiral Point"`
+
+Fusion will insert clean vendor part numbers like `"990910"`, so expect essentially zero collision with existing Plex records on first sync.
 
 ### Where tooling data actually lives
 

--- a/docs/Postman_Collections.md
+++ b/docs/Postman_Collections.md
@@ -30,6 +30,8 @@ Both collections live in Shane's Grace Engineering Postman workspace.
 | **Plex API — Datum** | `75b28dc4-9c73-4e27-90d0-1539777f52ea` | `53648712-75b28dc4-9c73-4e27-90d0-1539777f52ea` |
 | **Fusion 360 Tool Libraries — Datum** | `8a9b5ce6-f541-4301-b15d-fd95970df0e8` | `53648712-8a9b5ce6-f541-4301-b15d-fd95970df0e8` |
 
+**Request counts as of 2026-04-09:** Plex collection has **36 requests** (34 reads + new `[SCHED] List Jobs` + expanded `[PROBE]` group with 2 new entries) across 8 `[NS]` prefix groups. Fusion collection has 14 requests across 4 groups.
+
 The bare collection ID (no owner prefix) is the form most Postman MCP
 endpoints want. The UID form (with the `53648712-` prefix) is what
 `getCollection`, `getCollections`, etc. return as a stable handle.
@@ -107,6 +109,13 @@ Postman to see the groups together.
 All paths are relative to `{{base_url}}` which resolves to
 `https://connect.plex.com` from the environment.
 
+> **Verification state (as of 2026-04-09).** 23 GET requests were run in
+> the 2026-04-09 connectivity sweep + 6 Get-by-ID requests in the chain
+> test. **18/23 returned 200, 5/23 returned 404, all 6 per-id endpoints
+> returned 200.** Zero 401s. Record counts and schemas in the tables
+> below come from that sweep. `[WRITE]` requests are NOT tested (per
+> user instruction, writes only run on explicit approval).
+
 ### `[AUTH]` — Auth & Diagnostics
 
 | Request | Method | Path | Status |
@@ -126,45 +135,53 @@ this matters.
 
 ### `[MDM]` — Master Data
 
+All records verified 2026-04-09. Per-id endpoints all return the exact same fields as the list view — no hidden detail.
+
 | Request | Method | Path | Verified | Notes |
 |---|---|---|---|---|
-| List Parts — Unfiltered | GET | `/mdm/v1/parts` | ✅ 16,913 records | **19.6 MB unfiltered.** Tools are NOT here. |
-| List Parts — Active only | GET | `/mdm/v1/parts?status=Active` | ✅ | Only filter that actually works on this endpoint. 19.6 MB → 7.8 MB. |
-| Get Part by ID | GET | `/mdm/v1/parts/:partId` | ✅ | Same fields as list view. |
-| List Suppliers | GET | `/mdm/v1/suppliers` | ✅ ~708 KB | `supplierId` is a UUID, not a code. Cached by `validate_library --use-api` for VENDOR_NOT_IN_PLEX. |
-| Get Supplier by ID | GET | `/mdm/v1/suppliers/:supplierId` | ⚠️ Pattern unverified | List view IS verified. |
-| List Customers | GET | `/mdm/v1/customers` | ✅ ~96 KB | |
-| Get Customer by ID | GET | `/mdm/v1/customers/:customerId` | ⚠️ Pattern unverified | |
-| List Contacts | GET | `/mdm/v1/contacts` | ✅ ~202 KB | |
-| List Buildings | GET | `/mdm/v1/buildings` | ✅ ~1.2 KB | Provides the `buildingCode`/`buildingId` from workcenters. |
-| List Employees | GET | `/mdm/v1/employees` | ✅ ~272 KB | |
-| List Operations | GET | `/mdm/v1/operations` | ✅ 122 records | Minimal schema — no FK to tools/parts/routings. |
-| Get Operation by ID | GET | `/mdm/v1/operations/:operationId` | ✅ | Same fields as list view. |
+| List Parts — Unfiltered | GET | `/mdm/v1/parts` | ✅ **16,921** records | **19.6 MB.** +8 since 2026-04-07. Tools are NOT here. 17 fields. |
+| List Parts — Active only | GET | `/mdm/v1/parts?status=Active` | ✅ 7.8 MB | Only filter that actually works on this endpoint. |
+| Get Part by ID | GET | `/mdm/v1/parts/:partId` | ✅ verified 2026-04-09 | Same 17 fields as list view. |
+| List Suppliers | GET | `/mdm/v1/suppliers` | ✅ **1,575** records / 709 KB | 16 fields. `parentSupplierId` self-FK. Mixes material suppliers + carriers. Cached by `validate_library --use-api`. |
+| Get Supplier by ID | GET | `/mdm/v1/suppliers/:supplierId` | ✅ verified 2026-04-09 | Same 16 fields. |
+| List Customers | GET | `/mdm/v1/customers` | ✅ **109** records / 96 KB | 35 fields. FKs to employees, contacts, suppliers. |
+| Get Customer by ID | GET | `/mdm/v1/customers/:customerId` | ✅ verified 2026-04-09 | Same 35 fields. |
+| List Contacts | GET | `/mdm/v1/contacts` | ✅ **299** records / 202 KB | |
+| List Buildings | GET | `/mdm/v1/buildings` | ✅ **4** records / 1.2 KB | Provides `buildingCode`/`buildingId` referenced by workcenters. |
+| List Employees | GET | `/mdm/v1/employees` | ✅ **641** records / 272 KB | UUIDs appear as `createdById`/`modifiedById` across every resource. |
+| List Operations | GET | `/mdm/v1/operations` | ✅ **122** records | Minimal 4-field schema — no FK to tools/parts/routings. Issue #5 blocker. |
+| Get Operation by ID | GET | `/mdm/v1/operations/:operationId` | ✅ verified 2026-04-09 | Same 4 fields. |
 
 ### `[INV]` — Inventory
 
 | Request | Method | Path | Verified | Notes |
 |---|---|---|---|---|
-| List Supply Items — All | GET | `/inventory/v1/inventory-definitions/supply-items` | ✅ 2,516 records | Full unfiltered, ~614 KB. |
-| List Supply Items — Tools & Inserts | GET | `/inventory/v1/inventory-definitions/supply-items?category=Tools%20%26%20Inserts` | ✅ 1,109 after client filter | **Target endpoint for the Fusion sync.** Has a test script asserting array shape and `category="Tools & Inserts"`. |
-| Get Supply Item by ID | GET | `/inventory/v1/inventory-definitions/supply-items/:supplyItemId` | ⚠️ Pattern unverified | |
-| List Inventory Locations | GET | `/inventory/v1/inventory-definitions/locations` | ✅ ~279 KB | |
+| List Supply Items — All | GET | `/inventory/v1/inventory-definitions/supply-items` | ✅ **2,516** records | Full unfiltered, ~614 KB. |
+| List Supply Items — Tools & Inserts | GET | `/inventory/v1/inventory-definitions/supply-items?category=Tools%20%26%20Inserts` | ✅ **1,109** after client filter | **Target endpoint for the Fusion sync.** ⚠️ **No supplier FK, no cross-refs of any kind — see §4.5.** Has a test script asserting schema. |
+| Get Supply Item by ID | GET | `/inventory/v1/inventory-definitions/supply-items/:supplyItemId` | ✅ verified 2026-04-09 | Same 7 fields as list view. No hidden detail. |
+| List Inventory Locations | GET | `/inventory/v1/inventory-definitions/locations` | ✅ **1,270** records / 279 KB | Not cross-referenced from supply-item. |
 
 ### `[PROD]` — Production
 
 | Request | Method | Path | Verified | Notes |
 |---|---|---|---|---|
-| List Workcenters | GET | `/production/v1/production-definitions/workcenters` | ✅ 143 records | Includes 21 MILLs. Test script logs the count. |
-| Get Workcenter by ID — generic | GET | `/production/v1/production-definitions/workcenters/:workcenterId` | ✅ | |
-| Get Workcenter — Brother Speedio 879 | GET | `/production/v1/production-definitions/workcenters/0b6cf62b-2809-4d3d-ab24-369cd0171f62` | ✅ | workcenterCode `879`, FTP `192.168.25.79`. |
-| Get Workcenter — Brother Speedio 880 | GET | `/production/v1/production-definitions/workcenters/8e262d5a-3ce8-4597-8726-d2b979b1b6b7` | ✅ | workcenterCode `880`, FTP `192.168.25.80`. |
+| List Workcenters | GET | `/production/v1/production-definitions/workcenters` | ✅ **143** records | Includes 21 MILLs. ⚠️ Primary key is `workcenterId`, not `id`. Test script logs the count. |
+| Get Workcenter by ID — generic | GET | `/production/v1/production-definitions/workcenters/:workcenterId` | ✅ verified 2026-04-09 | Same 11 fields as list view. |
+| Get Workcenter — Brother Speedio 879 | GET | `/production/v1/production-definitions/workcenters/0b6cf62b-2809-4d3d-ab24-369cd0171f62` | ✅ verified 2026-04-09 | workcenterCode `879`, FTP `192.168.25.79`. |
+| Get Workcenter — Brother Speedio 880 | GET | `/production/v1/production-definitions/workcenters/8e262d5a-3ce8-4597-8726-d2b979b1b6b7` | ✅ verified 2026-04-09 | workcenterCode `880`, FTP `192.168.25.80`. |
 
 ### `[PURCH]` — Purchasing
 
 | Request | Method | Path | Verified | Notes |
 |---|---|---|---|---|
-| List Purchase Orders — Unfiltered | GET | `/purchasing/v1/purchase-orders` | ✅ | **44 MB unfiltered. Be careful.** |
-| List Purchase Orders — Filtered (template) | GET | `/purchasing/v1/purchase-orders?updatedAfter=...&supplier=...` | ⚠️ Filter effectiveness unverified | Use as a probe template. |
+| List Purchase Orders — Unfiltered | GET | `/purchasing/v1/purchase-orders` | ✅ 44.2 MB | Full PO history. **Be careful — 44 MB every call.** |
+| List Purchase Orders — Filtered (template) | GET | `/purchasing/v1/purchase-orders?updatedAfter=...` | 🚫 **Filter is a silent no-op** (verified 2026-04-09) | Both filtered and unfiltered returned byte-identical 44.2 MB. Kept as a probe template for future Plex behavior changes. |
+
+### `[SCHED]` — Scheduling (new 2026-04-09)
+
+| Request | Method | Path | Verified | Notes |
+|---|---|---|---|---|
+| List Jobs | GET | `/scheduling/v1/jobs` | ✅ 200 (2026-04-09) | **New endpoint discovered during the 2026-04-09 sweep.** ~15.8s response (large body). Schema, record count, and FK structure all TBD. Potentially relevant to issue #5 if jobs carry tool references — would give the operation→tool mapping for free. |
 
 ### `[WRITE]` — Mutating requests
 
@@ -194,20 +211,54 @@ this matters.
 
 ### `[PROBE]` — Unverified namespaces
 
-| Request | Method | Path | Last Status |
-|---|---|---|---|
-| tooling/v1/tools | GET | `/tooling/v1/tools` | 404 (2026-04-07) |
-| tooling/v1/tool-assemblies | GET | `/tooling/v1/tool-assemblies` | 404 (2026-04-07) |
-| manufacturing/v1/routings | GET | `/manufacturing/v1/routings` | 404 (2026-04-07) |
-| quality/v1/inspections | GET | `/quality/v1/inspections` | Never tested |
-| sales/v1/sales-orders | GET | `/sales/v1/sales-orders` | Never tested |
+**All probes returned 404 on 2026-04-09.** Kept so future sessions know they've been checked.
+
+| Request | Method | Path | First checked | Last check |
+|---|---|---|---|---|
+| tooling/v1/tools | GET | `/tooling/v1/tools` | 2026-04-07 | **2026-04-09 — still 404** |
+| tooling/v1/tool-assemblies | GET | `/tooling/v1/tool-assemblies` | 2026-04-07 | **2026-04-09 — still 404** |
+| manufacturing/v1/routings | GET | `/manufacturing/v1/routings` | 2026-04-07 | **2026-04-09 — still 404** |
+| quality/v1/inspections | GET | `/quality/v1/inspections` | 2026-04-09 | **2026-04-09 — 404 (first check)** |
+| sales/v1/sales-orders | GET | `/sales/v1/sales-orders` | 2026-04-09 | **2026-04-09 — 404 (first check)** |
+| inventory/v1/on-hand | GET | `/inventory/v1/on-hand` | 2026-04-09 | **2026-04-09 — 404 (first check)** — would have given stock levels |
+| purchasing/v1/purchase-orders-lines | GET | `/purchasing/v1/purchase-orders-lines` | 2026-04-09 | **2026-04-09 — 404 (first check)** — would have enabled supply-item → supplier back-channel |
 
 The `tooling/v1/*` and `manufacturing/v1/*` paths were in the original
 pre-Datum API reference and worked for the previous developer on a
 different Plex deployment, but the Datum app subscription returns 404 for
-all of them. They're kept here so that if the subscription set ever
-changes, we can rerun the probes and detect it. See `docs/BRIEFING.md`
-History §3.
+all of them. `inventory/v1/on-hand` and `purchasing/v1/purchase-orders-lines`
+were added 2026-04-09 after being probed while investigating how to
+derive vendor/stock data for supply-items (neither exists).
+
+All are kept here so that if the subscription set ever changes, we can
+rerun the probes and detect it. See `docs/BRIEFING.md` History §3 and
+`docs/Plex_API_Reference.md` §3 "Probed — returned 404".
+
+### §4.5 — Supply-item cross-reference map (the critical finding)
+
+Re-verified 2026-04-09 via the Get-by-ID chain test:
+
+**`inventory/v1/inventory-definitions/supply-items` has NO cross-references to any other resource.** The record is identity-only, 7 fields:
+
+```
+category, description, group, id, inventoryUnit, supplyItemNumber, type
+```
+
+Specifically — this resource does NOT have:
+
+| Missing FK | Would have given us |
+|---|---|
+| `supplierId` / `preferredSupplierId` | Who to buy the tool from. **You cannot get a tool's vendor from Plex alone.** |
+| `locationId` / `warehouseId` | Where the tool physically is. |
+| `partId` | Which finished product this tool helps produce. |
+| `workcenterId` | Which machine the tool is assigned to. |
+| `operationId` | Which operation/process step the tool is used for. |
+
+**Consequence for Datum:** vendor data for tools MUST live in Supabase as the source of truth. The Fusion sync writes vendor + product-id + description + geometry to `libraries`/`tools`/`cutting_presets` in Supabase; `build_supply_item_payload()` (issue #3) then constructs the Plex POST body from only the 7 identity fields. Plex never learns who the vendor is — and that's fine, because nothing in Plex depends on that information.
+
+Also killed the "use PO lines as a back-channel for the vendor link" hypothesis — `purchasing/v1/purchase-orders-lines` returned 404 on 2026-04-09. There is no sub-resource for PO line items; they must be embedded in the parent PO records (verification pending).
+
+For the full cross-reference map of *which* relationships DO exist in Plex (e.g. customer→employee, workcenter→building, supplier→parentSupplier), see the Notion page **"Plex Data Model — Cross-References"** under the Datum project page.
 
 ---
 


### PR DESCRIPTION
## Summary

Full non-destructive connectivity verification of every non-write endpoint in the Plex Postman collection + Get-by-ID chain test that dumped schemas for all 6 verified resources. Per-user instruction: read-only, no writes touched the wire.

## Connectivity sweep results (2026-04-09)

- **23 GETs**: 18 returned 200, 5 returned 404, **zero 401s**, zero errors
- **6 Get-by-ID chain tests**: all returned 200; **every per-id view returns exactly the same fields as the list view** (no hidden detail on any resource)
- **1 new endpoint discovered**: `scheduling/v1/jobs` (200, ~15.8s response, schema TBD — potential unblock for issue #5 if it carries tool references)
- **7 additional paths probed, all 404**: `purchase-orders-lines`, `on-hand`, `containers`, `parts-buckets`, `assets`, `assemblies`, `container-types`
- **Filter no-op confirmed**: unfiltered and `?updatedAfter` filtered PO responses were byte-identical at 44.2 MB (downgraded from "UNVERIFIED" to "CONFIRMED NO-OP")

## Critical architectural finding

**`inventory/v1/inventory-definitions/supply-items` has NO cross-references to any other resource.** Zero `supplierId`, no `locationId`, no `partId`, no `workcenterId`, no `operationId`. Supply-items are identity-only: `{category, description, group, id, inventoryUnit, supplyItemNumber, type}`.

**You cannot derive a tool's vendor from Plex alone** — Datum must keep vendor data in Supabase as the source of truth. This is a confirmation, not a course-correction (the architecture already treats Supabase as the vendor authority). Also killed the "PO lines as a vendor back-channel" hypothesis — `purchasing/v1/purchase-orders-lines` returns 404.

## Fresh record counts captured

| Resource | Previous | 2026-04-09 |
|---|---:|---:|
| parts | 16,913 | **16,921** (+8) |
| suppliers | — | **1,575** |
| customers | — | **109** |
| contacts | — | **299** |
| buildings | — | **4** |
| employees | — | **641** |
| inventory-locations | — | **1,270** |
| supply-items (all / Tools) | 2,516 / 1,109 | 2,516 / 1,109 ✓ |
| workcenters | 143 | 143 ✓ |
| operations | 122 | 122 ✓ |

## Files updated

- `docs/Plex_API_Reference.md` — §3 access matrix rewritten with 2026-04-09 layer, full schemas captured, new "Probed — returned 404" table, new §3.5 on supply-item cross-references
- `docs/BRIEFING.md` — access matrix refreshed, "Where tooling data actually lives" rewritten around the no-FK finding, new session log entry
- `docs/Postman_Collections.md` — all tables updated with fresh counts, new `[SCHED]` row, expanded `[PROBE]` table, new §4.5 cross-reference map

## Also updated (not in diff — external systems)

- **Postman collection** (in-place via `updateCollectionRequest`): 23 descriptions rewritten + 3 new requests created (`[SCHED] List Jobs`, `[PROBE] inventory/v1/on-hand`, `[PROBE] purchasing/v1/purchase-orders-lines`). Plex collection now has **36 requests** total.
- **Notion**:
  - Decision Log entry appended to the Datum project page with full findings
  - **New child page** `Plex Data Model — Cross-References` with FK map, probed-404 table, and ASCII diagram
  - `Postman Collections — Datum` child page refreshed with 2026-04-09 state + critical-finding banner
  - Current State block updated: next-action candidates are now (a) `scheduling/v1/jobs` deep-dive, or (b) issue #3 `build_supply_item_payload`

## Test plan

- [x] `pytest` — 262 tests pass locally (docs-only changes)
- [ ] CI `pytest` check on this PR
- [ ] Next session: deep-dive `scheduling/v1/jobs` — if records carry tool/operation/workcenter FKs, that's the operation→tool linkage issue #5 has been blocked on

🤖 Generated with [Claude Code](https://claude.com/claude-code)