### PR TITLE
feat: APS cloud tool library integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,11 @@ PLEX_API_SECRET=your-consumer-secret-here
 # cutting_presets tables. NEVER ship the service role key to a browser.
 SUPABASE_URL=https://<your-datum-project-ref>.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-jwt-here
+
+# ── AUTODESK PLATFORM SERVICES (APS) — cloud tool libraries ──────
+# Register an app at https://aps.autodesk.com → Applications → Create.
+# App type: "Traditional Web App". Enable API: Data Management.
+# Required scopes: data:read
+APS_CLIENT_ID=your-aps-client-id-here
+APS_CLIENT_SECRET=your-aps-client-secret-here
+# APS_CALLBACK_URL=http://localhost:5000/api/aps/callback

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 .env.local
 .env.*.local
 
+# APS OAuth tokens — local-only, contains access/refresh tokens
+.aps_tokens.json
+
 # Node / frontend
 node_modules/
 

--- a/app.py
+++ b/app.py
@@ -33,6 +33,15 @@ from plex_api import (
 from tool_library_loader import load_all_libraries, CAM_TOOLS_DIR
 from plex_diagnostics import tenant_whoami, list_tenants, get_tenant
 from validate_library import validate_library, ValidationMode
+from aps_client import (
+    APSClient,
+    APSConfigError,
+    APSAuthError,
+    APSHTTPError,
+    APS_CLIENT_ID,
+)
+from sync_supabase import sync_library
+from supabase_client import SupabaseClient
 
 app = Flask(__name__)
 
@@ -536,6 +545,355 @@ def api_fusion_validate():
         return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
 
 
+# ─────────────────────────────────────────────
+# APS (Autodesk Platform Services) — cloud tool libraries
+# ─────────────────────────────────────────────
+# The APS client is initialized lazily (credentials are optional).
+# OAuth flow: browser hits /api/aps/login → Autodesk consent →
+# callback at /api/aps/callback → tokens stored in memory.
+_aps_client: APSClient | None = None
+
+
+def _get_aps_client() -> APSClient:
+    """Lazy-init the APS client. Raises APSConfigError if creds missing."""
+    global _aps_client
+    if _aps_client is None:
+        _aps_client = APSClient()
+        _aps_client._require_config()
+    return _aps_client
+
+
+@app.route('/api/aps/status')
+def api_aps_status():
+    """Check whether APS is configured and authenticated."""
+    has_config = bool(APS_CLIENT_ID)
+    has_token = False
+    if has_config:
+        try:
+            c = _get_aps_client()
+            has_token = c.tokens.is_valid
+        except APSConfigError:
+            has_config = False
+    return jsonify({
+        "status": "success",
+        "configured": has_config,
+        "authenticated": has_token,
+    })
+
+
+@app.route('/api/aps/login')
+def api_aps_login():
+    """Redirect the browser to Autodesk's OAuth consent page."""
+    try:
+        c = _get_aps_client()
+        url = c.get_authorize_url()
+        return jsonify({"status": "success", "authorize_url": url})
+    except APSConfigError as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@app.route('/api/aps/callback')
+def api_aps_callback():
+    """
+    OAuth callback — Autodesk redirects here with ?code=...
+    Exchanges the code for tokens and confirms success.
+    """
+    code = request.args.get("code")
+    if not code:
+        return jsonify({
+            "status": "error",
+            "message": "Missing 'code' parameter from Autodesk redirect.",
+        }), 400
+    try:
+        c = _get_aps_client()
+        c.exchange_code(code)
+        return jsonify({
+            "status": "success",
+            "message": "APS authentication successful. You can close this tab.",
+            "authenticated": True,
+        })
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@app.route('/api/aps/hubs')
+def api_aps_hubs():
+    """List Fusion Team hubs accessible to the authenticated user."""
+    try:
+        c = _get_aps_client()
+        hubs = c.get_hubs()
+        return jsonify({"status": "success", "count": len(hubs), "data": hubs})
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+
+
+@app.route('/api/aps/hubs/<path:hub_id>/projects')
+def api_aps_projects(hub_id):
+    """List projects in a hub."""
+    try:
+        c = _get_aps_client()
+        projects = c.get_projects(hub_id)
+        return jsonify({"status": "success", "count": len(projects), "data": projects})
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+
+
+@app.route('/api/aps/hubs/<path:hub_id>/projects/<path:project_id>/folders')
+def api_aps_top_folders(hub_id, project_id):
+    """List top-level folders in a project."""
+    try:
+        c = _get_aps_client()
+        folders = c.get_top_folders(hub_id, project_id)
+        return jsonify({"status": "success", "count": len(folders), "data": folders})
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+
+
+@app.route('/api/aps/projects/<path:project_id>/folders/<path:folder_id>/contents')
+def api_aps_folder_contents(project_id, folder_id):
+    """List items in a folder."""
+    try:
+        c = _get_aps_client()
+        contents = c.get_folder_contents(project_id, folder_id)
+        return jsonify({"status": "success", "count": len(contents), "data": contents})
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+
+
+@app.route('/api/aps/libraries')
+def api_aps_libraries():
+    """
+    Find all .tools files across all hubs (or a specific hub).
+    Query param: hub_id (optional) — restrict search to one hub.
+    """
+    hub_id = request.args.get("hub_id")
+    try:
+        c = _get_aps_client()
+        libs = c.find_tool_libraries(hub_id=hub_id)
+        return jsonify({"status": "success", "count": len(libs), "data": libs})
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+
+
+@app.route('/api/aps/items/<path:item_id>/tip')
+def api_aps_item_tip(item_id):
+    """Get the latest version (tip) of an item, including its storage URL."""
+    project_id = request.args.get("project_id")
+    if not project_id:
+        return jsonify({"status": "error", "message": "Missing 'project_id' query param."}), 400
+    try:
+        c = _get_aps_client()
+        tip = c.get_item_tip(project_id, item_id)
+        # Extract storage URL from the tip
+        storage_url = (
+            tip.get("relationships", {})
+            .get("storage", {})
+            .get("meta", {})
+            .get("link", {})
+            .get("href", "")
+        )
+        return jsonify({
+            "status": "success",
+            "data": tip,
+            "storage_url": storage_url,
+        })
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+
+
+@app.route('/api/aps/cam-tools')
+def api_aps_cam_tools():
+    """
+    List tool libraries in the known XWERKS > Assets > CAMTools folder.
+    Resolves storage URLs for each file so they're ready to download.
+    Much faster than the full hub scan.
+    """
+    # Known IDs from the XWERKS hub discovery
+    project_id = "a.YnVzaW5lc3M6Z3JhY2Vlbmc0I0QyMDI0MTIyMDg0OTIxNzc3Ng"
+    cam_tools_folder = "urn:adsk.wipprod:fs.folder:co.C0zYkNP4TOexre_-hWRhRA"
+
+    try:
+        c = _get_aps_client()
+        contents = c.get_folder_contents(project_id, cam_tools_folder)
+
+        libraries = []
+        for item in contents:
+            if item.get("type") != "items":
+                continue
+            name = item.get("attributes", {}).get("displayName", "")
+            item_id = item["id"]
+
+            # Get the tip version to find the storage URN (for signed download)
+            try:
+                tip = c.get_item_tip(project_id, item_id)
+                storage_url = (
+                    tip.get("relationships", {})
+                    .get("storage", {})
+                    .get("data", {})
+                    .get("id", "")
+                )
+                last_modified = tip.get("attributes", {}).get("lastModifiedTime", "")
+            except APSHTTPError:
+                storage_url = ""
+                last_modified = ""
+
+            libraries.append({
+                "name": name,
+                "item_id": item_id,
+                "storage_url": storage_url,
+                "last_modified": last_modified,
+            })
+
+        return jsonify({
+            "status": "success",
+            "count": len(libraries),
+            "data": libraries,
+        })
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+@app.route('/api/aps/libraries/download')
+def api_aps_library_download():
+    """
+    Download and parse a single tool library from APS.
+    Query param: storage_url (required) — the OSS storage URL from find_tool_libraries.
+    Returns the same shape as /api/fusion/tools (library_name, tool_count, tools_sample).
+    """
+    storage_url = request.args.get("storage_url")
+    if not storage_url:
+        return jsonify({
+            "status": "error",
+            "message": "Missing required 'storage_url' query param.",
+        }), 400
+    name = request.args.get("name", "cloud-library")
+    try:
+        c = _get_aps_client()
+        tools = c.download_tool_library(storage_url)
+        return jsonify({
+            "status": "success",
+            "library_name": name,
+            "tool_count": len(tools),
+            "tools_sample": tools[:5],
+            "data": tools,
+        })
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
+@app.route('/api/aps/sync', methods=['POST'])
+def api_aps_sync():
+    """
+    Download all cloud tool libraries from APS and sync them into Supabase.
+
+    Uses the known XWERKS > Assets > CAMTools folder path. For each
+    .json file found, downloads via signed S3, then calls sync_library()
+    to upsert into the libraries/tools/cutting_presets tables.
+
+    Returns per-library results and totals.
+    """
+    project_id = "a.YnVzaW5lc3M6Z3JhY2Vlbmc0I0QyMDI0MTIyMDg0OTIxNzc3Ng"
+    cam_tools_folder = "urn:adsk.wipprod:fs.folder:co.C0zYkNP4TOexre_-hWRhRA"
+
+    try:
+        aps = _get_aps_client()
+        sb = SupabaseClient()
+
+        contents = aps.get_folder_contents(project_id, cam_tools_folder)
+
+        results = []
+        total_tools = 0
+        total_presets = 0
+
+        for item in contents:
+            if item.get("type") != "items":
+                continue
+            name = item.get("attributes", {}).get("displayName", "")
+            if not name.endswith(".json"):
+                continue
+
+            item_id = item["id"]
+            library_name = name.replace(".json", "")
+
+            # Get storage URN from the tip
+            tip = aps.get_item_tip(project_id, item_id)
+            storage_urn = (
+                tip.get("relationships", {})
+                .get("storage", {})
+                .get("data", {})
+                .get("id", "")
+            )
+            if not storage_urn:
+                results.append({
+                    "library": library_name,
+                    "status": "error",
+                    "message": "No storage URN in tip",
+                })
+                continue
+
+            # Download and parse
+            tools = aps.download_tool_library(storage_urn)
+            if not tools:
+                results.append({
+                    "library": library_name,
+                    "status": "skipped",
+                    "message": "Empty or unparseable",
+                    "tools": 0,
+                    "presets": 0,
+                })
+                continue
+
+            # Sync to Supabase
+            counts = sync_library(
+                library_name,
+                tools,
+                client=sb,
+                file_path=f"aps://{item_id}",
+            )
+            total_tools += counts["tools"]
+            total_presets += counts["presets"]
+            results.append({
+                "library": library_name,
+                "status": "success",
+                "tools": counts["tools"],
+                "presets": counts["presets"],
+            })
+
+        return jsonify({
+            "status": "success",
+            "libraries_synced": len([r for r in results if r.get("status") == "success"]),
+            "total_tools": total_tools,
+            "total_presets": total_presets,
+            "results": results,
+        })
+    except (APSConfigError, APSAuthError) as e:
+        return jsonify({"status": "error", "message": str(e)}), 401
+    except APSHTTPError as e:
+        return jsonify({"status": "error", "message": str(e)}), e.status
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e), "trace": traceback.format_exc()}), 500
+
+
 @app.route('/api/config')
 def api_config():
     """Expose non-secret client config to the UI (base URL, tenant, env)."""
