### PR TITLE
deploy: wrangler.jsonc for Workers Static Assets (fixes datum.shanewaid.workers.dev)

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,3 +1,0 @@
-# SPA fallback for react-router — any unmatched path serves index.html
-# so deep links like /tools/:id survive refresh on Cloudflare Pages.
-/*    /index.html   200

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "datum",
+  "compatibility_date": "2026-04-15",
+  "assets": {
+    "directory": "./web/dist",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## Summary
First Cloudflare deploy served the legacy Flask \`templates/index.html\` because \`wrangler deploy\` had no config to follow. This adds the explicit config.

- \`wrangler.jsonc\` — assets directory \`./web/dist\`, \`not_found_handling: single-page-application\` for react-router deep links
- Remove \`web/public/_redirects\` — redundant with wrangler's SPA handling (that file is a Pages-era artifact, not read by Workers Static Assets)

## Why this was missed in #68
Auto-merge squashed PR #68 on its first commit before the follow-up wrangler commit landed on the branch. This PR carries just the wrangler bits.

## Test plan
- [ ] CF Workers Build rebuilds on merge
- [ ] \`datum.shanewaid.workers.dev\` now shows the React tool browser, not the Flask UI
- [ ] Deep link to \`/tools/:id\` survives refresh