### PR TITLE
feat(db): Plex linkage + qty cache columns on tools (#75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ outputs/
 # Claude Code worktree scratch space
 .claude/worktrees/
 
+# Ad-hoc probe scripts, one-off dumps, and similar throwaway work
+scratch/
+
 # Claude Code per-machine permissions cache (regenerated on demand)
 .claude/settings.local.json

--- a/db/migrations/0005_tools_plex_linkage.sql
+++ b/db/migrations/0005_tools_plex_linkage.sql
@@ -1,0 +1,46 @@
+-- =========================================================================
+-- Datum — tools.plex_* linkage + qty cache columns
+-- =========================================================================
+-- Adds Plex linkage provenance and on-hand-qty cache columns to the tools
+-- table, supporting the inventory display work on datum.graceops.dev.
+--
+-- Supersedes the separate tool_plex_links table originally planned in #74:
+-- the tools table already carries plex_supply_item_id UUID (from
+-- 0001_initial_schema.sql line 116), so linkage is a property of the tool
+-- rather than a separate entity. Flattening avoids a join on every
+-- ToolsPage load.
+--
+-- Issue: #75 (parent #49)
+-- =========================================================================
+
+ALTER TABLE public.tools
+  ADD COLUMN plex_linked_by TEXT
+    CHECK (plex_linked_by IS NULL OR plex_linked_by IN ('manual', 'writeback', 'sync')),
+  ADD COLUMN plex_linked_at TIMESTAMPTZ,
+  ADD COLUMN qty_on_hand    NUMERIC,
+  ADD COLUMN qty_tracked    BOOLEAN,
+  ADD COLUMN qty_synced_at  TIMESTAMPTZ;
+
+-- Reverse lookup: "which tool is linked to this Plex supply-item?"
+-- Partial because most rows will have NULL plex_supply_item_id until
+-- #3 writeback catches up.
+CREATE INDEX tools_plex_supply_item_id_idx
+  ON public.tools (plex_supply_item_id)
+  WHERE plex_supply_item_id IS NOT NULL;
+
+-- Column semantics documented in the DB so they're visible in the
+-- Supabase Table Editor + `psql \d+ tools`.
+COMMENT ON COLUMN public.tools.plex_linked_by IS
+  'How plex_supply_item_id was populated. ''manual'' = hand-curated, ''writeback'' = captured from #3 Fusion->Plex write sync response, ''sync'' = automated description-match pass. NULL = not linked.';
+
+COMMENT ON COLUMN public.tools.plex_linked_at IS
+  'When plex_supply_item_id was set. NULL = not linked.';
+
+COMMENT ON COLUMN public.tools.qty_on_hand IS
+  'Running balance derived from summing Plex inventory-history/item-adjustments for plex_supply_item_id. NULL = unknown (tool not linked, or not yet synced, or no adjustment history).';
+
+COMMENT ON COLUMN public.tools.qty_tracked IS
+  'TRUE if the linked Plex supply-item has one or more adjustment records. FALSE = linked but Plex has no inventory history for it (the 97% case per the 2026-04-15 probe). NULL = not yet checked.';
+
+COMMENT ON COLUMN public.tools.qty_synced_at IS
+  'When qty_on_hand / qty_tracked were last refreshed from Plex. Distinct from plex_synced_at (the Fusion->Plex write-sync timestamp, populated by #3).';


### PR DESCRIPTION
## Summary

Migration 0005 adds the schema backing tool on-hand quantity in the Datum UI (parent issue #49, implementation issue #75).

Five new columns on `public.tools`:

| Column | Purpose |
|---|---|
| `plex_linked_by` | Provenance — `manual` / `writeback` / `sync` |
| `plex_linked_at` | When the link was established |
| `qty_on_hand` | Running balance from `item-adjustments` summation |
| `qty_tracked` | TRUE = Plex has history; FALSE = linked but no history; NULL = not checked |
| `qty_synced_at` | When qty was last refreshed (separate from `plex_synced_at`, which is the Fusion→Plex write-sync) |

Plus a partial index on `plex_supply_item_id` for reverse lookups, and `COMMENT ON COLUMN` documenting intent.

## Context

Originally planned as a separate `tool_plex_links` table (#74) — but `tools.plex_supply_item_id UUID` already exists from [0001_initial_schema.sql:116](db/migrations/0001_initial_schema.sql:116), so a separate table would duplicate state. Flattening avoids a join on every ToolsPage load. #74 closed as superseded.

Also `.gitignore`s `scratch/` — where the #49 probe scripts live.

## Verification

- Migration applied to `datum` Supabase project via MCP `apply_migration` — success
- `list_tables --verbose` confirms all 5 columns present with correct types, check constraint on `plex_linked_by`, and all five comments
- Existing 155 rows in `tools` default to NULL for all new columns — no backfill needed
- 328 pytest green (no test changes — schema-only)

## Test plan

- [x] Migration applies cleanly to Supabase
- [x] `list_tables` shows new columns + constraint + comments
- [x] pytest still green (328)
- [ ] Merge triggers Cloudflare Workers build (no build impact expected — React code doesn't reference new columns yet)

## Related

- Closes part of #75 (schema slice; sync-script slice continues in the same issue)
- Supersedes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)