@@ -547,6 +905,7 @@ def api_config():
         "tenant_id": TENANT_ID,
         "has_key": bool(API_KEY),
         "has_secret": bool(API_SECRET),
+        "aps_configured": bool(APS_CLIENT_ID),
     })
 
 

--- a/aps_client.py
+++ b/aps_client.py
@@ -1,0 +1,590 @@
+"""
+aps_client.py
+Autodesk Platform Services (APS) OAuth + Data Management client
+Grace Engineering — Datum project
+=============================================================
+Handles 3-legged OAuth 2.0 with Autodesk and provides methods to
+traverse Fusion Team hubs to locate and download cloud tool library
+files (.tools / .json).
+
+This eliminates the need for Fusion 360 or Autodesk Desktop Connector
+to be installed locally. The pipeline is:
+
+  APS Hub -> download .tools file -> unzip -> parse JSON
+  -> same schema as local CAMTools files -> Supabase ingest
+
+Credentials come from environment variables loaded via ``bootstrap.py``:
+
+  APS_CLIENT_ID        App client ID from aps.autodesk.com
+  APS_CLIENT_SECRET    App client secret
+  APS_CALLBACK_URL     OAuth redirect URI (default: http://localhost:5000/api/aps/callback)
+
+Token state is persisted to a local file (``.aps_tokens.json``, gitignored)
+so tokens survive Flask debug reloads and process restarts. A production
+deploy would use an encrypted store or database instead.
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+
+import bootstrap  # noqa: F401 — loads .env.local into os.environ on import
+
+log = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────
+# Configuration
+# ─────────────────────────────────────────────
+APS_CLIENT_ID = os.environ.get("APS_CLIENT_ID", "")
+APS_CLIENT_SECRET = os.environ.get("APS_CLIENT_SECRET", "")
+APS_CALLBACK_URL = os.environ.get(
+    "APS_CALLBACK_URL", "http://localhost:5000/api/aps/callback"
+)
+
+APS_AUTH_BASE = "https://developer.api.autodesk.com/authentication/v2"
+APS_DM_BASE = "https://developer.api.autodesk.com"
+
+# Scopes needed for reading hub data (tool libraries live in the hub)
+DEFAULT_SCOPES = "data:read"
+
+DEFAULT_TIMEOUT = 30  # seconds
+
+
+# ─────────────────────────────────────────────
+# Exceptions
+# ─────────────────────────────────────────────
+class APSConfigError(RuntimeError):
+    """Raised when APS_CLIENT_ID or APS_CLIENT_SECRET is missing."""
+
+
+class APSAuthError(RuntimeError):
+    """Raised when OAuth flow fails (bad code, expired token, etc.)."""
+
+
+class APSHTTPError(RuntimeError):
+    """Raised when an APS API call returns a non-2xx response."""
+
+    def __init__(self, status: int, body: Any, url: str):
+        self.status = status
+        self.body = body
+        self.url = url
+        super().__init__(f"APS {status} on {url}: {body}")
+
+
+# ─────────────────────────────────────────────
+# Token store (file-backed, single-user)
+# ─────────────────────────────────────────────
+# Default token file lives next to .env.local — both are gitignored.
+_DEFAULT_TOKEN_PATH = Path(__file__).resolve().parent / ".aps_tokens.json"
+
+
+class TokenStore:
+    """
+    Persists OAuth tokens to a local JSON file so they survive Flask
+    debug reloads and process restarts.
+
+    Parameters
+    ----------
+    path : Path | None
+        File to persist tokens to. ``None`` disables persistence
+        (pure in-memory, useful for tests).
+    """
+
+    def __init__(self, path: Path | None = _DEFAULT_TOKEN_PATH):
+        self._path = path
+        self.access_token: str | None = None
+        self.refresh_token: str | None = None
+        self.expires_at: float = 0.0  # epoch seconds
+        self._load()
+
+    @property
+    def is_valid(self) -> bool:
+        return bool(self.access_token) and time.time() < self.expires_at
+
+    def update(self, data: dict) -> None:
+        self.access_token = data["access_token"]
+        self.refresh_token = data.get("refresh_token")
+        self.expires_at = time.time() + data.get("expires_in", 3600) - 60
+        self._save()
+
+    def clear(self) -> None:
+        self.access_token = None
+        self.refresh_token = None
+        self.expires_at = 0.0
+        if self._path and self._path.exists():
+            self._path.unlink()
+
+    def _save(self) -> None:
+        if not self._path:
+            return
+        try:
+            self._path.write_text(json.dumps({
+                "access_token": self.access_token,
+                "refresh_token": self.refresh_token,
+                "expires_at": self.expires_at,
+            }), encoding="utf-8")
+        except OSError as e:
+            log.warning("Could not persist APS tokens: %s", e)
+
+    def _load(self) -> None:
+        if not self._path or not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            self.access_token = data.get("access_token")
+            self.refresh_token = data.get("refresh_token")
+            self.expires_at = data.get("expires_at", 0.0)
+        except (OSError, json.JSONDecodeError, KeyError) as e:
+            log.warning("Could not load APS tokens from %s: %s", self._path, e)
+
+
+# ─────────────────────────────────────────────
+# Client
+# ─────────────────────────────────────────────
+class APSClient:
+    """
+    Autodesk Platform Services client for OAuth and Data Management API.
+
+    Parameters
+    ----------
+    client_id : str | None
+        APS app client ID. Defaults to ``APS_CLIENT_ID`` env var.
+    client_secret : str | None
+        APS app client secret. Defaults to ``APS_CLIENT_SECRET`` env var.
+    callback_url : str | None
+        OAuth redirect URI. Defaults to ``APS_CALLBACK_URL`` env var.
+    timeout : int
+        Per-request timeout in seconds.
+    token_path : Path | None | str
+        File to persist tokens to. Pass ``None`` to disable persistence
+        (in-memory only, useful for tests). Defaults to ``.aps_tokens.json``.
+    """
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        callback_url: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        token_path: Path | None | str = _DEFAULT_TOKEN_PATH,
+    ):
+        self.client_id = client_id or APS_CLIENT_ID
+        self.client_secret = client_secret or APS_CLIENT_SECRET
+        self.callback_url = callback_url or APS_CALLBACK_URL
+        self.timeout = timeout
+        self.tokens = TokenStore(path=Path(token_path) if token_path else None)
+        self._session = requests.Session()
+
+    # ─────────────────────────────────────────
+    # Config validation
+    # ─────────────────────────────────────────
+    def _require_config(self) -> None:
+        if not self.client_id:
+            raise APSConfigError(
+                "APS_CLIENT_ID is not set. Register an app at "
+                "https://aps.autodesk.com and add the client ID to .env.local."
+            )
+        if not self.client_secret:
+            raise APSConfigError(
+                "APS_CLIENT_SECRET is not set. Add it to .env.local."
+            )
+
+    def _require_token(self) -> None:
+        if not self.tokens.is_valid:
+            raise APSAuthError(
+                "No valid APS access token. Complete the OAuth flow first "
+                "by visiting /api/aps/login in your browser."
+            )
+
+    # ─────────────────────────────────────────
+    # OAuth 2.0 — 3-legged flow
+    # ─────────────────────────────────────────
+    def get_authorize_url(self, scopes: str = DEFAULT_SCOPES) -> str:
+        """
+        Build the Autodesk authorization URL. Redirect the user's browser here.
+        After consent, Autodesk redirects back to ``callback_url`` with a code.
+        """
+        self._require_config()
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.callback_url,
+            "scope": scopes,
+        }
+        return f"{APS_AUTH_BASE}/authorize?{urlencode(params)}"
+
+    def exchange_code(self, code: str) -> dict:
+        """
+        Exchange an authorization code for access + refresh tokens.
+        Called from the OAuth callback handler.
+        """
+        self._require_config()
+        resp = self._session.post(
+            f"{APS_AUTH_BASE}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "redirect_uri": self.callback_url,
+            },
+            timeout=self.timeout,
+        )
+        if not resp.ok:
+            raise APSAuthError(
+                f"Token exchange failed: {resp.status_code} {resp.text}"
+            )
+        data = resp.json()
+        self.tokens.update(data)
+        log.info("APS OAuth tokens acquired (expires in %ss)", data.get("expires_in"))
+        return data
+
+    def refresh_access_token(self) -> dict:
+        """Use the refresh token to get a new access token."""
+        self._require_config()
+        if not self.tokens.refresh_token:
+            raise APSAuthError(
+                "No refresh token available. Re-authenticate via /api/aps/login."
+            )
+        resp = self._session.post(
+            f"{APS_AUTH_BASE}/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": self.tokens.refresh_token,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            },
+            timeout=self.timeout,
+        )
+        if not resp.ok:
+            raise APSAuthError(
+                f"Token refresh failed: {resp.status_code} {resp.text}"
+            )
+        data = resp.json()
+        self.tokens.update(data)
+        log.info("APS tokens refreshed")
+        return data
+
+    def _ensure_token(self) -> None:
+        """Auto-refresh if the current token is expired but we have a refresh token."""
+        if self.tokens.is_valid:
+            return
+        if self.tokens.refresh_token:
+            self.refresh_access_token()
+            return
+        raise APSAuthError(
+            "APS token expired and no refresh token available. "
+            "Re-authenticate via /api/aps/login."
+        )
+
+    # ─────────────────────────────────────────
+    # Authenticated API calls
+    # ─────────────────────────────────────────
+    def _authed_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.tokens.access_token}",
+            "Content-Type": "application/json",
+        }
+
+    def _get(self, url: str, params: dict | None = None) -> Any:
+        """Authenticated GET. Returns parsed JSON."""
+        self._ensure_token()
+        resp = self._session.get(
+            url,
+            headers=self._authed_headers(),
+            params=params,
+            timeout=self.timeout,
+        )
+        if not resp.ok:
+            try:
+                body = resp.json()
+            except ValueError:
+                body = resp.text
+            raise APSHTTPError(resp.status_code, body, resp.url)
+        return resp.json()
+
+    def _get_binary(self, url: str) -> bytes:
+        """Authenticated GET returning raw bytes (for file downloads)."""
+        self._ensure_token()
+        resp = self._session.get(
+            url,
+            headers={"Authorization": f"Bearer {self.tokens.access_token}"},
+            timeout=self.timeout,
+        )
+        if not resp.ok:
+            raise APSHTTPError(resp.status_code, resp.text, resp.url)
+        return resp.content
+
+    # ─────────────────────────────────────────
+    # Data Management API — hub traversal
+    # ─────────────────────────────────────────
+    def get_hubs(self) -> list[dict]:
+        """List all hubs the authenticated user can access."""
+        data = self._get(f"{APS_DM_BASE}/project/v1/hubs")
+        return data.get("data", [])
+
+    def get_projects(self, hub_id: str) -> list[dict]:
+        """List projects within a hub."""
+        data = self._get(f"{APS_DM_BASE}/project/v1/hubs/{hub_id}/projects")
+        return data.get("data", [])
+
+    def get_top_folders(self, hub_id: str, project_id: str) -> list[dict]:
+        """List top-level folders in a project."""
+        data = self._get(
+            f"{APS_DM_BASE}/project/v1/hubs/{hub_id}/projects/{project_id}/topFolders"
+        )
+        return data.get("data", [])
+
+    def get_folder_contents(
+        self, project_id: str, folder_id: str
+    ) -> list[dict]:
+        """List items in a folder."""
+        data = self._get(
+            f"{APS_DM_BASE}/data/v1/projects/{project_id}/folders/{folder_id}/contents"
+        )
+        return data.get("data", [])
+
+    def search_folder(
+        self, project_id: str, folder_id: str, filter_name: str = ""
+    ) -> list[dict]:
+        """
+        Search within a folder. Useful for finding .tools files by name.
+        """
+        params = {}
+        if filter_name:
+            params["filter[displayName]"] = filter_name
+        data = self._get(
+            f"{APS_DM_BASE}/data/v1/projects/{project_id}/folders/{folder_id}/search",
+            params=params,
+        )
+        return data.get("data", [])
+
+    def get_item_versions(self, project_id: str, item_id: str) -> list[dict]:
+        """List versions of an item (to get download links)."""
+        data = self._get(
+            f"{APS_DM_BASE}/data/v1/projects/{project_id}/items/{item_id}/versions"
+        )
+        return data.get("data", [])
+
+    def get_item_tip(self, project_id: str, item_id: str) -> dict:
+        """Get the latest version (tip) of an item."""
+        data = self._get(
+            f"{APS_DM_BASE}/data/v1/projects/{project_id}/items/{item_id}/tip"
+        )
+        return data.get("data", {})
+
+    # ─────────────────────────────────────────
+    # File download + parsing
+    # ─────────────────────────────────────────
+    def download_version(self, storage_url: str) -> bytes:
+        """
+        Download a file by its storage info.
+
+        Accepts either:
+        - An ``urn:adsk.objects:os.object:BUCKET/OBJECT`` URN
+          (from ``relationships.storage.data.id``)
+        - A legacy ``/oss/v2/buckets/...`` URL
+          (from ``relationships.storage.meta.link.href``)
+
+        Uses the signed S3 download endpoint (the old direct OSS v2
+        GET is deprecated and returns 403).
+        """
+        # Parse bucket and object key from URN or URL
+        bucket, obj_key = self._parse_storage_id(storage_url)
+        if not bucket or not obj_key:
+            raise APSHTTPError(
+                400,
+                f"Cannot parse storage reference: {storage_url}",
+                storage_url,
+            )
+
+        # Get a signed S3 download URL
+        sign_resp = self._get(
+            f"{APS_DM_BASE}/oss/v2/buckets/{bucket}/objects/{obj_key}/signeds3download"
+        )
+        signed_url = sign_resp.get("url")
+        if not signed_url:
+            raise APSHTTPError(
+                500,
+                f"No signed URL returned for {bucket}/{obj_key}",
+                storage_url,
+            )
+
+        # Download from S3 (no auth header needed — the URL is pre-signed)
+        resp = self._session.get(signed_url, timeout=self.timeout)
+        if not resp.ok:
+            raise APSHTTPError(resp.status_code, resp.text, signed_url)
+        return resp.content
+
+    @staticmethod
+    def _parse_storage_id(ref: str) -> tuple[str, str]:
+        """
+        Extract (bucket, object_key) from a storage URN or URL.
+
+        URN format: ``urn:adsk.objects:os.object:wip.dm.prod/abc-123.json``
+        URL format: ``.../oss/v2/buckets/wip.dm.prod/objects/abc-123.json?...``
+        """
+        # URN form
+        if ref.startswith("urn:adsk.objects:os.object:"):
+            path = ref.split("urn:adsk.objects:os.object:")[-1]
+            parts = path.split("/", 1)
+            if len(parts) == 2:
+                return parts[0], parts[1]
+
+        # URL form
+        if "/oss/v2/buckets/" in ref:
+            # .../oss/v2/buckets/{bucket}/objects/{object}?...
+            segment = ref.split("/oss/v2/buckets/")[-1]
+            segment = segment.split("?")[0]  # strip query params
+            parts = segment.split("/objects/", 1)
+            if len(parts) == 2:
+                return parts[0], parts[1]
+
+        return "", ""
+
+    def download_tool_library(self, storage_url: str) -> list[dict]:
+        """
+        Download a .tools file and extract the JSON tool data.
+
+        .tools files are ZIP archives containing a single JSON file
+        with the same schema as local Fusion tool library exports:
+        ``{"data": [<tool objects>], ...}``
+
+        Returns the list of tool dicts (the "data" array), matching
+        the return type of ``tool_library_loader.load_library()``.
+        """
+        raw_bytes = self.download_version(storage_url)
+
+        # Try ZIP first (.tools files are typically zipped)
+        try:
+            with zipfile.ZipFile(io.BytesIO(raw_bytes)) as zf:
+                names = zf.namelist()
+                # Find the JSON file inside
+                json_name = next(
+                    (n for n in names if n.endswith(".json")), names[0]
+                )
+                with zf.open(json_name) as jf:
+                    parsed = json.load(jf)
+        except zipfile.BadZipFile:
+            # Not a ZIP — might be raw JSON (some exports)
+            parsed = json.loads(raw_bytes)
+
+        # Extract the "data" array
+        if isinstance(parsed, dict) and "data" in parsed:
+            tools = parsed["data"]
+        elif isinstance(parsed, list):
+            tools = parsed
+        else:
+            log.warning(
+                "Unexpected tool library structure from %s — no 'data' key",
+                storage_url,
+            )
+            return []
+
+        if not isinstance(tools, list):
+            return []
+
+        log.info(
+            "Downloaded tool library from APS: %d entries", len(tools)
+        )
+        return tools
+
+    # ─────────────────────────────────────────
+    # High-level: find tool libraries in hub
+    # ─────────────────────────────────────────
+    def find_tool_libraries(
+        self, hub_id: str | None = None
+    ) -> list[dict]:
+        """
+        Walk the hub to find .tools files. Returns a list of dicts:
+
+            [{"name": "MyLibrary.tools",
+              "item_id": "urn:...",
+              "project_id": "...",
+              "hub_id": "...",
+              "storage_url": "https://..."}, ...]
+
+        If ``hub_id`` is None, searches all accessible hubs.
+        """
+        results = []
+        hubs = [{"id": hub_id}] if hub_id else self.get_hubs()
+
+        for hub in hubs:
+            hid = hub["id"]
+            projects = self.get_projects(hid)
+
+            for project in projects:
+                pid = project["id"]
+                try:
+                    top_folders = self.get_top_folders(hid, pid)
+                except APSHTTPError:
+                    log.debug("Skipping project %s — can't list folders", pid)
+                    continue
+
+                for folder in top_folders:
+                    fid = folder["id"]
+                    self._scan_folder_for_tools(
+                        hid, pid, fid, results, depth=0
+                    )
+
+        return results
+
+    def _scan_folder_for_tools(
+        self,
+        hub_id: str,
+        project_id: str,
+        folder_id: str,
+        results: list[dict],
+        depth: int = 0,
+        max_depth: int = 5,
+    ) -> None:
+        """Recursively scan folders for .tools files."""
+        if depth > max_depth:
+            return
+
+        try:
+            contents = self.get_folder_contents(project_id, folder_id)
+        except APSHTTPError:
+            return
+
+        for item in contents:
+            item_type = item.get("type", "")
+            name = item.get("attributes", {}).get("displayName", "")
+
+            if item_type == "folders":
+                # Recurse into subfolders
+                self._scan_folder_for_tools(
+                    hub_id, project_id, item["id"], results, depth + 1
+                )
+
+            elif item_type == "items" and (
+                name.endswith(".tools") or name.endswith(".json")
+            ):
+                # Found a tool library file — get its download URL
+                try:
+                    tip = self.get_item_tip(project_id, item["id"])
+                    storage = (
+                        tip.get("relationships", {})
+                        .get("storage", {})
+                        .get("meta", {})
+                        .get("link", {})
+                        .get("href", "")
+                    )
+                    results.append({
+                        "name": name,
+                        "item_id": item["id"],
+                        "project_id": project_id,
+                        "hub_id": hub_id,
+                        "storage_url": storage,
+                    })
+                except APSHTTPError as e:
+                    log.warning("Could not get tip for %s: %s", name, e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ os.environ.setdefault("PLEX_API_SECRET", "test-secret-do-not-use")
 os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
 os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-supabase-key-do-not-use")
 
+# Dummy APS credentials so aps_client imports cleanly. Tests patch
+# requests.Session — no real Autodesk calls are made.
+os.environ.setdefault("APS_CLIENT_ID", "test-aps-client-id")
+os.environ.setdefault("APS_CLIENT_SECRET", "test-aps-client-secret")
+
 
 # ─────────────────────────────────────────────
 # Shared fixtures

--- a/tests/test_aps_client.py
+++ b/tests/test_aps_client.py
@@ -1,0 +1,414 @@
+"""
+Tests for aps_client.py — APS OAuth + Data Management client.
+
+Focuses on:
+  - Config errors when env vars are missing
+  - OAuth URL generation
+  - Token exchange and refresh mechanics
+  - Token persistence to file
+  - Hub/project/folder traversal (mocked HTTP)
+  - .tools file download via signed S3 URL
+  - Storage ID parsing (URN and URL formats)
+  - Auto-refresh on expired tokens
+
+All HTTP traffic is patched — no real network calls.
+"""
+from __future__ import annotations
+
+import io
+import json
+import time
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from aps_client import (
+    APSClient,
+    APSConfigError,
+    APSAuthError,
+    APSHTTPError,
+    TokenStore,
+)
+
+
+# ─────────────────────────────────────────────
+# Token store — in-memory (path=None)
+# ─────────────────────────────────────────────
+class TestTokenStore:
+    def test_initially_invalid(self):
+        store = TokenStore(path=None)
+        assert not store.is_valid
+
+    def test_update_makes_valid(self):
+        store = TokenStore(path=None)
+        store.update({
+            "access_token": "tok123",
+            "refresh_token": "ref456",
+            "expires_in": 3600,
+        })
+        assert store.is_valid
+        assert store.access_token == "tok123"
+        assert store.refresh_token == "ref456"
+
+    def test_expired_token_is_invalid(self):
+        store = TokenStore(path=None)
+        store.update({
+            "access_token": "tok",
+            "expires_in": 0,  # already expired (minus 60s buffer)
+        })
+        assert not store.is_valid
+
+    def test_clear_invalidates(self):
+        store = TokenStore(path=None)
+        store.update({"access_token": "tok", "expires_in": 3600})
+        store.clear()
+        assert not store.is_valid
+
+
+# ─────────────────────────────────────────────
+# Token store — file persistence
+# ─────────────────────────────────────────────
+class TestTokenPersistence:
+    def test_save_and_load(self, tmp_path):
+        token_file = tmp_path / ".aps_tokens.json"
+
+        # Save tokens
+        store1 = TokenStore(path=token_file)
+        store1.update({
+            "access_token": "persisted-at",
+            "refresh_token": "persisted-rt",
+            "expires_in": 3600,
+        })
+        assert token_file.exists()
+
+        # Load into a new store
+        store2 = TokenStore(path=token_file)
+        assert store2.access_token == "persisted-at"
+        assert store2.refresh_token == "persisted-rt"
+        assert store2.is_valid
+
+    def test_clear_deletes_file(self, tmp_path):
+        token_file = tmp_path / ".aps_tokens.json"
+        store = TokenStore(path=token_file)
+        store.update({"access_token": "tok", "expires_in": 3600})
+        assert token_file.exists()
+        store.clear()
+        assert not token_file.exists()
+
+    def test_missing_file_is_ok(self, tmp_path):
+        token_file = tmp_path / "nonexistent.json"
+        store = TokenStore(path=token_file)
+        assert not store.is_valid
+
+    def test_corrupt_file_is_ok(self, tmp_path):
+        token_file = tmp_path / ".aps_tokens.json"
+        token_file.write_text("not json", encoding="utf-8")
+        store = TokenStore(path=token_file)
+        assert not store.is_valid
+
+
+# ─────────────────────────────────────────────
+# Config errors
+# ─────────────────────────────────────────────
+class TestConfigErrors:
+    def test_missing_client_id_raises(self, monkeypatch):
+        monkeypatch.delenv("APS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("APS_CLIENT_SECRET", raising=False)
+        monkeypatch.setattr("aps_client.APS_CLIENT_ID", "")
+        monkeypatch.setattr("aps_client.APS_CLIENT_SECRET", "s")
+        client = APSClient(client_id="", client_secret="s", token_path=None)
+        with pytest.raises(APSConfigError, match="APS_CLIENT_ID"):
+            client._require_config()
+
+    def test_missing_client_secret_raises(self, monkeypatch):
+        monkeypatch.setattr("aps_client.APS_CLIENT_ID", "id")
+        monkeypatch.setattr("aps_client.APS_CLIENT_SECRET", "")
+        client = APSClient(client_id="id", client_secret="", token_path=None)
+        with pytest.raises(APSConfigError, match="APS_CLIENT_SECRET"):
+            client._require_config()
+
+    def test_explicit_args_work(self):
+        client = APSClient(
+            client_id="my-id",
+            client_secret="my-secret",
+            callback_url="http://localhost:9999/cb",
+            token_path=None,
+        )
+        assert client.client_id == "my-id"
+        assert client.client_secret == "my-secret"
+        assert client.callback_url == "http://localhost:9999/cb"
+
+
+# ─────────────────────────────────────────────
+# OAuth URL generation
+# ─────────────────────────────────────────────
+class TestAuthorizeURL:
+    def test_url_contains_client_id(self):
+        client = APSClient(client_id="test-id", client_secret="test-secret", token_path=None)
+        url = client.get_authorize_url()
+        assert "client_id=test-id" in url
+        assert "response_type=code" in url
+        assert "scope=data%3Aread" in url
+
+    def test_url_contains_callback(self):
+        client = APSClient(
+            client_id="id",
+            client_secret="s",
+            callback_url="http://example.com/cb",
+            token_path=None,
+        )
+        url = client.get_authorize_url()
+        assert "redirect_uri=http%3A%2F%2Fexample.com%2Fcb" in url
+
+
+# ─────────────────────────────────────────────
+# Token exchange
+# ─────────────────────────────────────────────
+class TestExchangeCode:
+    def test_successful_exchange(self):
+        client = APSClient(client_id="id", client_secret="secret", token_path=None)
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 3600,
+        }
+
+        with patch.object(client._session, "post", return_value=mock_resp):
+            data = client.exchange_code("authcode123")
+
+        assert data["access_token"] == "at"
+        assert client.tokens.is_valid
+
+    def test_failed_exchange_raises(self):
+        client = APSClient(client_id="id", client_secret="secret", token_path=None)
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 401
+        mock_resp.text = "invalid_grant"
+
+        with patch.object(client._session, "post", return_value=mock_resp):
+            with pytest.raises(APSAuthError, match="401"):
+                client.exchange_code("badcode")
+
+
+class TestRefreshToken:
+    def test_refresh_updates_tokens(self):
+        client = APSClient(client_id="id", client_secret="secret", token_path=None)
+        client.tokens.refresh_token = "old-rt"
+
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "access_token": "new-at",
+            "refresh_token": "new-rt",
+            "expires_in": 3600,
+        }
+
+        with patch.object(client._session, "post", return_value=mock_resp):
+            client.refresh_access_token()
+
+        assert client.tokens.access_token == "new-at"
+        assert client.tokens.refresh_token == "new-rt"
+
+    def test_no_refresh_token_raises(self):
+        client = APSClient(client_id="id", client_secret="secret", token_path=None)
+        with pytest.raises(APSAuthError, match="No refresh token"):
+            client.refresh_access_token()
+
+
+# ─────────────────────────────────────────────
+# Data Management API calls
+# ─────────────────────────────────────────────
+def _authed_client() -> APSClient:
+    """Return a client with a valid (fake) token, no file persistence."""
+    client = APSClient(client_id="id", client_secret="secret", token_path=None)
+    client.tokens.update({
+        "access_token": "valid-token",
+        "expires_in": 3600,
+    })
+    return client
+
+
+class TestGetHubs:
+    def test_returns_hub_list(self):
+        client = _authed_client()
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "data": [{"id": "hub1", "type": "hubs"}]
+        }
+
+        with patch.object(client._session, "get", return_value=mock_resp):
+            hubs = client.get_hubs()
+
+        assert len(hubs) == 1
+        assert hubs[0]["id"] == "hub1"
+
+
+class TestGetProjects:
+    def test_returns_project_list(self):
+        client = _authed_client()
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "data": [{"id": "proj1", "type": "projects"}]
+        }
+
+        with patch.object(client._session, "get", return_value=mock_resp):
+            projects = client.get_projects("hub1")
+
+        assert len(projects) == 1
+        assert projects[0]["id"] == "proj1"
+
+
+class TestHTTPErrors:
+    def test_non_2xx_raises_aps_http_error(self):
+        client = _authed_client()
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 403
+        mock_resp.json.return_value = {"reason": "Forbidden"}
+        mock_resp.url = "https://developer.api.autodesk.com/project/v1/hubs"
+
+        with patch.object(client._session, "get", return_value=mock_resp):
+            with pytest.raises(APSHTTPError) as exc_info:
+                client.get_hubs()
+            assert exc_info.value.status == 403
+
+
+# ─────────────────────────────────────────────
+# Storage ID parsing
+# ─────────────────────────────────────────────
+class TestParseStorageId:
+    def test_urn_format(self):
+        bucket, key = APSClient._parse_storage_id(
+            "urn:adsk.objects:os.object:wip.dm.prod/abc-123.json"
+        )
+        assert bucket == "wip.dm.prod"
+        assert key == "abc-123.json"
+
+    def test_url_format(self):
+        bucket, key = APSClient._parse_storage_id(
+            "https://developer.api.autodesk.com/oss/v2/buckets/wip.dm.prod/objects/abc-123.json?scopes=global"
+        )
+        assert bucket == "wip.dm.prod"
+        assert key == "abc-123.json"
+
+    def test_unknown_format_returns_empty(self):
+        bucket, key = APSClient._parse_storage_id("something-else")
+        assert bucket == ""
+        assert key == ""
+
+
+# ─────────────────────────────────────────────
+# Tool library download + parsing (signed S3)
+# ─────────────────────────────────────────────
+class TestDownloadToolLibrary:
+    def _make_tools_zip(self, tools: list[dict]) -> bytes:
+        """Create a fake .tools ZIP containing a JSON file."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("library.json", json.dumps({"data": tools}))
+        return buf.getvalue()
+
+    def _mock_signed_download(self, client, content_bytes):
+        """
+        Mock the two-step signed S3 download:
+        1. GET /oss/v2/buckets/.../signeds3download → {"url": "https://s3..."}
+        2. GET https://s3... → raw bytes
+        """
+        sign_resp = MagicMock()
+        sign_resp.ok = True
+        sign_resp.json.return_value = {"url": "https://s3.signed.example.com/file"}
+
+        dl_resp = MagicMock()
+        dl_resp.ok = True
+        dl_resp.content = content_bytes
+
+        def side_effect(url, **kwargs):
+            if "signeds3download" in url:
+                return sign_resp
+            return dl_resp
+
+        return patch.object(client._session, "get", side_effect=side_effect)
+
+    def test_zip_extraction(self):
+        client = _authed_client()
+        tools_data = [
+            {"guid": "a", "type": "flat end mill", "vendor": "Acme"},
+            {"guid": "b", "type": "ball end mill", "vendor": "Acme"},
+        ]
+        zip_bytes = self._make_tools_zip(tools_data)
+
+        with self._mock_signed_download(client, zip_bytes):
+            result = client.download_tool_library(
+                "urn:adsk.objects:os.object:wip.dm.prod/lib.json"
+            )
+
+        assert len(result) == 2
+        assert result[0]["guid"] == "a"
+
+    def test_raw_json_fallback(self):
+        """If the file isn't a ZIP, try parsing as raw JSON."""
+        client = _authed_client()
+        raw = json.dumps({"data": [{"guid": "c", "type": "drill"}]}).encode()
+
+        with self._mock_signed_download(client, raw):
+            result = client.download_tool_library(
+                "urn:adsk.objects:os.object:wip.dm.prod/lib.json"
+            )
+
+        assert len(result) == 1
+        assert result[0]["type"] == "drill"
+
+    def test_empty_data_returns_empty_list(self):
+        client = _authed_client()
+        raw = json.dumps({"version": 1}).encode()  # no "data" key
+
+        with self._mock_signed_download(client, raw):
+            result = client.download_tool_library(
+                "urn:adsk.objects:os.object:wip.dm.prod/lib.json"
+            )
+
+        assert result == []
+
+    def test_unparseable_storage_ref_raises(self):
+        client = _authed_client()
+        with pytest.raises(APSHTTPError, match="Cannot parse"):
+            client.download_tool_library("not-a-valid-ref")
+
+
+# ─────────────────────────────────────────────
+# Auto-refresh
+# ─────────────────────────────────────────────
+class TestAutoRefresh:
+    def test_ensure_token_refreshes_when_expired(self):
+        client = APSClient(client_id="id", client_secret="secret", token_path=None)
+        client.tokens.access_token = "old"
+        client.tokens.refresh_token = "rt"
+        client.tokens.expires_at = time.time() - 100
+
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "access_token": "refreshed",
+            "refresh_token": "new-rt",
+            "expires_in": 3600,
+        }
+
+        with patch.object(client._session, "post", return_value=mock_resp):
+            client._ensure_token()
+
+        assert client.tokens.access_token == "refreshed"
+
+    def test_ensure_token_raises_when_no_refresh(self):
+        client = APSClient(client_id="id", client_secret="secret", token_path=None)
+        client.tokens.access_token = "old"
+        client.tokens.expires_at = time.time() - 100
+
+        with pytest.raises(APSAuthError, match="expired"):
+            client._ensure_token()


### PR DESCRIPTION
## Summary
- Adds APS (Autodesk Platform Services) OAuth + Data Management client that reads Fusion 360 tool libraries directly from the XWERKS cloud hub
- Eliminates the Fusion 360 / Autodesk Desktop Connector local install dependency — pure REST, server-side compatible
- New `/api/aps/sync` endpoint downloads all 8 cloud libraries and upserts them into Supabase in one call (155 tools, 631 presets verified live)
- File-backed token persistence survives Flask debug reloads

## New files
- `aps_client.py` — OAuth 2.0, signed S3 downloads, hub traversal, token persistence
- `tests/test_aps_client.py` — 29 tests (tokens, OAuth, signed S3, persistence, parsing)

## Modified files
- `app.py` — 10 new `/api/aps/*` routes
- `.env.example` — APS_CLIENT_ID, APS_CLIENT_SECRET, APS_CALLBACK_URL
- `.gitignore` — `.aps_tokens.json`
- `tests/conftest.py` — dummy APS creds

## Test plan
- [x] 291 tests pass (29 new APS tests)
- [x] Live-tested: OAuth flow → hub discovery → 8 libraries listed → download → Supabase sync
- [x] Token persistence verified across Flask reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)