### PR TITLE
feat: UI — fix libraries tab, type dropdown, unit toggle, type rename

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "web",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--prefix", "web"],
-      "port": 5173
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["--prefix", "web", "vite", "web", "--port", "5174"],
+      "port": 5174
     }
   ]
 }

--- a/sync_supabase.py
+++ b/sync_supabase.py
@@ -53,6 +53,12 @@ INCHES_TO_MM = 25.4
 
 EXCLUDED_TYPES = frozenset({"holder", "probe"})
 
+# Fusion 360 uses legacy type names that don't match modern shop terminology.
+# Map lowercased Fusion type → corrected display name.
+TYPE_RENAMES: dict[str, str] = {
+    "slot mill": "slitting saw",
+}
+
 # Geometry fields that are dimensional (convert inches → mm) vs dimensionless
 # (counts, flags, angles — carry as-is).
 GEOMETRY_LENGTH_FIELDS = {
@@ -239,7 +245,10 @@ def build_tool_row(tool: dict) -> dict:
         "vendor": _maybe_str(tool.get("vendor")) or "",
         "product_id": normalize_product_id(tool.get("product-id")) or "",
         "description": _maybe_str(tool.get("description")) or "",
-        "type": _maybe_str(tool.get("type")) or "",
+        "type": TYPE_RENAMES.get(
+            (_maybe_str(tool.get("type")) or "").lower(),
+            _maybe_str(tool.get("type")) or "",
+        ),
         "bmc": _maybe_str(tool.get("BMC")),
         "grade": _maybe_str(tool.get("GRADE")),
         # reference_guid is observed as integer 0 in Harvey/Helical — store as string

--- a/validate_library.py
+++ b/validate_library.py
@@ -46,7 +46,8 @@ KNOWN_TOOL_TYPES = {
     "drill",
     "face mill",
     "form mill",
-    "slot mill",
+    "slot mill",       # Fusion name; ingested as "slitting saw"
+    "slitting saw",
     "holder",
     "probe",
 }

--- a/web/src/pages/LibrariesPage.tsx
+++ b/web/src/pages/LibrariesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import type { Library } from "@/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,25 +8,16 @@ import { Badge } from "@/components/ui/badge";
 export function LibrariesPage() {
   const [libraries, setLibraries] = useState<Library[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchLibraries() {
-      const { data, error: err } = await supabase
+      const { data, error } = await supabase
         .from("libraries")
         .select("*")
         .order("library_name");
 
-      if (err) {
-        // libraries table has deny-all anon policy — expected with anon key
-        if (err.code === "PGRST301" || err.message.includes("permission")) {
-          setError(
-            "Libraries table requires authenticated access. " +
-            "The anon key can read tools and presets but not libraries directly."
-          );
-        } else {
-          setError(err.message);
-        }
+      if (error) {
+        console.error("Failed to fetch libraries:", error);
       } else {
         setLibraries(data ?? []);
       }
@@ -36,19 +28,6 @@ export function LibrariesPage() {
 
   if (loading) {
     return <div className="py-12 text-center text-muted-foreground">Loading libraries...</div>;
-  }
-
-  if (error) {
-    return (
-      <div className="space-y-4">
-        <h1 className="text-2xl font-semibold tracking-tight">Libraries</h1>
-        <Card>
-          <CardContent className="py-8 text-center text-sm text-muted-foreground">
-            {error}
-          </CardContent>
-        </Card>
-      </div>
-    );
   }
 
   return (
@@ -69,27 +48,29 @@ export function LibrariesPage() {
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {libraries.map((lib) => (
-            <Card key={lib.id}>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{lib.library_name}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2 text-sm">
-                {lib.vendor && (
+            <Link key={lib.id} to={`/?library=${encodeURIComponent(lib.library_name)}`}>
+              <Card className="transition-colors hover:bg-accent/50">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{lib.library_name}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm">
+                  {lib.vendor && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Vendor</span>
+                      <span>{lib.vendor}</span>
+                    </div>
+                  )}
                   <div className="flex justify-between">
-                    <span className="text-muted-foreground">Vendor</span>
-                    <span>{lib.vendor}</span>
+                    <span className="text-muted-foreground">Tools</span>
+                    <Badge variant="secondary">{lib.tool_count}</Badge>
                   </div>
-                )}
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Tools</span>
-                  <Badge variant="secondary">{lib.tool_count}</Badge>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Ingested</span>
-                  <span>{new Date(lib.ingested_at).toLocaleDateString()}</span>
-                </div>
-              </CardContent>
-            </Card>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Ingested</span>
+                    <span>{new Date(lib.ingested_at).toLocaleDateString()}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
           ))}
         </div>
       )}

--- a/web/src/pages/ToolDetailPage.tsx
+++ b/web/src/pages/ToolDetailPage.tsx
@@ -14,14 +14,57 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-function GeoRow({ label, value, unit }: { label: string; value: number | null; unit?: string }) {
+const MM_PER_INCH = 25.4;
+
+function UnitToggle({ imperial, setImperial }: { imperial: boolean; setImperial: (v: boolean) => void }) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2 text-sm">
+      <span className={imperial ? "text-muted-foreground" : "font-medium"}>mm</span>
+      <button
+        role="switch"
+        aria-checked={imperial}
+        onClick={() => setImperial(!imperial)}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
+          imperial ? "bg-primary" : "bg-muted"
+        }`}
+      >
+        <span
+          className={`pointer-events-none block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform ${
+            imperial ? "translate-x-4" : "translate-x-0.5"
+          }`}
+        />
+      </button>
+      <span className={imperial ? "font-medium" : "text-muted-foreground"}>in</span>
+    </label>
+  );
+}
+
+function GeoRow({
+  label,
+  value,
+  unit,
+  imperial,
+}: {
+  label: string;
+  value: number | null;
+  unit?: string;
+  imperial?: boolean;
+}) {
   if (value == null) return null;
+
+  let displayVal = value;
+  let displayUnit = unit;
+  if (unit === "mm" && imperial) {
+    displayVal = value / MM_PER_INCH;
+    displayUnit = "in";
+  }
+
   return (
     <div className="flex justify-between py-1">
       <span className="text-muted-foreground">{label}</span>
       <span className="font-mono text-sm">
-        {typeof value === "number" ? value.toFixed(3) : value}
-        {unit && <span className="ml-1 text-muted-foreground">{unit}</span>}
+        {typeof displayVal === "number" ? displayVal.toFixed(imperial && unit === "mm" ? 4 : 3) : displayVal}
+        {displayUnit && <span className="ml-1 text-muted-foreground">{displayUnit}</span>}
       </span>
     </div>
   );
@@ -32,6 +75,7 @@ export function ToolDetailPage() {
   const [tool, setTool] = useState<Tool | null>(null);
   const [presets, setPresets] = useState<CuttingPreset[]>([]);
   const [loading, setLoading] = useState(true);
+  const [imperial, setImperial] = useState(false);
 
   useEffect(() => {
     async function fetch() {
@@ -85,7 +129,8 @@ export function ToolDetailPage() {
             {tool.vendor} &middot; {tool.product_id}
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-3">
+          <UnitToggle imperial={imperial} setImperial={setImperial} />
           <Badge variant="secondary">{tool.type}</Badge>
           {tool.plex_supply_item_id ? (
             <Badge variant="default">Synced to Plex</Badge>
@@ -101,14 +146,14 @@ export function ToolDetailPage() {
             <CardTitle className="text-base">Geometry</CardTitle>
           </CardHeader>
           <CardContent className="space-y-0.5">
-            <GeoRow label="Cutting diameter (DC)" value={tool.geo_dc} unit="mm" />
-            <GeoRow label="Overall length (OAL)" value={tool.geo_oal} unit="mm" />
-            <GeoRow label="Flute length (LCF)" value={tool.geo_lcf} unit="mm" />
-            <GeoRow label="Body length (LB)" value={tool.geo_lb} unit="mm" />
-            <GeoRow label="Shank diameter (SFDM)" value={tool.geo_sfdm} unit="mm" />
+            <GeoRow label="Cutting diameter (DC)" value={tool.geo_dc} unit="mm" imperial={imperial} />
+            <GeoRow label="Overall length (OAL)" value={tool.geo_oal} unit="mm" imperial={imperial} />
+            <GeoRow label="Flute length (LCF)" value={tool.geo_lcf} unit="mm" imperial={imperial} />
+            <GeoRow label="Body length (LB)" value={tool.geo_lb} unit="mm" imperial={imperial} />
+            <GeoRow label="Shank diameter (SFDM)" value={tool.geo_sfdm} unit="mm" imperial={imperial} />
             <GeoRow label="Number of flutes (NOF)" value={tool.geo_nof} />
             <GeoRow label="Helix angle (SIG)" value={tool.geo_sig} unit="deg" />
-            <GeoRow label="Corner radius (RE)" value={tool.geo_re} unit="mm" />
+            <GeoRow label="Corner radius (RE)" value={tool.geo_re} unit="mm" imperial={imperial} />
             {tool.geo_dc == null && tool.geo_oal == null && (
               <p className="py-2 text-sm text-muted-foreground">No geometry data available.</p>
             )}
@@ -214,9 +259,9 @@ export function ToolDetailPage() {
                   <TableHead>Name</TableHead>
                   <TableHead>Material</TableHead>
                   <TableHead className="text-right">Vc (m/min)</TableHead>
-                  <TableHead className="text-right">fz (mm)</TableHead>
+                  <TableHead className="text-right">fz ({imperial ? "in" : "mm"})</TableHead>
                   <TableHead className="text-right">RPM</TableHead>
-                  <TableHead className="text-right">Vf (mm/min)</TableHead>
+                  <TableHead className="text-right">Vf ({imperial ? "in/min" : "mm/min"})</TableHead>
                   <TableHead>Coolant</TableHead>
                 </TableRow>
               </TableHeader>
@@ -229,13 +274,21 @@ export function ToolDetailPage() {
                       {p.v_c?.toFixed(1) ?? "—"}
                     </TableCell>
                     <TableCell className="text-right font-mono text-sm">
-                      {p.f_z?.toFixed(4) ?? "—"}
+                      {p.f_z == null
+                        ? "—"
+                        : imperial
+                          ? (p.f_z / MM_PER_INCH).toFixed(5)
+                          : p.f_z.toFixed(4)}
                     </TableCell>
                     <TableCell className="text-right font-mono text-sm">
                       {p.n?.toFixed(0) ?? "—"}
                     </TableCell>
                     <TableCell className="text-right font-mono text-sm">
-                      {p.v_f?.toFixed(1) ?? "—"}
+                      {p.v_f == null
+                        ? "—"
+                        : imperial
+                          ? (p.v_f / MM_PER_INCH).toFixed(2)
+                          : p.v_f.toFixed(1)}
                     </TableCell>
                     <TableCell>
                       {p.tool_coolant ? (

--- a/web/src/pages/ToolsPage.tsx
+++ b/web/src/pages/ToolsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import type { Tool } from "@/lib/types";
 import { Input } from "@/components/ui/input";
@@ -13,11 +13,15 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+const MM_PER_INCH = 25.4;
+
 export function ToolsPage() {
   const [tools, setTools] = useState<Tool[]>([]);
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [imperial, setImperial] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
     async function fetchTools() {
@@ -37,10 +41,14 @@ export function ToolsPage() {
     fetchTools();
   }, []);
 
+  // Support ?library= param from Libraries page links
+  const libraryParam = searchParams.get("library");
+
   const toolTypes = [...new Set(tools.map((t) => t.type))].sort();
 
   const filtered = tools.filter((t) => {
     if (typeFilter && t.type !== typeFilter) return false;
+    if (libraryParam && t.libraries?.library_name !== libraryParam) return false;
     if (!search) return true;
     const q = search.toLowerCase();
     return (
@@ -49,6 +57,14 @@ export function ToolsPage() {
       t.vendor.toLowerCase().includes(q)
     );
   });
+
+  function fmt(val: number | null): string {
+    if (val == null) return "—";
+    const v = imperial ? val / MM_PER_INCH : val;
+    return imperial ? v.toFixed(4) : v.toFixed(2);
+  }
+
+  const dimUnit = imperial ? "in" : "mm";
 
   if (loading) {
     return <div className="py-12 text-center text-muted-foreground">Loading tools...</div>;
@@ -63,6 +79,24 @@ export function ToolsPage() {
             ({filtered.length})
           </span>
         </h1>
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <span className={imperial ? "text-muted-foreground" : "font-medium"}>mm</span>
+          <button
+            role="switch"
+            aria-checked={imperial}
+            onClick={() => setImperial(!imperial)}
+            className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
+              imperial ? "bg-primary" : "bg-muted"
+            }`}
+          >
+            <span
+              className={`pointer-events-none block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                imperial ? "translate-x-4" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+          <span className={imperial ? "font-medium" : "text-muted-foreground"}>in</span>
+        </label>
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
@@ -72,31 +106,26 @@ export function ToolsPage() {
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"
         />
-        <div className="flex flex-wrap gap-1">
-          <button
-            onClick={() => setTypeFilter(null)}
-            className={`rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
-              typeFilter === null
-                ? "border-primary bg-primary text-primary-foreground"
-                : "border-border text-muted-foreground hover:bg-accent"
-            }`}
-          >
-            All
-          </button>
+        <select
+          value={typeFilter ?? ""}
+          onChange={(e) => setTypeFilter(e.target.value || null)}
+          className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+        >
+          <option value="">All types</option>
           {toolTypes.map((type) => (
-            <button
-              key={type}
-              onClick={() => setTypeFilter(type === typeFilter ? null : type)}
-              className={`rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
-                typeFilter === type
-                  ? "border-primary bg-primary text-primary-foreground"
-                  : "border-border text-muted-foreground hover:bg-accent"
-              }`}
-            >
+            <option key={type} value={type}>
               {type}
-            </button>
+            </option>
           ))}
-        </div>
+        </select>
+        {libraryParam && (
+          <div className="flex items-center gap-1.5">
+            <Badge variant="secondary">{libraryParam}</Badge>
+            <Link to="/" className="text-xs text-muted-foreground hover:underline">
+              clear
+            </Link>
+          </div>
+        )}
       </div>
 
       <div className="overflow-x-auto rounded-md border">
@@ -107,8 +136,8 @@ export function ToolsPage() {
               <TableHead className="whitespace-nowrap">Part #</TableHead>
               <TableHead>Vendor</TableHead>
               <TableHead>Type</TableHead>
-              <TableHead className="text-right whitespace-nowrap">Dia (mm)</TableHead>
-              <TableHead className="text-right whitespace-nowrap">OAL (mm)</TableHead>
+              <TableHead className="text-right whitespace-nowrap">Dia ({dimUnit})</TableHead>
+              <TableHead className="text-right whitespace-nowrap">OAL ({dimUnit})</TableHead>
               <TableHead className="text-right">Flutes</TableHead>
               <TableHead>Plex</TableHead>
             </TableRow>
@@ -140,10 +169,10 @@ export function ToolsPage() {
                     <Badge variant="secondary">{tool.type}</Badge>
                   </TableCell>
                   <TableCell className="text-right font-mono text-sm">
-                    {tool.geo_dc?.toFixed(2) ?? "—"}
+                    {fmt(tool.geo_dc)}
                   </TableCell>
                   <TableCell className="text-right font-mono text-sm">
-                    {tool.geo_oal?.toFixed(2) ?? "—"}
+                    {fmt(tool.geo_oal)}
                   </TableCell>
                   <TableCell className="text-right font-mono text-sm">
                     {tool.geo_nof ?? "—"}


### PR DESCRIPTION
## Summary
- **#53** — Libraries tab was empty due to deny-all anon RLS on `libraries` table. Added `libraries_anon_read` policy (SELECT only). Library cards now link to Tools page filtered by library name.
- **#52** — Fusion 360 calls slitting saws "slot mill". Added `TYPE_RENAMES` map in `sync_supabase.py` to correct this at ingest time. Takes effect on next sync.
- **#51** — Replaced tool-type filter pill buttons with a single `<select>` dropdown. Same location, less space.
- **#50** — Added mm/in toggle switch on both Tools list and Tool Detail pages. Converts all dimensional geometry, fz, and Vf values in the browser (÷25.4). Angles and counts unaffected.

Also includes: clickable library cards, `?library=` URL param filtering, updated `launch.json` for Vite preview.

## Test plan
- [x] `py -m pytest` — 328 passed
- [x] Libraries page shows 7 libraries with correct tool counts
- [x] Unit toggle converts values correctly (e.g. 50.80mm → 2.0000in)
- [x] Type dropdown filters work
- [x] Library card links filter tools by library name
- [x] No console errors

Closes #50, closes #51, closes #52, closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)