### PR TITLE
deploy: prep for Cloudflare Pages (SPA fallback + TS shim)

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,0 +1,3 @@
+# SPA fallback for react-router — any unmatched path serves index.html
+# so deep links like /tools/:id survive refresh on Cloudflare Pages.
+/*    /index.html   200

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -23,7 +23,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
Prep for deploying the React UI to `datum.graceops.dev` via Cloudflare Pages' GitHub integration.

- `web/public/_redirects` — `/* → /index.html 200` so react-router deep links (e.g. `/tools/:id`) survive refresh on Pages
- `web/tsconfig.app.json` — add `ignoreDeprecations: "6.0"` to silence a TS 7 deprecation on `baseUrl` that currently breaks `npm run build`

No backend changes. Flask app, `static/`, and `templates/` left untouched (dev-only).

## Supabase RLS check (done out-of-band)
All 5 public tables (`tools`, `libraries`, `cutting_presets`, `holder_catalog`, `reference_catalog`) have RLS on with explicit `anon SELECT` policies. Safe to ship `VITE_SUPABASE_ANON_KEY` in the bundle.

## Next steps (you, in the Cloudflare dashboard under the Grace account)
1. Pages → Create project → Connect to GitHub → select this repo
2. Build config:
   - Framework preset: **None**
   - Build command: `cd web && npm ci && npm run build`
   - Build output directory: `web/dist`
   - Root directory: `/`
3. Env vars (Production + Preview):
   - `VITE_SUPABASE_URL = https://crimblieyypiyarssoel.supabase.co`
   - `VITE_SUPABASE_ANON_KEY = <anon key from Supabase dashboard>`
4. Custom domain: `datum.graceops.dev` (CNAME auto-added since graceops.dev is on CF)
5. (Recommended) Zero Trust → Access → add an app policy on `datum.graceops.dev` gated to Grace Engineering emails

## Test plan
- [ ] Cloudflare Pages build succeeds on master push
- [ ] `datum.graceops.dev` loads the tools list from Supabase
- [ ] Deep-linking to `/tools/:id` works after refresh (tests the `_redirects` file)
- [ ] PR previews deploy on `*.pages.dev` with the same env vars