### PR TITLE
feat(sync): tool inventory qty sync (Plex -> Supabase) — #75

### DIFF
--- a/docs/Plex_API_Reference.md
+++ b/docs/Plex_API_Reference.md
@@ -100,6 +100,9 @@ Record counts are as of **2026-04-09** unless noted. Schemas captured
 | **200** | `production/v1/production-definitions/workcenters` | **143** | 21 MILLs. ⚠️ **Primary key is `workcenterId`, not `id`.** Fields: `buildingCode, buildingId, ipAddress, name, plcName, productionLineId, tankSilo, workcenterCode, workcenterGroup, workcenterId, workcenterType`. |
 | **200** | `production/v1/production-definitions/workcenters/{id}` | — | Same 11 fields as list view. |
 | **200** | `purchasing/v1/purchase-orders` | — | **44.2 MB** unfiltered. Full PO history. `?updatedAfter=` filter confirmed as a silent no-op on 2026-04-09 (byte-identical response). |
+| **200** | `inventory/v1-beta1/inventory-history/item-adjustments?ItemId=<uuid>&StartDate=<ISO>&EndDate=<ISO>` | varies | **Supply-item adjustment log.** 31/1,109 tools have non-empty history (2026-04-15). Fields: `adjustmentDate, itemId, itemNo, location, locationId, quantity, transactionType`. Summing `quantity` (already signed) gives running balance. **Dates MUST be full ISO with `Z`** (plain YYYY-MM-DD → 400 ARGUMENT_INVALID). See §3.6. |
+| **200** | `inventory/v1/inventory-tracking/containers` | **10,676** | On-hand for parts (RAW/WIP/FG). Fields include `quantity, partId, partNo, location, locationId, serialNo, lotId, inventoryType`. Disjoint from supply-items (tools). |
+| **200** | `inventory/v1/inventory-history/container-adjustments?BeginDate=<ISO>&EndDate=<ISO>` | **6,298** | Per-container adjustment log. Fields: `adjustmentCode, adjustmentDate, location, partId, partNumber, quantity, serialNo, ...`. |
 | **200** | `scheduling/v1/jobs` | TBD | **NEW — discovered 2026-04-09.** Returns 200 but **15.8s response time**, so the body is large. Schema, record count, and whether it carries tool/operation/workcenter FKs all TBD. Worth a deep-dive as follow-up to issue #5 (routing/operation linkage) — if jobs link to tools, we get the missing operation→tool mapping for free. |
 
 ### Probed — returned 404 (not subscribed or doesn't exist)
@@ -155,6 +158,27 @@ from the 2026-04-08 Decision Log):
 - `"Tap #8-32 H3 Spiral Point"`
 
 Fusion will insert clean vendor part numbers like `"990910"`, so expect essentially zero collision with existing Plex records on first sync.
+
+### §3.6 — Supply-item `item-adjustments` and the `transactionType` sign table
+
+Endpoint: `GET inventory/v1-beta1/inventory-history/item-adjustments`
+Required params: `ItemId` (supply-item UUID), `StartDate`, `EndDate` (full ISO with `Z`).
+
+**Key finding (probed 2026-04-15 across all 1,109 `category="Tools & Inserts"` supply-items):** the `quantity` field is delivered **pre-signed** — positive for additions, negative for removals. You do NOT need to apply sign based on `transactionType`. Sum `quantity` directly to get the running balance.
+
+The enumerated `transactionType` values across 2,005 real records:
+
+| transactionType | records | qty_min | qty_max | quantity sign | interpretation |
+|---|---:|---:|---:|---|---|
+| `PO Receipt` | 1,479 | 1.0 | 100.0 | always `+` | vendor received into stock |
+| `Checkout` | 326 | -75.0 | -1.0 | always `-` | pulled from crib to production |
+| `Correction` | 125 | -6433.0 | 78.0 | either | manual count adjustment, signed |
+| `Check In` | 74 | 1.0 | 103.0 | always `+` | returned to crib / physical recount up |
+| `null` | 1 | 19.0 | 19.0 | — | one record with missing `transactionType`; treat as data-quality issue, still sum the qty |
+
+**Implementation rule:** `running_balance = sum(r.quantity for r in records)`. No sign flip, no lookup table. If future records introduce a new `transactionType`, the pre-signed `quantity` contract should still hold — but the sync script should log any unknown `transactionType` values it encounters as a warning for review.
+
+Of Grace's 1,109 tools, **31 (2.8%) have non-empty adjustment history.** The remaining 1,078 have never been tracked in Plex inventory at all — a data-quality finding, not an API limitation. Datum distinguishes this in `tools.qty_tracked`: TRUE = ≥1 record, FALSE = linked but Plex has no history (display as "not tracked"), NULL = not yet checked by sync.
 
 ### Where tooling data actually lives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
 
 [project.scripts]
 datum-sync = "sync:cli"
