### PR TITLE
fix: UI polish — dropdown, Fusion timestamps, recent page, link

### DIFF
--- a/db/migrations/0003_source_modified_at.sql
+++ b/db/migrations/0003_source_modified_at.sql
@@ -1,0 +1,7 @@
+-- Track when the library file was last modified in Fusion Hub (APS).
+-- Distinct from ingested_at (when we last synced) and updated_at (Supabase trigger).
+ALTER TABLE public.libraries
+  ADD COLUMN IF NOT EXISTS source_modified_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.libraries.source_modified_at
+  IS 'lastModifiedTime from APS Data Management API — when the .tools file was last saved in Fusion Hub';

--- a/sync.py
+++ b/sync.py
@@ -173,6 +173,9 @@ def sync_from_aps(*, dry_run: bool = False) -> SyncReport:
                 .get("data", {})
                 .get("id", "")
             )
+            source_modified_at = (
+                tip.get("attributes", {}).get("lastModifiedTime", "")
+            ) or None
             if not storage_urn:
                 report.results.append(LibraryResult(
                     library_name, "fail", message="No storage URN in tip",
@@ -239,6 +242,7 @@ def sync_from_aps(*, dry_run: bool = False) -> SyncReport:
                 tools,
                 client=sb,
                 file_path=f"aps://{item_id}",
+                source_modified_at=source_modified_at,
             )
             report.results.append(LibraryResult(
                 library_name, "success",

--- a/sync_supabase.py
+++ b/sync_supabase.py
@@ -388,6 +388,7 @@ def sync_library(
     client: SupabaseClient,
     file_path: str | None = None,
     file_hash: str | None = None,
+    source_modified_at: str | None = None,
 ) -> dict[str, int]:
     """
     Upsert one library worth of Fusion tools into Supabase.
@@ -406,6 +407,9 @@ def sync_library(
     file_hash : str | None
         SHA-256 of the source file. Stored on the library row so future
         runs can skip unchanged files.
+    source_modified_at : str | None
+        ISO 8601 timestamp from APS ``lastModifiedTime``. When the
+        library file was last saved in Fusion Hub.
 
     Returns
     -------
@@ -428,6 +432,8 @@ def sync_library(
         "unit_original": unit_original,
         "ingested_at": datetime.now(timezone.utc).isoformat(),
     }
+    if source_modified_at:
+        library_row["source_modified_at"] = source_modified_at
     lib_result = client.upsert(
         "libraries",
         library_row,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from "@/components/Layout";
 import { ToolsPage } from "@/pages/ToolsPage";
 import { ToolDetailPage } from "@/pages/ToolDetailPage";
 import { LibrariesPage } from "@/pages/LibrariesPage";
+import { RecentPage } from "@/pages/RecentPage";
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
           <Route index element={<ToolsPage />} />
           <Route path="tools/:id" element={<ToolDetailPage />} />
           <Route path="libraries" element={<LibrariesPage />} />
+          <Route path="recent" element={<RecentPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -33,7 +33,7 @@ export function Layout() {
             ))}
           </nav>
           <a
-            href="https://graceeng.com"
+            href="https://www.graceeng.com"
             target="_blank"
             rel="noopener noreferrer"
             className="ml-auto text-xs text-muted-foreground hover:underline"

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface Library {
   file_hash: string | null;
   tool_count: number;
   unit_original: string | null;
+  source_modified_at: string | null;
   ingested_at: string;
   created_at: string;
 }
@@ -48,7 +49,7 @@ export interface Tool {
   updated_at: string;
 
   // Joined
-  libraries?: Pick<Library, "library_name" | "vendor"> | null;
+  libraries?: Pick<Library, "library_name" | "vendor" | "source_modified_at"> | null;
 }
 
 export interface CuttingPreset {

--- a/web/src/pages/RecentPage.tsx
+++ b/web/src/pages/RecentPage.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+import type { Tool } from "@/lib/types";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const MM_PER_INCH = 25.4;
+const STORAGE_KEY_IMPERIAL = "datum-imperial";
+
+function readImperialPref(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY_IMPERIAL) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function RecentPage() {
+  const [tools, setTools] = useState<Tool[]>([]);
+  const [loading, setLoading] = useState(true);
+  const imperial = readImperialPref();
+
+  useEffect(() => {
+    async function fetchRecent() {
+      const { data, error } = await supabase
+        .from("tools")
+        .select("*, libraries(library_name, vendor, source_modified_at)")
+        .order("updated_at", { ascending: false });
+
+      if (error) {
+        console.error("Failed to fetch tools:", error);
+        setLoading(false);
+        return;
+      }
+
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const recent = (data ?? []).filter(
+        (t) => t.libraries?.source_modified_at && t.libraries.source_modified_at > oneDayAgo
+      );
+      setTools(recent);
+      setLoading(false);
+    }
+    fetchRecent();
+  }, []);
+
+  function fmt(val: number | null): string {
+    if (val == null) return "\u2014";
+    const v = imperial ? val / MM_PER_INCH : val;
+    return imperial ? v.toFixed(4) : v.toFixed(2);
+  }
+
+  const dimUnit = imperial ? "in" : "mm";
+
+  if (loading) {
+    return <div className="py-12 text-center text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Link to="/" className="text-sm text-muted-foreground hover:underline">
+          &larr; All tools
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Recently Modified{" "}
+        <span className="text-muted-foreground font-normal">
+          ({tools.length})
+        </span>
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Tools whose Fusion Hub library was modified in the last 24 hours.
+      </p>
+
+      {tools.length === 0 ? (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            No tools modified in the last 24 hours.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {tools.map((tool) => (
+            <Link key={tool.id} to={`/tools/${tool.id}`}>
+              <Card className="transition-colors hover:bg-accent/50">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">
+                    {tool.description || tool.product_id || "\u2014"}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-1.5 text-sm">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary">{tool.type}</Badge>
+                    {tool.plex_supply_item_id ? (
+                      <Badge variant="default">Synced</Badge>
+                    ) : (
+                      <Badge variant="outline">Local</Badge>
+                    )}
+                  </div>
+                  {tool.vendor && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Vendor</span>
+                      <span>{tool.vendor}</span>
+                    </div>
+                  )}
+                  {tool.product_id && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Part #</span>
+                      <span className="font-mono text-xs">{tool.product_id}</span>
+                    </div>
+                  )}
+                  {tool.geo_dc != null && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Diameter</span>
+                      <span className="font-mono text-xs">{fmt(tool.geo_dc)} {dimUnit}</span>
+                    </div>
+                  )}
+                  {tool.libraries?.library_name && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Library</span>
+                      <span className="text-xs">{tool.libraries.library_name}</span>
+                    </div>
+                  )}
+                  {tool.libraries?.source_modified_at && (
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Modified in Fusion</span>
+                      <span className="text-xs">
+                        {new Date(tool.libraries.source_modified_at).toLocaleString()}
+                      </span>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/ToolsPage.tsx
+++ b/web/src/pages/ToolsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import type { Tool } from "@/lib/types";
@@ -35,7 +35,7 @@ type SortField =
   | "plex";
 type SortDir = "asc" | "desc";
 
-function compare(a: Tool, b: Tool, field: SortField, imperial: boolean): number {
+function compare(a: Tool, b: Tool, field: SortField): number {
   switch (field) {
     case "description":
       return (a.description || "").localeCompare(b.description || "");
@@ -62,6 +62,85 @@ function compare(a: Tool, b: Tool, field: SortField, imperial: boolean): number 
   }
 }
 
+/** Custom multi-select dropdown that looks like a normal <select> */
+function TypeDropdown({
+  types,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  types: string[];
+  selected: Set<string>;
+  onToggle: (type: string) => void;
+  onClear: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const label =
+    selected.size === 0
+      ? "All types"
+      : selected.size === 1
+        ? [...selected][0]
+        : `${selected.size} types`;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex h-9 items-center gap-1 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+      >
+        {label}
+        <svg
+          className={`ml-1 h-3 w-3 transition-transform ${open ? "rotate-180" : ""}`}
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M3 4.5 L6 7.5 L9 4.5" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-10 z-50 min-w-[180px] rounded-md border border-border bg-background py-1 shadow-md">
+          {selected.size > 0 && (
+            <button
+              onClick={() => { onClear(); setOpen(false); }}
+              className="w-full px-3 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent"
+            >
+              Clear all
+            </button>
+          )}
+          {types.map((type) => (
+            <label
+              key={type}
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(type)}
+                onChange={() => onToggle(type)}
+                className="rounded"
+              />
+              {type}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function ToolsPage() {
   const [tools, setTools] = useState<Tool[]>([]);
   const [search, setSearch] = useState("");
@@ -71,12 +150,13 @@ export function ToolsPage() {
   const [searchParams] = useSearchParams();
   const [sortField, setSortField] = useState<SortField>("description");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [recentCount, setRecentCount] = useState<number | null>(null);
 
   useEffect(() => {
     async function fetchTools() {
       const { data, error } = await supabase
         .from("tools")
-        .select("*, libraries(library_name, vendor)")
+        .select("*, libraries(library_name, vendor, source_modified_at)")
         .order("vendor")
         .order("product_id");
 
@@ -84,6 +164,13 @@ export function ToolsPage() {
         console.error("Failed to fetch tools:", error);
       } else {
         setTools(data ?? []);
+
+        // Count tools whose library was modified in the last 24h (per Fusion Hub)
+        const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        const recent = (data ?? []).filter(
+          (t) => t.libraries?.source_modified_at && t.libraries.source_modified_at > oneDayAgo
+        );
+        setRecentCount(recent.length);
       }
       setLoading(false);
     }
@@ -98,9 +185,7 @@ export function ToolsPage() {
     } catch {}
   }
 
-  // Support ?library= param from Libraries page links
   const libraryParam = searchParams.get("library");
-
   const toolTypes = [...new Set(tools.map((t) => t.type))].sort();
 
   const filtered = tools.filter((t) => {
@@ -116,13 +201,9 @@ export function ToolsPage() {
   });
 
   const sorted = [...filtered].sort((a, b) => {
-    const c = compare(a, b, sortField, imperial);
+    const c = compare(a, b, sortField);
     return sortDir === "asc" ? c : -c;
   });
-
-  // Recent modifications (last 24h)
-  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-  const recentMods = tools.filter((t) => t.updated_at > oneDayAgo);
 
   function handleSort(field: SortField) {
     if (sortField === field) {
@@ -136,11 +217,8 @@ export function ToolsPage() {
   function toggleTypeFilter(type: string) {
     setTypeFilters((prev) => {
       const next = new Set(prev);
-      if (next.has(type)) {
-        next.delete(type);
-      } else {
-        next.add(type);
-      }
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
       return next;
     });
   }
@@ -172,13 +250,15 @@ export function ToolsPage() {
 
   return (
     <div className="space-y-4">
-      {recentMods.length > 0 && (
-        <div className="rounded-md border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
-          <span className="font-medium">{recentMods.length} tool{recentMods.length !== 1 ? "s" : ""} modified in the last 24 hours</span>
-          {" \u2014 "}
-          {recentMods.slice(0, 5).map((t) => t.description || t.product_id).join(", ")}
-          {recentMods.length > 5 && `, and ${recentMods.length - 5} more`}
-        </div>
+      {recentCount != null && recentCount > 0 && (
+        <Link to="/recent">
+          <div className="cursor-pointer rounded-md border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-800 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950 dark:text-red-200 dark:hover:bg-red-900">
+            <span className="font-medium">
+              {recentCount} tool{recentCount !== 1 ? "s" : ""} modified in Fusion Hub in the last 24 hours
+            </span>
+            <span className="ml-2 text-red-600 dark:text-red-400">&rarr;</span>
+          </div>
+        </Link>
       )}
 
       <div className="flex items-center justify-between">
@@ -215,23 +295,12 @@ export function ToolsPage() {
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"
         />
-        <select
-          multiple
-          value={[...typeFilters]}
-          onChange={(e) => {
-            const selected = new Set(
-              [...e.target.selectedOptions].map((o) => o.value)
-            );
-            setTypeFilters(selected);
-          }}
-          className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
-        >
-          {toolTypes.map((type) => (
-            <option key={type} value={type}>
-              {type}
-            </option>
-          ))}
-        </select>
+        <TypeDropdown
+          types={toolTypes}
+          selected={typeFilters}
+          onToggle={toggleTypeFilter}
+          onClear={() => setTypeFilters(new Set())}
+        />
         {typeFilters.size > 0 && (
           <div className="flex flex-wrap items-center gap-1.5">
             {[...typeFilters].map((t) => (
@@ -244,12 +313,6 @@ export function ToolsPage() {
                 {t} &times;
               </Badge>
             ))}
-            <button
-              onClick={() => setTypeFilters(new Set())}
-              className="text-xs text-muted-foreground hover:underline"
-            >
-              clear all
-            </button>
           </div>
         )}
         {libraryParam && (


### PR DESCRIPTION
## Summary
- **Type filter**: Replaced native `<select multiple>` (looked terrible) with a custom dropdown with checkboxes. Selected types show as dismissible badges.
- **Recent modifications banner**: Now links to `/recent` page showing a card for each tool whose Fusion Hub library was modified in the last 24 hours. Uses `source_modified_at` from APS `lastModifiedTime`, not the Supabase `updated_at` trigger.
- **`source_modified_at` column**: New migration (0003) adds the column to `libraries`. `sync.py` extracts `lastModifiedTime` from the APS tip and passes it through to `sync_library()`. Populated on next sync run.
- **Grace Engineering link**: Corrected to `https://www.graceeng.com`

## Test plan
- [x] `py -m pytest` — 328 passed
- [x] Custom dropdown opens with checkboxes, multi-select works, badges dismiss
- [x] `/recent` page renders with back link, empty state when no recent mods
- [x] Grace Engineering href is `https://www.graceeng.com/`
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)