### PR TITLE
feat: nightly sync CLI + pyproject.toml packaging (#9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "datum"
+version = "0.1.0"
+description = "Fusion 360 tool library sync pipeline — Grace Engineering"
+requires-python = ">=3.11"
+dependencies = [
+    "flask>=3.0",
+    "requests>=2.31",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[project.scripts]
+datum-sync = "sync:cli"
+
+[tool.setuptools]
+# Flat layout — all modules live at the repo root, no src/ directory.
+py-modules = [
+    "app",
+    "aps_client",
+    "bootstrap",
+    "build_supply_item_payload",
+    "plex_api",
+    "plex_diagnostics",
+    "supabase_client",
+    "sync",
+    "sync_supabase",
+    "tool_library_loader",
+    "validate_library",
+]
+# Don't try to auto-discover packages — there are none.
+packages = []

--- a/sync.py
+++ b/sync.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python
+"""
+sync.py
+Nightly sync CLI — APS cloud-first, local ADC fallback
+Grace Engineering — Datum project
+=============================================================
+Downloads Fusion 360 tool libraries from the Autodesk cloud
+(APS Data Management API) and upserts them into Supabase.
+Falls back to local ADC-synced files when APS OAuth is
+unavailable.
+
+Usage
+-----
+    # Full sync (APS cloud → Supabase)
+    py sync.py
+
+    # Dry run — download + validate only, no Supabase writes
+    py sync.py --dry-run
+
+    # Force local ADC fallback (skip APS entirely)
+    py sync.py --local
+
+    # Verbose logging
+    py sync.py -v
+
+Exit codes
+----------
+    0  All libraries synced (or validated, in dry-run mode)
+    1  One or more libraries failed validation or sync
+    2  Fatal error (no source available, config missing, etc.)
+
+Scheduling
+----------
+    # Windows Task Scheduler (daily at 02:00)
+    schtasks /create /tn "Datum Nightly Sync" ^
+        /tr "py C:\\projects\\Datum\\sync.py" /sc daily /st 02:00
+
+    # Linux cron (daily at 02:00)
+    0 2 * * * /opt/datum/sync.py >> /var/log/datum-sync.log 2>&1
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── Anchor working directory to the project root ──────────
+# Task Scheduler / cron may launch from any CWD. All local
+# imports (bootstrap, aps_client, etc.) and .env.local rely
+# on CWD being the project root.
+_PROJECT_ROOT = Path(__file__).resolve().parent
+os.chdir(_PROJECT_ROOT)
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import bootstrap  # noqa: E402, F401 — loads .env.local into os.environ
+
+from aps_client import APSClient, APSAuthError, APSConfigError, APSHTTPError  # noqa: E402
+from supabase_client import SupabaseClient  # noqa: E402
+from sync_supabase import sync_library, hash_file  # noqa: E402
+from tool_library_loader import load_all_libraries, CAM_TOOLS_DIR  # noqa: E402
+from validate_library import validate_library, ValidationMode  # noqa: E402
+
+log = logging.getLogger("datum.sync")
+
+# Known XWERKS hub IDs (see memory: project_aps_cloud_integration.md)
+PROJECT_ID = "a.YnVzaW5lc3M6Z3JhY2Vlbmc0I0QyMDI0MTIyMDg0OTIxNzc3Ng"
+CAM_TOOLS_FOLDER = "urn:adsk.wipprod:fs.folder:co.C0zYkNP4TOexre_-hWRhRA"
+
+
+# ─────────────────────────────────────────────
+# Result tracking
+# ─────────────────────────────────────────────
+@dataclass
+class LibraryResult:
+    name: str
+    status: str  # "success" | "skipped" | "fail"
+    tools: int = 0
+    presets: int = 0
+    message: str = ""
+
+
+@dataclass
+class SyncReport:
+    source: str  # "aps" | "local"
+    results: list[LibraryResult] = field(default_factory=list)
+    start_time: float = 0.0
+    end_time: float = 0.0
+
+    @property
+    def succeeded(self) -> list[LibraryResult]:
+        return [r for r in self.results if r.status == "success"]
+
+    @property
+    def failed(self) -> list[LibraryResult]:
+        return [r for r in self.results if r.status == "fail"]
+
+    @property
+    def skipped(self) -> list[LibraryResult]:
+        return [r for r in self.results if r.status == "skipped"]
+
+    @property
+    def total_tools(self) -> int:
+        return sum(r.tools for r in self.results)
+
+    @property
+    def total_presets(self) -> int:
+        return sum(r.presets for r in self.results)
+
+    @property
+    def elapsed(self) -> float:
+        return self.end_time - self.start_time
+
+    def print_summary(self) -> None:
+        log.info("=" * 60)
+        log.info("Sync complete — source: %s", self.source)
+        log.info(
+            "  %d succeeded, %d skipped, %d failed",
+            len(self.succeeded),
+            len(self.skipped),
+            len(self.failed),
+        )
+        log.info(
+            "  Totals: %d tools, %d presets",
+            self.total_tools,
+            self.total_presets,
+        )
+        log.info("  Elapsed: %.1fs", self.elapsed)
+        log.info("=" * 60)
+
+
+# ─────────────────────────────────────────────
+# APS cloud sync
+# ─────────────────────────────────────────────
+def sync_from_aps(*, dry_run: bool = False) -> SyncReport:
+    """
+    Download all cloud tool libraries from APS and sync into Supabase.
+    Same pipeline as /api/aps/sync but callable without Flask.
+    """
+    report = SyncReport(source="aps", start_time=time.monotonic())
+
+    aps = APSClient()
+    aps._require_config()
+    aps._ensure_token()
+
+    sb = None if dry_run else SupabaseClient()
+
+    contents = aps.get_folder_contents(PROJECT_ID, CAM_TOOLS_FOLDER)
+
+    for item in contents:
+        if item.get("type") != "items":
+            continue
+        name = item.get("attributes", {}).get("displayName", "")
+        if not name.endswith(".json"):
+            continue
+
+        library_name = name.replace(".json", "")
+        log.info("── %s ──", library_name)
+
+        # Get storage URN from the tip
+        try:
+            item_id = item["id"]
+            tip = aps.get_item_tip(PROJECT_ID, item_id)
+            storage_urn = (
+                tip.get("relationships", {})
+                .get("storage", {})
+                .get("data", {})
+                .get("id", "")
+            )
+            if not storage_urn:
+                report.results.append(LibraryResult(
+                    library_name, "fail", message="No storage URN in tip",
+                ))
+                log.error("  FAIL: no storage URN in tip")
+                continue
+
+            # Download and parse
+            tools = aps.download_tool_library(storage_urn)
+        except (APSHTTPError, Exception) as e:
+            report.results.append(LibraryResult(
+                library_name, "fail", message=str(e),
+            ))
+            log.error("  FAIL download: %s", e)
+            continue
+
+        if not tools:
+            report.results.append(LibraryResult(
+                library_name, "skipped", message="Empty library",
+            ))
+            log.info("  SKIP: empty library")
+            continue
+
+        # Validation gate
+        vr = validate_library(
+            tools=tools,
+            library_name=library_name,
+            mode=ValidationMode.PRODUCTION,
+            use_api=False,
+        )
+        if not vr.passed:
+            report.results.append(LibraryResult(
+                library_name, "fail",
+                message=f"Validation failed: {len(vr.fails)} issue(s)",
+            ))
+            log.error("  FAIL validation: %s", vr.summary())
+            for issue in vr.fails:
+                log.error("    %s: %s", issue.rule, issue.message)
+            continue
+
+        log.info("  Validated: %s", vr.summary())
+
+        if dry_run:
+            report.results.append(LibraryResult(
+                library_name, "success",
+                tools=vr.sync_candidate_count,
+                message="dry-run — validated OK, no write",
+            ))
+            log.info("  DRY-RUN: %d tools validated, skipping write", vr.sync_candidate_count)
+            continue
+
+        # Sync to Supabase
+        try:
+            counts = sync_library(
+                library_name,
+                tools,
+                client=sb,
+                file_path=f"aps://{item_id}",
+            )
+            report.results.append(LibraryResult(
+                library_name, "success",
+                tools=counts["tools"],
+                presets=counts["presets"],
+            ))
+            log.info("  OK: %d tools, %d presets", counts["tools"], counts["presets"])
+        except Exception as e:
+            report.results.append(LibraryResult(
+                library_name, "fail", message=str(e),
+            ))
+            log.error("  FAIL sync: %s", e)
+
+    report.end_time = time.monotonic()
+    return report
+
+
+# ─────────────────────────────────────────────
+# Local ADC fallback
+# ─────────────────────────────────────────────
+def sync_from_local(*, dry_run: bool = False) -> SyncReport:
+    """
+    Load tool libraries from the local ADC sync path and sync into Supabase.
+    Fallback when APS OAuth is unavailable.
+    """
+    report = SyncReport(source="local", start_time=time.monotonic())
+
+    log.info("Loading libraries from local path: %s", CAM_TOOLS_DIR)
+
+    if not CAM_TOOLS_DIR.exists():
+        log.error("CAMTools directory not found: %s", CAM_TOOLS_DIR)
+        report.end_time = time.monotonic()
+        return report
+
+    libraries = load_all_libraries(
+        CAM_TOOLS_DIR,
+        abort_on_stale=False,
+        validate=False,  # We run validation ourselves below
+    )
+
+    if not libraries:
+        log.error("No libraries loaded from %s", CAM_TOOLS_DIR)
+        report.end_time = time.monotonic()
+        return report
+
+    sb = None if dry_run else SupabaseClient()
+
+    for library_name, tools in libraries.items():
+        log.info("── %s ──", library_name)
+
+        # Validation gate
+        vr = validate_library(
+            tools=tools,
+            library_name=library_name,
+            mode=ValidationMode.PRODUCTION,
+            use_api=False,
+        )
+        if not vr.passed:
+            report.results.append(LibraryResult(
+                library_name, "fail",
+                message=f"Validation failed: {len(vr.fails)} issue(s)",
+            ))
+            log.error("  FAIL validation: %s", vr.summary())
+            for issue in vr.fails:
+                log.error("    %s: %s", issue.rule, issue.message)
+            continue
+
+        log.info("  Validated: %s", vr.summary())
+
+        if dry_run:
+            report.results.append(LibraryResult(
+                library_name, "success",
+                tools=vr.sync_candidate_count,
+                message="dry-run — validated OK, no write",
+            ))
+            log.info("  DRY-RUN: %d tools validated, skipping write", vr.sync_candidate_count)
+            continue
+
+        # Sync to Supabase
+        try:
+            file_path = CAM_TOOLS_DIR / f"{library_name}.json"
+            fh = hash_file(file_path) if file_path.exists() else None
+            counts = sync_library(
+                library_name,
+                tools,
+                client=sb,
+                file_path=str(file_path),
+                file_hash=fh,
+            )
+            report.results.append(LibraryResult(
+                library_name, "success",
+                tools=counts["tools"],
+                presets=counts["presets"],
+            ))
+            log.info("  OK: %d tools, %d presets", counts["tools"], counts["presets"])
+        except Exception as e:
+            report.results.append(LibraryResult(
+                library_name, "fail", message=str(e),
+            ))
+            log.error("  FAIL sync: %s", e)
+
+    report.end_time = time.monotonic()
+    return report
+
+
+# ─────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Datum nightly sync -- Fusion tool libraries to Supabase",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Download and validate only, no Supabase writes",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Force local ADC fallback (skip APS cloud)",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable debug-level logging",
+    )
+    args = parser.parse_args(argv)
+
+    # Logging setup
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    log.info("Datum sync starting%s", " (dry-run)" if args.dry_run else "")
+
+    report: SyncReport | None = None
+
+    if not args.local:
+        # Try APS cloud first
+        try:
+            log.info("Attempting APS cloud sync...")
+            report = sync_from_aps(dry_run=args.dry_run)
+        except (APSConfigError, APSAuthError) as e:
+            log.warning("APS unavailable: %s — falling back to local", e)
+        except Exception as e:
+            log.warning("APS error: %s — falling back to local", e)
+
+    if report is None:
+        # Fallback to local ADC
+        log.info("Using local ADC path...")
+        try:
+            report = sync_from_local(dry_run=args.dry_run)
+        except Exception as e:
+            log.critical("Local sync failed: %s", e)
+            return 2
+
+    report.print_summary()
+
+    if not report.results:
+        log.error("No libraries processed from any source")
+        return 2
+
+    if report.failed:
+        log.error(
+            "Failed libraries: %s",
+            ", ".join(r.name for r in report.failed),
+        )
+        return 1
+
+    return 0
+
+
+def cli() -> None:
+    """Console-script entry point (called by ``datum-sync`` after pip install)."""
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,325 @@
+"""
+Tests for sync.py — nightly sync CLI entrypoint.
+
+Covers:
+  - APS cloud sync path (mocked APS client + Supabase)
+  - Local ADC fallback path (mocked loader)
+  - Validation gate (libraries that fail validation are rejected)
+  - --dry-run mode (no Supabase writes)
+  - --local flag (skips APS, goes straight to local)
+  - Fallback from APS to local on auth failure
+  - Exit codes (0 = success, 1 = partial failure, 2 = fatal)
+  - SyncReport summary helpers
+
+All I/O is mocked — no real network or filesystem calls.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sync import (
+    main,
+    sync_from_aps,
+    sync_from_local,
+    LibraryResult,
+    SyncReport,
+)
+from aps_client import APSAuthError, APSConfigError
+from validate_library import ValidationResult
+
+
+# ─────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────
+def _make_folder_contents(*names: str) -> list[dict]:
+    """Build a fake APS folder contents response."""
+    items = []
+    for name in names:
+        items.append({
+            "type": "items",
+            "id": f"urn:adsk.wipprod:dm.lineage:{name}",
+            "attributes": {"displayName": f"{name}.json"},
+        })
+    return items
+
+
+def _make_tip(storage_urn: str = "urn:adsk.objects:os.object:bucket/obj") -> dict:
+    return {
+        "relationships": {
+            "storage": {
+                "data": {"id": storage_urn},
+            },
+        },
+    }
+
+
+def _passing_validation(library_name: str, tool_count: int = 10) -> ValidationResult:
+    return ValidationResult(
+        library_name=library_name,
+        passed=True,
+        tool_count=tool_count,
+        sync_candidate_count=tool_count,
+    )
+
+
+def _failing_validation(library_name: str) -> ValidationResult:
+    from validate_library import ValidationIssue
+    return ValidationResult(
+        library_name=library_name,
+        passed=False,
+        tool_count=5,
+        sync_candidate_count=5,
+        issues=[ValidationIssue(
+            severity="FAIL",
+            rule="TEST_RULE",
+            tool_index=0,
+            tool_description="test tool",
+            field="guid",
+            value=None,
+            message="missing guid",
+        )],
+    )
+
+
+# ─────────────────────────────────────────────
+# SyncReport
+# ─────────────────────────────────────────────
+class TestSyncReport:
+    def test_succeeded_failed_skipped(self):
+        report = SyncReport(source="test")
+        report.results = [
+            LibraryResult("A", "success", tools=10, presets=20),
+            LibraryResult("B", "fail", message="boom"),
+            LibraryResult("C", "skipped", message="empty"),
+            LibraryResult("D", "success", tools=5, presets=8),
+        ]
+        assert len(report.succeeded) == 2
+        assert len(report.failed) == 1
+        assert len(report.skipped) == 1
+        assert report.total_tools == 15
+        assert report.total_presets == 28
+
+    def test_elapsed(self):
+        report = SyncReport(source="test", start_time=100.0, end_time=105.5)
+        assert report.elapsed == pytest.approx(5.5)
+
+
+# ─────────────────────────────────────────────
+# sync_from_aps
+# ─────────────────────────────────────────────
+class TestSyncFromAps:
+    @patch("sync.SupabaseClient")
+    @patch("sync.sync_library")
+    @patch("sync.validate_library")
+    @patch("sync.APSClient")
+    def test_full_sync_success(self, MockAPS, mock_validate, mock_sync, MockSB):
+        aps = MockAPS.return_value
+        aps.get_folder_contents.return_value = _make_folder_contents("LIB_A", "LIB_B")
+        aps.get_item_tip.return_value = _make_tip()
+        aps.download_tool_library.return_value = [{"guid": "g1", "type": "flat end mill"}]
+
+        mock_validate.return_value = _passing_validation("LIB_A")
+        mock_sync.return_value = {"tools": 10, "presets": 20}
+
+        report = sync_from_aps(dry_run=False)
+
+        assert len(report.succeeded) == 2
+        assert report.total_tools == 20
+        assert report.total_presets == 40
+        assert mock_sync.call_count == 2
+        assert report.source == "aps"
+
+    @patch("sync.APSClient")
+    @patch("sync.validate_library")
+    def test_dry_run_no_supabase(self, mock_validate, MockAPS):
+        aps = MockAPS.return_value
+        aps.get_folder_contents.return_value = _make_folder_contents("LIB_A")
+        aps.get_item_tip.return_value = _make_tip()
+        aps.download_tool_library.return_value = [{"guid": "g1", "type": "drill"}]
+
+        mock_validate.return_value = _passing_validation("LIB_A", tool_count=5)
+
+        report = sync_from_aps(dry_run=True)
+
+        assert len(report.succeeded) == 1
+        assert report.results[0].message == "dry-run — validated OK, no write"
+        # sync_library should NOT have been called
+        # (SupabaseClient is never instantiated either — no mock needed)
+
+    @patch("sync.APSClient")
+    @patch("sync.validate_library")
+    def test_validation_failure_blocks_sync(self, mock_validate, MockAPS):
+        aps = MockAPS.return_value
+        aps.get_folder_contents.return_value = _make_folder_contents("BAD_LIB")
+        aps.get_item_tip.return_value = _make_tip()
+        aps.download_tool_library.return_value = [{"guid": "g1"}]
+
+        mock_validate.return_value = _failing_validation("BAD_LIB")
+
+        report = sync_from_aps(dry_run=False)
+
+        assert len(report.failed) == 1
+        assert "Validation failed" in report.results[0].message
+
+    @patch("sync.APSClient")
+    def test_empty_library_skipped(self, MockAPS):
+        aps = MockAPS.return_value
+        aps.get_folder_contents.return_value = _make_folder_contents("EMPTY")
+        aps.get_item_tip.return_value = _make_tip()
+        aps.download_tool_library.return_value = []
+
+        report = sync_from_aps(dry_run=False)
+
+        assert len(report.skipped) == 1
+
+    @patch("sync.APSClient")
+    def test_no_storage_urn_fails(self, MockAPS):
+        aps = MockAPS.return_value
+        aps.get_folder_contents.return_value = _make_folder_contents("BROKEN")
+        aps.get_item_tip.return_value = {"relationships": {"storage": {"data": {"id": ""}}}}
+
+        report = sync_from_aps(dry_run=False)
+
+        assert len(report.failed) == 1
+        assert "storage URN" in report.results[0].message
+
+    @patch("sync.APSClient")
+    def test_aps_config_error_propagates(self, MockAPS):
+        MockAPS.return_value._require_config.side_effect = APSConfigError("no creds")
+        with pytest.raises(APSConfigError):
+            sync_from_aps()
+
+
+# ─────────────────────────────────────────────
+# sync_from_local
+# ─────────────────────────────────────────────
+class TestSyncFromLocal:
+    @patch("sync.hash_file", return_value="abc123")
+    @patch("sync.SupabaseClient")
+    @patch("sync.sync_library")
+    @patch("sync.validate_library")
+    @patch("sync.load_all_libraries")
+    def test_full_local_sync(
+        self, mock_load, mock_validate, mock_sync, MockSB, mock_hash,
+    ):
+        mock_cam = MagicMock()
+        mock_cam.exists.return_value = True
+        mock_file = MagicMock()
+        mock_file.exists.return_value = True
+        mock_cam.__truediv__ = MagicMock(return_value=mock_file)
+
+        mock_load.return_value = {
+            "LIB_A": [{"guid": "g1", "type": "drill"}],
+        }
+        mock_validate.return_value = _passing_validation("LIB_A")
+        mock_sync.return_value = {"tools": 5, "presets": 10}
+
+        with patch("sync.CAM_TOOLS_DIR", mock_cam):
+            report = sync_from_local(dry_run=False)
+
+        assert len(report.succeeded) == 1
+        assert report.source == "local"
+        assert mock_sync.call_count == 1
+
+    @patch("sync.validate_library")
+    @patch("sync.load_all_libraries")
+    def test_local_dry_run(self, mock_load, mock_validate):
+        mock_cam = MagicMock()
+        mock_cam.exists.return_value = True
+
+        mock_load.return_value = {
+            "LIB_A": [{"guid": "g1"}],
+        }
+        mock_validate.return_value = _passing_validation("LIB_A", tool_count=3)
+
+        with patch("sync.CAM_TOOLS_DIR", mock_cam):
+            report = sync_from_local(dry_run=True)
+
+        assert len(report.succeeded) == 1
+        assert "dry-run" in report.results[0].message
+
+    def test_missing_directory(self):
+        mock_cam = MagicMock()
+        mock_cam.exists.return_value = False
+
+        with patch("sync.CAM_TOOLS_DIR", mock_cam):
+            report = sync_from_local(dry_run=False)
+
+        assert len(report.results) == 0
+
+    @patch("sync.validate_library")
+    @patch("sync.load_all_libraries")
+    def test_validation_failure(self, mock_load, mock_validate):
+        mock_cam = MagicMock()
+        mock_cam.exists.return_value = True
+
+        mock_load.return_value = {"BAD": [{"guid": "g1"}]}
+        mock_validate.return_value = _failing_validation("BAD")
+
+        with patch("sync.CAM_TOOLS_DIR", mock_cam):
+            report = sync_from_local(dry_run=False)
+
+        assert len(report.failed) == 1
+
+
+# ─────────────────────────────────────────────
+# CLI (main)
+# ─────────────────────────────────────────────
+class TestMain:
+    @patch("sync.sync_from_aps")
+    def test_exit_0_on_success(self, mock_aps):
+        report = SyncReport(source="aps", start_time=0, end_time=1)
+        report.results = [LibraryResult("A", "success", tools=5, presets=10)]
+        mock_aps.return_value = report
+
+        assert main([]) == 0
+
+    @patch("sync.sync_from_aps")
+    def test_exit_1_on_partial_failure(self, mock_aps):
+        report = SyncReport(source="aps", start_time=0, end_time=1)
+        report.results = [
+            LibraryResult("A", "success", tools=5, presets=10),
+            LibraryResult("B", "fail", message="boom"),
+        ]
+        mock_aps.return_value = report
+
+        assert main([]) == 1
+
+    @patch("sync.sync_from_local")
+    @patch("sync.sync_from_aps", side_effect=APSAuthError("expired"))
+    def test_fallback_to_local_on_auth_error(self, mock_aps, mock_local):
+        report = SyncReport(source="local", start_time=0, end_time=1)
+        report.results = [LibraryResult("A", "success", tools=5, presets=10)]
+        mock_local.return_value = report
+
+        assert main([]) == 0
+        mock_local.assert_called_once()
+
+    @patch("sync.sync_from_local")
+    def test_local_flag_skips_aps(self, mock_local):
+        report = SyncReport(source="local", start_time=0, end_time=1)
+        report.results = [LibraryResult("A", "success", tools=5, presets=10)]
+        mock_local.return_value = report
+
+        assert main(["--local"]) == 0
+
+    @patch("sync.sync_from_local")
+    @patch("sync.sync_from_aps", side_effect=APSConfigError("no creds"))
+    def test_exit_2_when_no_libraries(self, mock_aps, mock_local):
+        report = SyncReport(source="local", start_time=0, end_time=1)
+        report.results = []
+        mock_local.return_value = report
+
+        assert main([]) == 2
+
+    @patch("sync.sync_from_aps")
+    def test_dry_run_flag(self, mock_aps):
+        report = SyncReport(source="aps", start_time=0, end_time=1)
+        report.results = [LibraryResult("A", "success", tools=5, message="dry-run")]
+        mock_aps.return_value = report
+
+        assert main(["--dry-run"]) == 0
+        mock_aps.assert_called_once_with(dry_run=True)


### PR DESCRIPTION
## Summary
- Adds `sync.py` — nightly sync CLI that downloads Fusion tool libraries from APS cloud, validates each with `validate_library`, and upserts into Supabase. Falls back to local ADC files if APS OAuth is unavailable.
- Supports `--dry-run` (download + validate, no writes), `--local` (skip APS), `-v` (debug logging), and clean exit codes (0/1/2) for Task Scheduler / cron.
- Adds `pyproject.toml` — `pip install .` registers `datum-sync` on PATH as a console script. No more `py C:\path\to\sync.py`.
- Self-anchoring `os.chdir` so it works from any CWD without a wrapper script.
- 18 new tests (309 total, all green).

## Test plan
- [x] `py -m pytest` — 309 passed
- [x] `py sync.py --help` from foreign CWD — clean output
- [x] Entry point resolves: `from sync import cli`
- [ ] `pip install -e .` then `datum-sync --dry-run` on a machine with APS tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)