### PR TITLE
feat: upstream enrichment in sync pipeline

### DIFF
--- a/enrich.py
+++ b/enrich.py
@@ -141,6 +141,83 @@ def find_reference_match_raw(
     return filtered[0] if filtered else None
 
 
+# ─────────────────────────────────────────────
+# Upstream enrichment (raw Fusion JSON, pre-validation)
+# ─────────────────────────────────────────────
+INCHES_TO_MM = 25.4
+
+
+def enrich_raw_tools(
+    tools: list[dict],
+    client: SupabaseClient,
+) -> dict[str, int]:
+    """
+    Enrich raw Fusion tool dicts in-place before validation.
+
+    For each tool missing ``product-id``, queries the reference_catalog
+    by (type, DC, NOF) geometry match and fills in ``product-id`` and
+    ``vendor`` from the best match.
+
+    Parameters
+    ----------
+    tools : list[dict]
+        Raw Fusion JSON tool dicts (the "data" array). Modified in-place.
+    client : SupabaseClient
+        Client with access to reference_catalog table.
+
+    Returns
+    -------
+    dict
+        ``{"enriched": N, "skipped": M}`` counts.
+    """
+    enriched = 0
+    skipped = 0
+
+    for t in tools:
+        # Skip holders/probes and tools that already have product-id
+        if t.get("type") in ("holder", "probe"):
+            continue
+        pid = t.get("product-id", "")
+        if pid and str(pid).strip():
+            continue
+
+        # Normalize DC to mm for reference catalog lookup
+        geo = t.get("geometry") or {}
+        dc_raw = geo.get("DC")
+        nof_raw = geo.get("NOF")
+        unit = t.get("unit", "inches")
+
+        if dc_raw is None or nof_raw is None:
+            skipped += 1
+            continue
+
+        try:
+            dc_mm = float(dc_raw)
+            if isinstance(unit, str) and unit.lower() == "inches":
+                dc_mm *= INCHES_TO_MM
+            nof = float(nof_raw)
+        except (TypeError, ValueError):
+            skipped += 1
+            continue
+
+        ref = find_reference_match_raw(client, t.get("type", ""), dc_mm, nof)
+        if ref:
+            t["product-id"] = ref["product_id"]
+            if ref.get("vendor") and not t.get("vendor"):
+                t["vendor"] = ref["vendor"]
+            enriched += 1
+            log.info(
+                "  ENRICH: %s -> %s %s",
+                t.get("description", t.get("type", "")),
+                ref["vendor"],
+                ref["product_id"],
+            )
+        else:
+            skipped += 1
+
+    return {"enriched": enriched, "skipped": skipped}
+
+
 def enrich_tools(
     client: SupabaseClient,
     *,

--- a/sync.py
+++ b/sync.py
@@ -63,6 +63,7 @@ from aps_client import APSClient, APSAuthError, APSConfigError, APSHTTPError  # 
 from supabase_client import SupabaseClient  # noqa: E402
 from sync_supabase import sync_library, hash_file  # noqa: E402
 from tool_library_loader import load_all_libraries, CAM_TOOLS_DIR  # noqa: E402
+from enrich import enrich_raw_tools  # noqa: E402
 from validate_library import validate_library, ValidationMode  # noqa: E402
 
 log = logging.getLogger("datum.sync")
@@ -147,7 +148,8 @@ def sync_from_aps(*, dry_run: bool = False) -> SyncReport:
     aps._require_config()
     aps._ensure_token()
 
-    sb = None if dry_run else SupabaseClient()
+    # Supabase client needed for both enrichment (read) and sync (write)
+    sb = SupabaseClient()
 
     contents = aps.get_folder_contents(PROJECT_ID, CAM_TOOLS_FOLDER)
 
@@ -193,6 +195,14 @@ def sync_from_aps(*, dry_run: bool = False) -> SyncReport:
             ))
             log.info("  SKIP: empty library")
             continue
+
+        # Enrich tools missing product-id from reference catalog
+        try:
+            ec = enrich_raw_tools(tools, sb)
+            if ec["enriched"]:
+                log.info("  Enriched %d tools from reference catalog", ec["enriched"])
+        except Exception as e:
+            log.warning("  Enrichment failed (non-fatal): %s", e)
 
         # Validation gate
         vr = validate_library(
@@ -274,10 +284,18 @@ def sync_from_local(*, dry_run: bool = False) -> SyncReport:
         report.end_time = time.monotonic()
         return report
 
-    sb = None if dry_run else SupabaseClient()
+    sb = SupabaseClient()
 
     for library_name, tools in libraries.items():
         log.info("── %s ──", library_name)
+
+        # Enrich tools missing product-id from reference catalog
+        try:
+            ec = enrich_raw_tools(tools, sb)
+            if ec["enriched"]:
+                log.info("  Enriched %d tools from reference catalog", ec["enriched"])
+        except Exception as e:
+            log.warning("  Enrichment failed (non-fatal): %s", e)
 
         # Validation gate
         vr = validate_library(


### PR DESCRIPTION
## Summary
- Enrichment now runs **before** validation in the sync pipeline — tools missing `product-id` get matched against the 82k reference catalog by geometry before the validator sees them.
- Live-tested: 40/57 missing tools auto-enriched from reference catalog. Validation errors dropped from 28 to 8 on the 848 HAAS library alone.
- Remaining failures: taps (no catalog coverage), custom form mills, face mills, and duplicate product-id collisions from identical geometry matches.

## Test plan
- [x] `py -m pytest` — 328 passed
- [x] Live dry-run: 40 tools enriched across 7 libraries in 11 seconds
- [x] Enrichment is non-fatal — if reference_catalog is empty or unreachable, sync proceeds without enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)