### PR TITLE
chore: gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ outputs/
 
 # Claude Code worktree scratch space
 .claude/worktrees/
+
+# Claude Code per-machine permissions cache (regenerated on demand)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Claude Code writes a per-machine permissions cache at \`.claude/settings.local.json\` that previously wasn't gitignored. The file is different on every developer's machine and regenerated on demand, so committing it would pollute shared repo state.

The existing \`.gitignore\` only had \`.claude/worktrees/\` under the "Claude Code" section. This adds a specific line for \`.claude/settings.local.json\` alongside it, rather than broadening to all of \`.claude/\` — that would also hide anything else we might later track there (e.g. shared \`.claude/commands/\` slash-command definitions).

Shipped as part of the 2026-04-09 session end-of-day housekeeping, alongside branch cleanup (44 merged branches removed locally + remote, stale worktrees pruned).

## Test plan

- [x] After the edit, \`git status\` no longer lists \`.claude/settings.local.json\` as untracked
- [ ] CI \`pytest\` check on this PR (should be green — .gitignore-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)