### PR TITLE
fix: handle empty/corrupt JSON in loader + deploy nightly sync (#10, #11)

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -356,14 +356,25 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Enable debug-level logging",
     )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Append logs to this file (in addition to stdout)",
+    )
     args = parser.parse_args(argv)
 
     # Logging setup
     level = logging.DEBUG if args.verbose else logging.INFO
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    if args.log_file:
+        fh = logging.FileHandler(args.log_file, encoding="utf-8")
+        handlers.append(fh)
     logging.basicConfig(
         level=level,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=handlers,
     )
 
     log.info("Datum sync starting%s", " (dry-run)" if args.dry_run else "")

--- a/tool_library_loader.py
+++ b/tool_library_loader.py
@@ -91,6 +91,10 @@ def load_library(path: Path, validate: bool = False) -> list[dict] | None:
     if not _check_file_age(path):
         return None  # stale — caller decides whether to abort or skip
 
+    if path.stat().st_size == 0:
+        log.warning("EMPTY FILE — %s is 0 bytes. Skipping.", path.name)
+        return None
+
     try:
         with open(path, "r", encoding="utf-8") as f:
             raw = json.load(f)
@@ -103,7 +107,7 @@ def load_library(path: Path, validate: bool = False) -> list[dict] | None:
         )
         return None
 
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, OSError) as e:
         log.error(
             "MALFORMED JSON — %s failed to parse: %s. "
             "File may be mid-write by ADC.",


### PR DESCRIPTION
## Summary
- Fixes `tool_library_loader.py` crash on 0-byte files (`865 (HAAS VF4SS).json` is empty on disk). Adds `st_size == 0` guard and catches `OSError` alongside `JSONDecodeError`.
- Deployed `datum-sync` on GRACE144 via `pip install -e .` (editable, tracks master).
- Created Windows Task Scheduler entry: "Datum Nightly Sync" runs daily at midnight, logs to `C:\projects\Datum\logs\sync.log`.

Closes #10, closes #11

## Test plan
- [x] `py -m pytest` — 315 passed
- [x] `datum-sync --help` works from installed exe
- [x] Scheduled task verified via `schtasks /query`
- [x] Dry-run tested (APS falls back to local, loads 10 libraries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)