+datum-sync-inventory = "sync_tool_inventory:cli"
 datum-ingest-reference = "ingest_reference:main"
 datum-enrich = "enrich:main"
 
@@ -34,6 +35,7 @@ py-modules = [
     "supabase_client",
     "sync",
     "sync_supabase",
+    "sync_tool_inventory",
     "tool_library_loader",
     "validate_library",
     "enrich",

--- a/sync_tool_inventory.py
+++ b/sync_tool_inventory.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+"""
+sync_tool_inventory.py
+Plex -> Supabase nightly sync of tool on-hand quantities.
+Grace Engineering -- Datum project  --  Issue #75
+=============================================================
+For every row in ``tools`` with a non-NULL ``plex_supply_item_id``, call
+``inventory/v1-beta1/inventory-history/item-adjustments`` and update:
+
+  qty_on_hand   -- sum of adjustment quantities (quantity is pre-signed by Plex)
+  qty_tracked   -- TRUE iff Plex returned >=1 adjustment record
+  qty_synced_at -- now()
+
+See docs/Plex_API_Reference.md Section 3.6 for the transactionType sign
+table. The contract: ``quantity`` is delivered pre-signed, so we sum it
+directly -- no lookup from transactionType required.
+
+Usage
+-----
+    py sync_tool_inventory.py                 # run the sync
+    py sync_tool_inventory.py --dry-run       # fetch + compute, no Supabase writes
+    py sync_tool_inventory.py -v              # debug logging
+    py sync_tool_inventory.py --log-file f.log
+
+Exit codes
+----------
+    0  All linked tools synced
+    1  One or more tools failed (partial)
+    2  Fatal: config missing, no tools linked, etc.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import bootstrap  # noqa: E402, F401 -- loads .env.local
+
+from plex_api import PlexClient, API_KEY, API_SECRET, TENANT_ID, USE_TEST  # noqa: E402
+from supabase_client import SupabaseClient  # noqa: E402
+
+log = logging.getLogger("datum.sync_tool_inventory")
+
+# History window. 2015-01-01 predates Grace's Plex go-live; using a wide
+# window means we capture the full running balance, not just recent deltas.
+# Plex requires full ISO with Z suffix -- plain dates return 400.
+DEFAULT_START = "2015-01-01T00:00:00Z"
+
+# Known transactionType values as of 2026-04-15 probe. Unknown values are
+# still summed (quantity is pre-signed) but we log a warning so new types
+# can be reviewed and added to the docs.
+KNOWN_TRANSACTION_TYPES = frozenset({
+    "PO Receipt",
+    "Checkout",
+    "Correction",
+    "Check In",
+})
+
+
+# ---------------------------------------------------------------
+# Result tracking
+# ---------------------------------------------------------------
+@dataclass
+class ToolResult:
+    fusion_guid: str
+    plex_supply_item_id: str
+    status: str  # "success" | "fail"
+    qty_on_hand: float | None = None
+    qty_tracked: bool | None = None
+    n_records: int = 0
+    message: str = ""
+
+
+@dataclass
+class SyncReport:
+    results: list[ToolResult] = field(default_factory=list)
+    unknown_transaction_types: set[str] = field(default_factory=set)
+    start_time: float = 0.0
+    end_time: float = 0.0
+
+    @property
+    def succeeded(self) -> list[ToolResult]:
+        return [r for r in self.results if r.status == "success"]
+
+    @property
+    def failed(self) -> list[ToolResult]:
+        return [r for r in self.results if r.status == "fail"]
+
+    @property
+    def tracked(self) -> list[ToolResult]:
+        return [r for r in self.succeeded if r.qty_tracked]
+
+    @property
+    def elapsed(self) -> float:
+        return self.end_time - self.start_time
+
+    def print_summary(self) -> None:
+        log.info("=" * 60)
+        log.info("Tool inventory sync complete")
+        log.info(
+            "  %d succeeded (%d with history, %d empty), %d failed",
+            len(self.succeeded),
+            len(self.tracked),
+            len(self.succeeded) - len(self.tracked),
+            len(self.failed),
+        )
+        log.info("  Elapsed: %.1fs", self.elapsed)
+        if self.unknown_transaction_types:
+            log.warning(
+                "  Unknown transactionType values encountered: %s "
+                "-- review and update docs/Plex_API_Reference.md Section 3.6",
+                sorted(self.unknown_transaction_types),
+            )
+        log.info("=" * 60)
+
+
+# ---------------------------------------------------------------
+# Pure helpers (easy to unit-test)
+# ---------------------------------------------------------------
+def compute_qty(records: list[dict]) -> tuple[float, bool]:
+    """Return (qty_on_hand, qty_tracked) for a list of adjustment records.
+
+    ``quantity`` is delivered pre-signed by Plex (positive for receipts/
+    check-ins, negative for checkouts), so we sum directly. Missing or
+    non-numeric quantities are skipped silently.
+
+    qty_tracked is TRUE iff ``records`` is non-empty -- a linked tool with
+    zero history is a valid, distinct state from "not linked".
+    """
+    total = 0.0
+    for r in records:
+        q = r.get("quantity")
+        if q is None:
+            continue
+        try:
+            total += float(q)
+        except (TypeError, ValueError):
+            continue
+    return total, len(records) > 0
+
+
+def collect_unknown_types(records: list[dict]) -> set[str]:
+    """Return the set of transactionType values not in KNOWN_TRANSACTION_TYPES."""
+    unknown = set()
+    for r in records:
+        tt = r.get("transactionType")
+        if tt is not None and tt not in KNOWN_TRANSACTION_TYPES:
+            unknown.add(tt)
+    return unknown
+
+
+def _unwrap_records(body: Any) -> list[dict]:
+    """Plex inventory-history returns either a bare list or {data: [...]}."""
+    if isinstance(body, list):
+        return body
+    if isinstance(body, dict):
+        data = body.get("data")
+        if isinstance(data, list):
+            return data
+    return []
+
+
+# ---------------------------------------------------------------
+# Main sync
+# ---------------------------------------------------------------
+def sync_tool_inventory(
+    plex: PlexClient,
+    sb: SupabaseClient,
+    *,
+    start_date: str = DEFAULT_START,
+    end_date: str | None = None,
+    dry_run: bool = False,
+) -> SyncReport:
+    """Sync qty_on_hand / qty_tracked / qty_synced_at from Plex to Supabase.
+
+    Fetches every ``tools`` row with a non-NULL ``plex_supply_item_id``,
+    calls ``inventory/v1-beta1/inventory-history/item-adjustments`` for
+    each, and writes the computed totals back. Returns a SyncReport.
+    """
+    report = SyncReport(start_time=time.monotonic())
+
+    if end_date is None:
+        end_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # 1. Fetch linked tools from Supabase
+    linked = sb.select(
+        "tools",
+        columns="fusion_guid,plex_supply_item_id",
+        filters={"plex_supply_item_id": "not.is.null"},
+    )
+    log.info("Found %d linked tool(s) in Supabase", len(linked))
+
+    if not linked:
+        report.end_time = time.monotonic()
+        return report
+
+    # 2. For each, fetch adjustments and update Supabase
+    for tool in linked:
+        fusion_guid = tool["fusion_guid"]
+        plex_id = tool["plex_supply_item_id"]
+
+        env = plex.get_envelope(
+            "inventory", "v1-beta1", "inventory-history/item-adjustments",
+            params={"ItemId": plex_id, "StartDate": start_date, "EndDate": end_date},
+        )
+
+        if not env["ok"]:
+            report.results.append(ToolResult(
+                fusion_guid=fusion_guid,
+                plex_supply_item_id=plex_id,
+                status="fail",
+                message=f"Plex {env['status']}: {env.get('error') or env.get('body')}",
+            ))
+            log.error("  FAIL %s: Plex HTTP %s", fusion_guid, env["status"])
+            continue
+
+        records = _unwrap_records(env["body"])
+        qty_on_hand, qty_tracked = compute_qty(records)
+        unknown = collect_unknown_types(records)
+        if unknown:
+            report.unknown_transaction_types.update(unknown)
+            log.warning(
+                "  %s: unknown transactionType(s) %s (still summing; pre-signed quantity)",
+                fusion_guid, sorted(unknown),
+            )
+
+        result = ToolResult(
+            fusion_guid=fusion_guid,
+            plex_supply_item_id=plex_id,
+            status="success",
+            qty_on_hand=qty_on_hand,
+            qty_tracked=qty_tracked,
+            n_records=len(records),
+        )
+
+        if dry_run:
+            log.info(
+                "  DRY-RUN %s: qty=%s tracked=%s n=%d",
+                fusion_guid, qty_on_hand, qty_tracked, len(records),
+            )
+            report.results.append(result)
+            continue
+
+        # 3. Write back to Supabase
+        try:
+            sb.update(
+                "tools",
+                {
+                    "qty_on_hand": qty_on_hand,
+                    "qty_tracked": qty_tracked,
+                    "qty_synced_at": datetime.now(timezone.utc).isoformat(),
+                },
+                filters={"fusion_guid": f"eq.{fusion_guid}"},
+            )
+            log.info(
+                "  OK %s: qty=%s tracked=%s n=%d",
+                fusion_guid, qty_on_hand, qty_tracked, len(records),
+            )
+            report.results.append(result)
+        except Exception as e:
+            result.status = "fail"
+            result.message = f"Supabase update: {e}"
+            log.error("  FAIL %s: Supabase update: %s", fusion_guid, e)
+            report.results.append(result)
+
+    report.end_time = time.monotonic()
+    return report
+
+
+# ---------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Datum -- sync tool on-hand qty from Plex to Supabase",
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Fetch and compute, but do not write to Supabase")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Enable debug-level logging")
+    parser.add_argument("--log-file", type=str, default=None,
+                        help="Append logs to this file (in addition to stdout)")
+    parser.add_argument("--start-date", type=str, default=DEFAULT_START,
+                        help=f"ISO start date (default: {DEFAULT_START})")
+    args = parser.parse_args(argv)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    if args.log_file:
+        handlers.append(logging.FileHandler(args.log_file, encoding="utf-8"))
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=handlers,
+    )
+
+    log.info("Tool inventory sync starting%s", " (dry-run)" if args.dry_run else "")
+
+    try:
+        plex = PlexClient(API_KEY, API_SECRET, TENANT_ID, use_test=USE_TEST)
+        sb = SupabaseClient()
+    except Exception as e:
+        log.critical("Config error: %s", e)
+        return 2
+
+    try:
+        report = sync_tool_inventory(
+            plex, sb,
+            start_date=args.start_date,
+            dry_run=args.dry_run,
+        )
+    except Exception as e:
+        log.critical("Fatal sync error: %s", e)
+        return 2
+
+    report.print_summary()
+
+    if not report.results:
+        log.warning("No linked tools to sync -- populate tools.plex_supply_item_id first")
+        return 2
+
+    return 1 if report.failed else 0
+
+
+def cli() -> None:
+    """Console-script entry point (``datum-sync-inventory``)."""
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_sync_tool_inventory.py
+++ b/tests/test_sync_tool_inventory.py
@@ -1,0 +1,319 @@
+"""
+Tests for sync_tool_inventory.py -- Plex -> Supabase qty sync.
+
+Focus on:
+  - compute_qty(): pre-signed quantity sum, empty records, bad quantities
+  - collect_unknown_types(): detection of new transactionType values
+  - _unwrap_records(): handles bare-list and {data: [...]} envelopes
+  - sync_tool_inventory(): writes qty_on_hand/qty_tracked/qty_synced_at,
+    skips writes on --dry-run, logs failures without aborting the batch
+  - CLI exit codes: 0 success, 1 partial fail, 2 no linked tools
+
+All Plex + Supabase I/O is mocked.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sync_tool_inventory import (
+    compute_qty,
+    collect_unknown_types,
+    _unwrap_records,
+    sync_tool_inventory,
+    main,
+    KNOWN_TRANSACTION_TYPES,
+    ToolResult,
+)
+
+
+# ---------------------------------------------------------------
+# compute_qty
+# ---------------------------------------------------------------
+class TestComputeQty:
+    def test_pre_signed_positive_and_negative_sum(self):
+        # Real-world: PO Receipt +50, Checkout -43, PO Receipt +44 -> +51
+        records = [
+            {"quantity": 50.0, "transactionType": "PO Receipt"},
+            {"quantity": -43.0, "transactionType": "Checkout"},
+            {"quantity": 44.0, "transactionType": "Check In"},
+        ]
+        qty, tracked = compute_qty(records)
+        assert qty == pytest.approx(51.0)
+        assert tracked is True
+
+    def test_empty_records_zero_and_untracked(self):
+        qty, tracked = compute_qty([])
+        assert qty == 0.0
+        assert tracked is False
+
+    def test_single_record_tracked_even_if_zero(self):
+        # A linked tool with one adjustment whose delta nets to zero is
+        # still "tracked" -- the distinction is presence of history.
+        records = [{"quantity": 0, "transactionType": "Correction"}]
+        qty, tracked = compute_qty(records)
+        assert qty == 0.0
+        assert tracked is True
+
+    def test_missing_quantity_is_skipped(self):
+        records = [
+            {"quantity": 10, "transactionType": "PO Receipt"},
+            {"transactionType": "Correction"},  # no quantity key
+            {"quantity": None, "transactionType": "Correction"},
+        ]
+        qty, tracked = compute_qty(records)
+        assert qty == pytest.approx(10.0)
+        # tracked counts records, not summable ones -- Plex returned 3 rows
+        assert tracked is True
+
+    def test_non_numeric_quantity_is_skipped(self):
+        records = [
+            {"quantity": 5, "transactionType": "PO Receipt"},
+            {"quantity": "not-a-number", "transactionType": "Correction"},
+        ]
+        qty, _ = compute_qty(records)
+        assert qty == pytest.approx(5.0)
+
+    def test_string_numeric_quantity_is_summed(self):
+        # PostgREST-style numeric strings should still work.
+        records = [{"quantity": "12.5", "transactionType": "PO Receipt"}]
+        qty, _ = compute_qty(records)
+        assert qty == pytest.approx(12.5)
+
+    def test_negative_running_balance_preserved(self):
+        # Plex occasionally returns a net-negative balance (data-quality
+        # issue). The sync must preserve it faithfully, not clamp to 0.
+        records = [
+            {"quantity": 10, "transactionType": "PO Receipt"},
+            {"quantity": -50, "transactionType": "Checkout"},
+        ]
+        qty, _ = compute_qty(records)
+        assert qty == pytest.approx(-40.0)
+
+
+# ---------------------------------------------------------------
+# collect_unknown_types
+# ---------------------------------------------------------------
+class TestCollectUnknownTypes:
+    def test_all_known_returns_empty(self):
+        records = [
+            {"transactionType": "PO Receipt"},
+            {"transactionType": "Checkout"},
+            {"transactionType": "Correction"},
+            {"transactionType": "Check In"},
+        ]
+        assert collect_unknown_types(records) == set()
+
+    def test_null_transaction_type_is_not_unknown(self):
+        # null is an observed data-quality quirk, not a new type.
+        assert collect_unknown_types([{"transactionType": None}]) == set()
+
+    def test_new_type_is_flagged(self):
+        records = [
+            {"transactionType": "PO Receipt"},
+            {"transactionType": "Scrap"},
+            {"transactionType": "Physical Inventory"},
+        ]
+        assert collect_unknown_types(records) == {"Scrap", "Physical Inventory"}
+
+    def test_known_set_matches_docs(self):
+        # Guard against accidental drift from docs/Plex_API_Reference.md Section 3.6.
+        assert KNOWN_TRANSACTION_TYPES == {
+            "PO Receipt", "Checkout", "Correction", "Check In",
+        }
+
+
+# ---------------------------------------------------------------
+# _unwrap_records
+# ---------------------------------------------------------------
+class TestUnwrapRecords:
+    def test_bare_list(self):
+        assert _unwrap_records([{"a": 1}]) == [{"a": 1}]
+
+    def test_data_envelope(self):
+        assert _unwrap_records({"data": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_empty_data_envelope(self):
+        assert _unwrap_records({"data": []}) == []
+
+    def test_missing_data_key(self):
+        assert _unwrap_records({"error": "nope"}) == []
+
+    def test_none(self):
+        assert _unwrap_records(None) == []
+
+
+# ---------------------------------------------------------------
+# sync_tool_inventory
+# ---------------------------------------------------------------
+def _ok_env(body):
+    return {"ok": True, "status": 200, "body": body, "error": None}
+
+
+def _fail_env(status=500, error="HTTP 500"):
+    return {"ok": False, "status": status, "body": None, "error": error}
+
+
+class TestSyncToolInventory:
+    def _linked_tools(self, *guids):
+        return [
+            {"fusion_guid": g, "plex_supply_item_id": f"plex-{g}"}
+            for g in guids
+        ]
+
+    def test_writes_qty_for_each_linked_tool(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = self._linked_tools("a", "b")
+        plex.get_envelope.side_effect = [
+            _ok_env([
+                {"quantity": 50, "transactionType": "PO Receipt"},
+                {"quantity": -10, "transactionType": "Checkout"},
+            ]),
+            _ok_env([]),  # linked but no history
+        ]
+
+        report = sync_tool_inventory(plex, sb)
+
+        assert len(report.succeeded) == 2
+        assert len(report.failed) == 0
+        # Two update calls, one per tool
+        assert sb.update.call_count == 2
+        first_call = sb.update.call_args_list[0]
+        assert first_call.args[0] == "tools"
+        values = first_call.args[1]
+        assert values["qty_on_hand"] == pytest.approx(40.0)
+        assert values["qty_tracked"] is True
+        assert "qty_synced_at" in values
+        assert first_call.kwargs["filters"] == {"fusion_guid": "eq.a"}
+        # Second tool: empty history -> tracked False, qty 0
+        second = sb.update.call_args_list[1]
+        assert second.args[1]["qty_on_hand"] == 0.0
+        assert second.args[1]["qty_tracked"] is False
+
+    def test_dry_run_does_not_write(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = self._linked_tools("a")
+        plex.get_envelope.return_value = _ok_env(
+            [{"quantity": 5, "transactionType": "PO Receipt"}]
+        )
+
+        report = sync_tool_inventory(plex, sb, dry_run=True)
+
+        sb.update.assert_not_called()
+        assert len(report.succeeded) == 1
+        assert report.succeeded[0].qty_on_hand == pytest.approx(5.0)
+
+    def test_plex_failure_is_recorded_and_does_not_abort_batch(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = self._linked_tools("a", "b")
+        plex.get_envelope.side_effect = [
+            _fail_env(500, "boom"),
+            _ok_env([{"quantity": 3, "transactionType": "PO Receipt"}]),
+        ]
+
+        report = sync_tool_inventory(plex, sb)
+
+        assert len(report.failed) == 1
+        assert len(report.succeeded) == 1
+        assert report.failed[0].fusion_guid == "a"
+        # Only one Supabase write (for the successful tool)
+        assert sb.update.call_count == 1
+
+    def test_supabase_update_failure_is_recorded(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = self._linked_tools("a")
+        plex.get_envelope.return_value = _ok_env(
+            [{"quantity": 1, "transactionType": "PO Receipt"}]
+        )
+        sb.update.side_effect = RuntimeError("postgrest borked")
+
+        report = sync_tool_inventory(plex, sb)
+
+        assert len(report.failed) == 1
+        assert "postgrest borked" in report.failed[0].message
+
+    def test_no_linked_tools_returns_empty_report(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = []
+
+        report = sync_tool_inventory(plex, sb)
+
+        assert report.results == []
+        plex.get_envelope.assert_not_called()
+        sb.update.assert_not_called()
+
+    def test_unknown_transaction_type_logged_and_still_summed(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = self._linked_tools("a")
+        plex.get_envelope.return_value = _ok_env([
+            {"quantity": 7, "transactionType": "PO Receipt"},
+            {"quantity": -2, "transactionType": "Scrap"},  # new type
+        ])
+
+        report = sync_tool_inventory(plex, sb)
+
+        assert report.succeeded[0].qty_on_hand == pytest.approx(5.0)
+        assert "Scrap" in report.unknown_transaction_types
+
+    def test_supabase_select_uses_not_null_filter(self):
+        plex = MagicMock()
+        sb = MagicMock()
+        sb.select.return_value = []
+
+        sync_tool_inventory(plex, sb)
+
+        sb.select.assert_called_once()
+        kwargs = sb.select.call_args.kwargs
+        assert kwargs["filters"] == {"plex_supply_item_id": "not.is.null"}
+        assert "fusion_guid" in kwargs["columns"]
+        assert "plex_supply_item_id" in kwargs["columns"]
+
+
+# ---------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------
+class TestCLI:
+    @patch("sync_tool_inventory.SupabaseClient")
+    @patch("sync_tool_inventory.PlexClient")
+    @patch("sync_tool_inventory.sync_tool_inventory")
+    def test_exit_0_on_full_success(self, mock_sync, mock_plex, mock_sb):
+        from sync_tool_inventory import SyncReport
+        rpt = SyncReport()
+        rpt.results.append(ToolResult("a", "p", "success", 5.0, True, 2))
+        rpt.end_time = 1.0
+        mock_sync.return_value = rpt
+
+        assert main([]) == 0
+
+    @patch("sync_tool_inventory.SupabaseClient")
+    @patch("sync_tool_inventory.PlexClient")
+    @patch("sync_tool_inventory.sync_tool_inventory")
+    def test_exit_1_on_partial_failure(self, mock_sync, mock_plex, mock_sb):
+        from sync_tool_inventory import SyncReport
+        rpt = SyncReport()
+        rpt.results.append(ToolResult("a", "p", "success"))
+        rpt.results.append(ToolResult("b", "q", "fail", message="x"))
+        rpt.end_time = 1.0
+        mock_sync.return_value = rpt
+
+        assert main([]) == 1
+
+    @patch("sync_tool_inventory.SupabaseClient")
+    @patch("sync_tool_inventory.PlexClient")
+    @patch("sync_tool_inventory.sync_tool_inventory")
+    def test_exit_2_on_no_linked_tools(self, mock_sync, mock_plex, mock_sb):
+        from sync_tool_inventory import SyncReport
+        mock_sync.return_value = SyncReport(end_time=1.0)
+        assert main([]) == 2
+
+    @patch("sync_tool_inventory.SupabaseClient")
+    @patch("sync_tool_inventory.PlexClient", side_effect=RuntimeError("no key"))
+    def test_exit_2_on_config_error(self, _plex, _sb):
+        assert main([]) == 2


### PR DESCRIPTION
## Summary
- Probed `inventory/v1-beta1/inventory-history/item-adjustments` across all 1,109 Grace tools. Finding: `quantity` is **delivered pre-signed** by Plex (positive for PO Receipt/Check In, negative for Checkout, mixed for Correction). No sign-table lookup needed — sum directly. 31/1,109 tools have non-empty history, matching the 2026-04-15 probe.
- New `sync_tool_inventory.py` reads `tools.plex_supply_item_id`, pulls adjustments per tool, writes `qty_on_hand` / `qty_tracked` / `qty_synced_at`. `--dry-run`, `-v`, `--log-file`, `--start-date` flags. Exit codes 0 / 1 / 2.
- `docs/Plex_API_Reference.md` §3.6 documents the endpoint, sign contract, and enumerated transactionType table. Three new rows in the verified-endpoints table.
- 27 new pytest cases covering the sum logic, unknown-type detection, envelope unwrap, per-tool failure isolation, dry-run, and CLI exit codes. **355 tests green.**

Follow-ups (NOT in this PR):
- Populate `tools.plex_supply_item_id` for the ~31 tracked tools (manual curation for now, #75 sync-based matching later).
- Deploy to GRACE144 Task Scheduler alongside `datum-sync`.
- #76 UI column on ToolsPage reading from `qty_on_hand` / `qty_tracked`.

## Test plan
- [x] `py -m pytest` — 355 passed
- [ ] Live `py sync_tool_inventory.py --dry-run` against production once a tool is linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)