### PR TITLE
feat(infra): GCP provisioning scripts + migration/reorg plans

### DIFF
--- a/docs/GCP_MIGRATION.md
+++ b/docs/GCP_MIGRATION.md
@@ -1,0 +1,235 @@
+# GCP Migration — Datum
+
+**Status:** Planning (2026-04-17). No code changes in the session that wrote this doc.
+**Umbrella issue:** [#85](https://github.com/grace-shane/Datum/issues/85)
+
+This document captures the agreed architecture for moving Datum off Supabase +
+Autodesk Desktop Connector (ADC) + the locked-down work machine, and onto GCP +
+the Autodesk Platform Services (APS) HTTP API. Read this together with
+[`BRIEFING.md`](./BRIEFING.md) for project context and
+[`validate_library_spec.md`](./validate_library_spec.md) for the pre-sync gate
+(the validation engine itself is source-agnostic and survives the migration
+unchanged — only the CLI entry point that walks `CAMTools` needs to change).
+
+---
+
+## Why migrate
+
+Three forcing functions collided in April 2026:
+
+1. **Dev machine at Grace is locked down.** New tooling can't be installed,
+   long-lived dev servers are awkward, `.env.local` churn is painful. A
+   persistent cloud dev environment (`datum-dev`) solves this.
+2. **Supabase is a stopgap.** It earned its keep during Phase A, but it adds a
+   vendor we don't need once GCP is the deploy surface. Cloud SQL gives us one
+   infra control plane.
+3. **APS removes the ADC dependency.** Autodesk Platform Services exposes Fusion
+   Hub tool libraries over HTTP. That kills the "ADC stall for >25h" failure
+   mode in `tool_library_loader.py:34`, the "file locked mid-sync" error path
+   in `tool_library_loader.py:104`, and the whole CAMTools network share as a
+   moving part. `aps_client.py` already exists in the tree — partial
+   implementation from earlier Fusion-cloud work.
+
+---
+
+## Target architecture
+
+```
+  Autodesk Hub (APS)
+      │  HTTP (OAuth, refresh via Secret Manager)
+      ▼
+  ┌─────────────────┐         ┌─────────────────────┐
+  │  datum-runtime  │ ──────▶ │   Cloud SQL         │
+  │  e2-micro       │         │   Postgres          │
+  │  always-on      │         │   db-f1-micro       │
+  │  us-central1    │         │   libraries / tools │
+  │  (sync + API)   │         │   cutting_presets   │
+  └─────────────────┘         └─────────────────────┘
+      │ Secret Manager: PLEX_API_KEY, PLEX_API_SECRET,
+      │                 DB URL, APS client creds
+      ▼
+  Plex connect.plex.com — identity slice → supply-items
+
+  Cloudflare (datum.graceops.dev) ──▶ Flask on runtime VM ──▶ React UI
+
+  ┌─────────────────┐
+  │  datum-dev      │  Cloud Scheduler: start 7am CT / stop 5pm CT (Mon–Fri)
+  │  e2-standard-2  │
+  │  Ubuntu 22.04   │  SSH target for VS Code Remote / Claude Code
+  └─────────────────┘
+```
+
+---
+
+## VM topology
+
+| VM | Purpose | Machine type | OS | Runtime model |
+|---|---|---|---|---|
+| `datum-dev` | Cloud dev environment — replaces the locked-down work machine. SSH target for VS Code Remote / Claude Code. | `e2-standard-2` | Ubuntu 22.04 | Business hours only. Cloud Scheduler start 7am CT / stop 5pm CT, Mon–Fri. Off weekends and evenings. |
+| `datum-runtime` | Nightly sync cron + Flask API surface for the React UI | `e2-micro` | Ubuntu 22.04 | Always-on in `us-central1` (free tier) |
+
+### Why split them
+
+`datum-dev` needs enough RAM/CPU to run VS Code Remote, pytest, and Claude Code
+comfortably — but only during work hours. Keeping it on 24/7 wastes money and
+lets state rot (nightly shutdowns force us to keep env setup scripted).
+`datum-runtime` only needs to call APS once a night and serve a light Flask API,
+so the free `e2-micro` fits. Keeping them separate means a dev-side crash,
+reboot, or upgrade can't take the nightly sync down.
+
+---
+
+## Service mapping
+
+| Today | After migration | Notes |
+|---|---|---|
+| Supabase (`datum` project, us-east-2) | Cloud SQL `db-f1-micro`, us-central1 | Same Postgres schema and bare table names (`libraries` / `tools` / `cutting_presets`) — Supabase is on its own DB, so no prefix is needed for isolation |
+| Autodesk Desktop Connector + CAMTools network share | Autodesk Platform Services (APS) HTTP API | Removes 25h stale-file guard, mid-sync file-lock handling, and per-machine ADC install requirement. `aps_client.py` is already partially wired. |
+| Windows Task Scheduler (planned, never built) | Cloud Scheduler → systemd timer on `datum-runtime` (or Cloud Run Job) | Cloud Scheduler also drives the dev VM start/stop |
+| `.env.local` loaded by `bootstrap.py` | Secret Manager on both VMs, fallback `.env.local` for local dev | Never commit Secrets; `bootstrap.py` gains a Secret Manager loader path |
+| Work machine (locked down) | `datum-dev` VM + Cloudflare DNS | `datum.graceops.dev` serves the React UI over TLS |
+| Supabase service-role key (server-side only) | Cloud SQL connection via Cloud SQL Auth Proxy / IAM | Same "never ship to browser" model; Flask holds the connection server-side |
+| (none — Phase 5 was never deployed) | Cloudflare in front of Cloud Run or runtime VM | `datum.graceops.dev` |
+
+**Not in scope:** Firebase, Cloud Data Connect, Firestore. Cloud SQL is the only
+database. The React UI reads through Flask, not directly.
+
+---
+
+## Data flow (ADC-free)
+
+1. Cloud Scheduler fires nightly at midnight CT → triggers the sync unit on
+   `datum-runtime`.
+2. `sync.py` authenticates to APS using the OAuth client credentials stored in
+   Secret Manager, lists Fusion Hub projects, and downloads tool library JSON
+   over HTTP.
+3. `validate_library.py` gates each library per
+   [`validate_library_spec.md`](./validate_library_spec.md). FAIL aborts that
+   library; PASS continues.
+4. Upsert into Cloud SQL `libraries` / `tools` / `cutting_presets` via the new
+   DB client.
+5. `build_supply_item_payload` (issue #3) reads the `tools` table and pushes
+   the identity slice (vendor part #, description) to Plex
+   `inventory/v1/inventory-definitions/supply-items`.
+6. Flask (`app.py`) serves `/api/*` and the React UI from `datum-runtime`.
+   Cloudflare terminates TLS at `datum.graceops.dev` and proxies to the VM.
+
+The production write guard (`PLEX_ALLOW_WRITES=1`, PR #17) still applies.
+Default OFF in the VM boot env; the systemd sync unit sets it just for the
+invocation window.
+
+---
+
+## Credentials — Secret Manager layout
+
+| Secret name | Contents | Consumers |
+|---|---|---|
+| `plex-api-key` | Datum Consumer Key (rotates every 31 days, next 2026-05-08) | `datum-runtime` (sync), `datum-dev` (optional) |
+| `plex-api-secret` | Datum Consumer Secret (currently optional — reserved for future) | same |
+| `plex-tenant-id` | Grace tenant UUID (`58f781ba-…`) — not actually secret, but convenient | same |
+| `db-url` | Cloud SQL Postgres connection string | `datum-runtime`, `datum-dev` |
+| `aps-client-id`, `aps-client-secret` | Autodesk Platform Services app credentials | `datum-runtime` |
+| `aps-refresh-token` | APS OAuth refresh token (rotated by the sync runner) | `datum-runtime` |
+
+### IAM split
+
+- `datum-runtime` service account — `Secret Accessor` on all of the above,
+  `Cloud SQL Client` on the runtime DB.
+- `datum-dev` service account — `Secret Accessor` on everything except
+  `aps-refresh-token` (the runner owns token rotation; dev shouldn't contend).
+  `Cloud SQL Client` on the runtime DB for read/write access during dev.
+
+### `bootstrap.py` behavior
+
+Add a `USE_SECRET_MANAGER=1` path that pulls secrets at process start via
+`google-cloud-secret-manager`. `setdefault` semantics are preserved — a real
+shell env var still wins (lesson from BRIEFING.md History §4, the stale
+`PLEX_API_KEY` Windows env var that shadowed `.env.local`). Local dev falls
+back to `.env.local` exactly as today.
+
+---
+
+## Affected code (change-surface map)
+
+**No edits in the planning session. This is the enumeration that future
+implementation PRs will work through.**
+
+### ADC / local-filesystem removal
+
+| File | Change | Reason |
+|---|---|---|
+| [`tool_library_loader.py`](../tool_library_loader.py) | Replace with an APS-backed loader or refactor to a source-agnostic interface with an APS adapter. The 25h stale-file guard becomes an "APS response freshness" check or is retired entirely. | Core ADC reader: `_DC_REL_PATH = DC\Fusion\XWERKS\Assets\CAMTools`, `load_library`, `load_all_libraries`, `_check_file_age`, `report_library_contents`. Every consumer path flows through here. |
+| [`sync.py`](../sync.py) | Delete the "local ADC fallback" branch (~lines 265–420). APS becomes the only source. `--local-adc` flag becomes dead code. | File header currently reads "APS cloud-first, local ADC fallback" — the fallback is the thing we're removing. |
+| [`app.py`](../app.py) | `/api/fusion/validate` GET currently walks `CAM_TOOLS_DIR`; switch to APS. `/api/aps/*` OAuth routes stay (they were built for this). `/api/fusion/libraries` GET likewise. | Flask endpoints that back the React library browser. |
+| [`validate_library.py`](../validate_library.py) | CLI default resolves a CAMTools dir; switch to APS listing, or require an explicit `--file` / `--hub-project`. Engine itself is unchanged — the spec stays valid. | `CAM_TOOLS_DIR` references around line 996. |
+| [`aps_client.py`](../aps_client.py) | Audit for completeness against the new required scope. Add refresh-token rotation writing back to Secret Manager. | Already partially implemented — reused, not rewritten. |
+| [`tests/test_tool_library_loader.py`](../tests/test_tool_library_loader.py), [`tests/test_sync.py`](../tests/test_sync.py), [`tests/test_validate_library.py`](../tests/test_validate_library.py), [`tests/test_app_routes.py`](../tests/test_app_routes.py) | Replace filesystem fixtures with APS-response fixtures (mocked HTTP). | Follow the production code. |
+
+### Supabase → Cloud SQL
+
+| File | Change | Reason |
+|---|---|---|
+| [`supabase_client.py`](../supabase_client.py) | Replace with `db_client.py` (psycopg / SQLAlchemy against Cloud SQL). Preserve the public surface so call sites change by import only. | Single point of change if the adapter is clean. |
+| [`sync_supabase.py`](../sync_supabase.py) | Rename → `sync_db.py` (or keep name, just swap client). Switch to new client. | |
+| [`sync_tool_inventory.py`](../sync_tool_inventory.py), [`populate_supply_items.py`](../populate_supply_items.py), [`ingest_reference.py`](../ingest_reference.py), [`enrich.py`](../enrich.py), [`scripts/load_sample.py`](../scripts/load_sample.py) | Swap `from supabase_client import …` for new DB client import. | All currently depend on `supabase_client`. |
+| [`app.py`](../app.py) | Swap Supabase reads for DB client reads on every Flask route that hits the DB. | React UI back-end. |
+| [`tests/test_supabase_client.py`](../tests/test_supabase_client.py), [`tests/conftest.py`](../tests/conftest.py), [`tests/test_sync_supabase.py`](../tests/test_sync_supabase.py), [`tests/test_sync_tool_inventory.py`](../tests/test_sync_tool_inventory.py), [`tests/test_populate_supply_items.py`](../tests/test_populate_supply_items.py), [`tests/test_ingest_reference.py`](../tests/test_ingest_reference.py), [`tests/test_enrich.py`](../tests/test_enrich.py), [`tests/test_sync.py`](../tests/test_sync.py) | Point fixtures at a local Postgres (docker) or SQLAlchemy fake; drop the Supabase REST mocks. | Follow the production code. |
+
+### Credentials / secrets
+
+| File | Change | Reason |
+|---|---|---|
+| [`bootstrap.py`](../bootstrap.py) | Add Secret Manager loader path behind `USE_SECRET_MANAGER=1`. Keep `.env.local` fallback. Preserve `setdefault` semantics (shell env wins — see BRIEFING History §4). | Entry point for every credential read. |
+| [`plex_api.py`](../plex_api.py) | No change — reads env vars which `bootstrap.py` populates. | Transparent to the API layer. |
+
+### Docs needing follow-up edits (not in this doc)
+
+- `CLAUDE.md` entry #7 (Supabase staging layer) — repoint at Cloud SQL
+- `README.md` — status table, architecture diagram, "Why the pivot" paragraph
+- `docs/BRIEFING.md` — "Current situation" block, architecture diagram, Notion link to schema page
+- `docs/validate_library_spec.md` — any language mentioning "ADC share" or the network-share GET path
+
+---
+
+## Migration sequence (suggested)
+
+1. **Provision GCP** — project, `datum-dev`, `datum-runtime`, Cloud SQL,
+   Secret Manager entries. No application code yet.
+2. **Apply schema to Cloud SQL** with bare table names (`libraries` / `tools`
+   / `cutting_presets`) — matches the current Supabase schema post-PR #34.
+3. **`bootstrap.py` Secret Manager path** — additive change, can land before
+   anything else is wired up; it's a no-op until `USE_SECRET_MANAGER=1` is set.
+4. **`db_client.py`** — new module, drop-in for `supabase_client`. Land behind
+   a feature flag (`USE_CLOUD_SQL=1`), dual-read/dual-write if useful, then flip.
+5. **APS-only loader** — replace/refactor `tool_library_loader.py`, gut the
+   local-ADC branch in `sync.py`, update Flask routes. Tests follow.
+6. **Cloud Scheduler wiring** — nightly sync cron + dev VM start/stop schedules.
+7. **Cloudflare DNS** — `datum.graceops.dev` → runtime VM (or Cloud Run if we
+   promote the Flask app off the VM; defer that decision).
+8. **Decom** — remove Supabase project, strip ADC references from CLAUDE.md,
+   BRIEFING, README, validate_library_spec.
+
+---
+
+## Open questions / risks
+
+- **Cold Cloud SQL on the nightly cron.** `db-f1-micro` + one-shot nightly
+  writes may hit cold-start latency. Acceptable for a midnight job; revisit if
+  it ever matters for interactive UI reads.
+- **APS rate limits + OAuth refresh.** Need to confirm refresh-token lifetime
+  and build rotation into `aps_client.py`. Token write-back to Secret Manager
+  needs its own IAM grant.
+- **Cloud Run vs runtime VM for Flask.** Either works. The VM is simpler given
+  we already have one; Cloud Run is cheaper at idle and scales to zero. Defer
+  the decision until the migration is otherwise done.
+- **`datum-dev` state management.** Business-hours-only means no long-running
+  background processes on it. Fine for editor + pytest + Claude Code; document
+  so we don't get surprised.
+- **Secret Manager IAM per service account.** `datum-dev` should not have
+  write access to production credentials; scope narrowly.
+- **Production write guard on the runtime VM.** `PLEX_ALLOW_WRITES` should
+  default OFF at boot and be set only by the systemd unit that invokes the
+  nightly sync. Never in the VM's shell profile.
+- **APS token vs Consumer Key lifetime.** Plex Consumer Key rotates every 31
+  days; APS tokens rotate on their own cycle. Two independent rotation alarms;
+  document both in the runbook.

--- a/docs/REORG_AND_STACK.md
+++ b/docs/REORG_AND_STACK.md
@@ -1,0 +1,317 @@
+# Reorg + Stack Update — Datum
+
+**Status:** Planning (2026-04-17). No code changes in the session that wrote this doc.
+**Trigger:** Grace Engineering has provided Shane company-supplied GCP access and
+budget for Datum. That funds the [GCP migration epic #85](https://github.com/grace-shane/Datum/issues/85)
+and opens room for stack changes that wouldn't have been justifiable on a
+zero-budget project.
+**Relationship to #85:** This plan executes *before* the GCP migration. The
+repo ships to Cloud SQL + Cloud Run / VMs easier if it's organized and the DB
+layer is already vendor-neutral. See the sequencing block at the bottom.
+
+---
+
+## Scope boundaries (read first)
+
+These are explicit limits, not stretch goals. Written up front because
+"everyone asks when you have a UI" and scope creep is the fastest way to
+wreck a cleanup PR series.
+
+| Boundary | Meaning |
+|---|---|
+| **React UI is debug + show-and-tell only** | `datum.graceops.dev` is not a product Shane actively develops. Other Grace engineers use it and that's valuable, but feature requests land in a user-goals conversation before any code. No speculative features. |
+| **No mobile support** | Not now, not as part of this reorg, not as a stretch goal. No PWA, no mobile-first refactors, no React Native. If the UI renders acceptably on a tablet, that's a bonus, not a requirement. |
+| **Plex writes stay last** | Nothing in this plan changes the "DB first, Plex last, can't dry-run prod" sequencing. The reorg and stack update are strictly below the Plex write layer. |
+| **No new features masquerading as cleanup** | Organize moves files. Stack updates change imports. Neither adds behavior. New features get their own issues and PRs. |
+| **Don't touch the Flask endpoint-tester scope** | `app.py` + `templates/` + `static/` is Shane's personal Plex-API poking tool. It's not user-facing. Retain it through the reorg — Shane uses it to sanity-check Plex responses. React UI is the user-facing surface. |
+
+If any PR in this series starts drifting past these boundaries, pause and
+split the work instead of letting it grow.
+
+---
+
+## Why now, why this order
+
+Three reasons to organize before migrating, not after:
+
+1. **Vendor-neutral DB layer is the single highest-leverage stack change** —
+   and it's also the natural prerequisite for swapping Supabase → Cloud SQL.
+   Doing it after migration means a second round of rewrites. Doing it before
+   means Cloud SQL is a connection-string flip.
+2. **15 flat `.py` files at the repo root is the visible symptom of "we didn't
+   know what we were building yet."** That excuse is gone. We know what we're
+   building. The layout should reflect it.
+3. **Mixing a reorg PR with a migration PR makes every diff ambiguous** — is
+   this a rename, a rewrite, a behavior change? Separating them keeps review
+   tractable.
+
+Stack updates that *don't* unblock Cloud SQL (FastAPI, httpx, uv) are
+secondary. They're in §3 but flagged as "weigh against whether it unblocks
+anything," not mandatory.
+
+---
+
+## Current state
+
+```
+datum/
+├── 15 top-level *.py files    ← the main symptom
+├── tests/                      flat, 17 test files
+├── scripts/load_sample.py      single script, no organization needed
+├── db/migrations/              SQL migrations
+├── web/                        React UI (product surface)
+├── templates/, static/         legacy Flask endpoint-tester UI
+├── docs/                       documentation
+├── .github/workflows/          CI
+├── pyproject.toml              Python packaging
+├── requirements.txt, requirements-dev.txt   pinned deps
+└── README.md, CLAUDE.md, TODO.md
+```
+
+Pain points that motivate the reorg:
+
+- Four sync-adjacent entrypoints (`sync.py`, `sync_supabase.py`,
+  `sync_tool_inventory.py`, `populate_supply_items.py`) with overlapping
+  concerns — hard to tell which one is the real nightly path without
+  reading each
+- `supabase_client.py` is the direct blocker for Cloud SQL migration
+- No `datum/` package — imports are all top-level, which means worktree
+  discovery and cloud packaging both hit edge cases
+- Tests mirror the flat layout, which means `test_sync_supabase.py` +
+  `test_sync.py` + `test_sync_tool_inventory.py` live side by side with
+  no obvious relationship
+- The React UI sits in `web/` with no statement about whether it's part
+  of the Python project (it isn't) or a peer (it is) — affects how
+  Cloudflare, CI, and dependency management read the repo
+
+---
+
+## Phase 1: Organize
+
+One PR series, three or four PRs, each one mechanical. Goal: every file
+in `*.py` at the repo root gets a home.
+
+### Target Python package layout
+
+```
+datum/                           # Python package (importable as `datum.*`)
+├── __init__.py
+├── bootstrap.py                 # credential loader (moved from root)
+├── plex/
+│   ├── __init__.py
+│   ├── client.py                # from plex_api.py
+│   ├── diagnostics.py           # plex_diagnostics.py
+│   └── extractors.py            # extract_* helpers split from plex_api.py
+├── fusion/
+│   ├── __init__.py
+│   ├── aps.py                   # aps_client.py (primary source)
+│   └── adc_loader.py            # tool_library_loader.py (fallback, slated
+│                                #   for deletion under #85)
+├── db/
+│   ├── __init__.py
+│   ├── client.py                # supabase_client.py → becomes SQLAlchemy
+│   │                            #   in Phase 2
+│   └── ingest.py                # ingest_reference.py
+├── sync/
+│   ├── __init__.py
+│   ├── runner.py                # sync.py — the nightly CLI entry point
+│   ├── staging.py               # sync_supabase.py (writes to DB staging)
+│   ├── inventory.py             # sync_tool_inventory.py (Plex qty pull)
+│   ├── supply_items.py          # populate_supply_items.py
+│   ├── payload.py               # build_supply_item_payload (new home
+│   │                            #   for issue #3 work)
+│   └── enrich.py                # enrich.py
+├── validate/
+│   ├── __init__.py
+│   └── library.py               # validate_library.py
+└── web/                         # Flask API only — React UI stays separate
+    ├── __init__.py
+    ├── app.py                   # from top-level app.py
+    ├── templates/               # Flask endpoint-tester (retained)
+    ├── static/                  # Flask endpoint-tester assets (retained)
+    └── routes/
+        ├── plex.py              # /api/plex/*
+        ├── fusion.py            # /api/fusion/*, /api/aps/*
+        └── diagnostics.py       # /api/diagnostics/*
+```
+
+Top-level after reorg:
+
+```
+/
+├── datum/                  # Python package (above)
+├── web/                    # React UI (unchanged — peer to datum/,
+│                           #   NOT absorbed into the Python package)
+├── tests/                  # mirror datum/ structure
+├── db/migrations/          # SQL migrations (unchanged location)
+├── scripts/                # one-off CLI scripts
+├── docs/
+├── .github/workflows/
+├── pyproject.toml
+├── requirements.txt
+├── requirements-dev.txt
+└── README.md, CLAUDE.md, TODO.md
+```
+
+**Key decision:** `web/` (React) is a peer to `datum/` (Python), not a
+subdirectory of it. Different language, different toolchain, different
+deploy (Cloudflare Workers vs runtime VM). Monorepo layout, not nested.
+
+### File-move table
+
+| From | To | Notes |
+|---|---|---|
+| `plex_api.py` | `datum/plex/client.py` | Split `extract_*` helpers into `datum/plex/extractors.py` |
+| `plex_diagnostics.py` | `datum/plex/diagnostics.py` | |
+| `aps_client.py` | `datum/fusion/aps.py` | |
+| `tool_library_loader.py` | `datum/fusion/adc_loader.py` | Renamed to make its "fallback path" status visible |
+| `supabase_client.py` | `datum/db/client.py` | Becomes SQLAlchemy in Phase 2 |
+| `ingest_reference.py` | `datum/db/ingest.py` | |
+| `sync.py` | `datum/sync/runner.py` | The nightly CLI entry point |
+| `sync_supabase.py` | `datum/sync/staging.py` | |
+| `sync_tool_inventory.py` | `datum/sync/inventory.py` | |
+| `populate_supply_items.py` | `datum/sync/supply_items.py` | |
+| `enrich.py` | `datum/sync/enrich.py` | |
+| `validate_library.py` | `datum/validate/library.py` | Spec doc stays in `docs/` |
+| `bootstrap.py` | `datum/bootstrap.py` | |
+| `app.py` | `datum/web/app.py` | Split route handlers into `datum/web/routes/*.py` |
+| `templates/` | `datum/web/templates/` | Flask tester — retain |
+| `static/` | `datum/web/static/` | Flask tester — retain |
+| `run_dev.py` | stays at root | Dev launcher — convenient at the top level |
+| `scripts/load_sample.py` | unchanged | |
+| `web/` (React) | unchanged | Peer, not absorbed |
+
+`pyproject.toml` gets a `packages = ["datum"]` entry (or the src-layout
+equivalent) so `pip install -e .` picks it up.
+
+### Suggested PR breakdown
+
+1. **PR A — add `datum/` package skeleton, move leaf modules** (`bootstrap`,
+   `plex`, `fusion`, `validate`). Update imports. Green CI.
+2. **PR B — move sync layer** (`sync/*`). Update all imports. Green CI.
+3. **PR C — move Flask app** (`datum/web/`). Split route handlers. React UI
+   untouched. Green CI.
+4. **PR D — mirror-structure test reorg** — move `tests/test_*.py` into
+   `tests/plex/`, `tests/fusion/`, etc. Optional; low value if the flat
+   layout is readable.
+
+Each PR is ~15–30 file moves + import-path updates. Git catches renames
+automatically (see BRIEFING session log 2026-04-08, lesson #7), so history
+is preserved.
+
+---
+
+## Phase 2: Stack updates
+
+### Primary: SQLAlchemy 2.0 + psycopg3 (unblocks Cloud SQL)
+
+Replace the Supabase Python client with SQLAlchemy 2.0 over psycopg3.
+
+**What changes:**
+
+- `datum/db/client.py` gains a SQLAlchemy `Engine` and session factory.
+- `datum/db/models.py` (new) — SQLAlchemy declarative models for
+  `libraries`, `tools`, `cutting_presets`, `plex_supply_items`.
+- Supabase-client calls (`client.table("tools").upsert(...)`) become
+  SQLAlchemy `session.merge(...)` or `insert(...).on_conflict_do_update(...)`.
+- Connection string moves from `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`
+  to a standard `DATABASE_URL` env var (psycopg3 parses it directly).
+  `.env.local` gains `DATABASE_URL` — Supabase exposes a direct Postgres
+  connection that works with psycopg3.
+- Tests swap Supabase-REST mocks for an in-process SQLite-or-Postgres
+  fixture. `pytest-postgresql` or `sqlalchemy-utils` create/drop.
+
+**Why this unblocks Cloud SQL:** after the swap, pointing `DATABASE_URL`
+at Cloud SQL is a connection-string flip. No application code changes.
+The migration PR becomes infra + secret rotation, not a rewrite.
+
+### Secondary (pick-and-choose, not mandatory)
+
+| Change | Verdict | Reason |
+|---|---|---|
+| `ruff` for lint + format | **Do it** | Single tool replaces black + flake8 + isort. Cheap to adopt, fast, widely used. |
+| `uv` for dep resolution | **Probably** | Pins `requirements.txt` stay, but `uv pip install` is dramatically faster. Low risk, no lock-in. |
+| Type-check with `mypy` / `pyright` | **Skip for now** | Codebase is small and well-tested (262 tests). The ROI shows up at 50k+ LOC, not 5k. Revisit if the reorg surfaces unclear interfaces. |
+| Flask → FastAPI | **Skip** | Flask is stable, the production write guard is non-trivial to port, and the React UI doesn't need async. Swap later if there's a real pain point. |
+| `requests` → `httpx` | **Skip** | Plex client is throttled at 200/min and synchronous is fine. `httpx` buys nothing concrete. |
+| Structured logging (`structlog` or plain `logging` JSON) | **Do it with GCP migration** | GCP Cloud Logging parses structured JSON natively. Align with the `datum-runtime` deploy, not this phase. |
+| `pytest-postgresql` for DB tests | **Do it, with SQLAlchemy** | Pairs with the primary stack change. |
+
+### Stack change file surface
+
+| File | Change |
+|---|---|
+| `datum/db/client.py` | SQLAlchemy `Engine` + `sessionmaker` replaces Supabase client |
+| `datum/db/models.py` | New — declarative models for all 4 tables |
+| `datum/sync/staging.py`, `datum/sync/inventory.py`, `datum/sync/supply_items.py`, `datum/sync/enrich.py`, `datum/db/ingest.py` | Swap Supabase API calls for SQLAlchemy session ops |
+| `datum/web/routes/*.py` | Swap Supabase reads for SQLAlchemy query objects |
+| `requirements.txt` | Drop `supabase`, add `sqlalchemy>=2`, `psycopg[binary]>=3`, `alembic` (optional — for migrations going forward) |
+| `pyproject.toml` | Add `[tool.ruff]` config |
+| `tests/conftest.py` | Swap Supabase REST mocks for a `pytest-postgresql` fixture or SQLAlchemy in-memory SQLite |
+| All test files that mock Supabase | Update fixtures |
+
+---
+
+## Phase 3: React UI — lock the scope
+
+No code changes in this phase — just a docs pass that makes the scope
+boundaries visible on the UI itself and in the repo.
+
+- Add a "scope" section to `README.md` under the UI section: "debug +
+  show-and-tell; no mobile; feature requests need a documented use case."
+- Add a small footer to the React UI (`web/src/components/Footer.tsx`
+  or similar) that links to the scope statement. Makes the boundary
+  visible where the users actually are.
+- `web/README.md` (if it doesn't exist) — one-page statement of what
+  the UI is for, who owns it (Shane), and what the contribution bar is.
+- No mobile-related dependencies in `web/package.json`. No PWA manifest.
+  No responsive-design retrofit.
+
+Cost: one PR, maybe 20 LOC + two doc paragraphs. Pays for itself the
+first time someone asks "why doesn't this work on my phone."
+
+---
+
+## Sequencing
+
+Suggested order, with rough effort estimates:
+
+1. **Reorg PRs A → D** (Phase 1) — ~4 PRs, ~1 day each if done in one
+   pass. Tests should stay green throughout — these are pure moves.
+2. **Stack update: SQLAlchemy + psycopg3** (Phase 2 primary) — ~1 week.
+   Biggest risk is test fixture rewrites. Land behind a feature flag
+   (`DATUM_USE_SQLALCHEMY=1`) so Supabase client stays in place as the
+   fallback during bring-up.
+3. **Stack update: ruff + uv** (Phase 2 secondary) — ~half a day total.
+   Low risk, immediate payoff.
+4. **UI scope doc pass** (Phase 3) — ~1 PR, under an hour.
+5. **Now ready for GCP migration (#85)** — Cloud SQL cutover is a
+   connection string flip, APS was already primary, Cloudflare DNS
+   already points at Workers.
+
+Everything below #5 (Phase 5 deploy items, etc.) is already done.
+
+---
+
+## Open questions
+
+- **Should the DB schema move from raw SQL in `db/migrations/` to
+  Alembic?** Alembic is nicer for collaborative schema changes but you're
+  the only dev touching it. Weigh against: raw SQL is simpler to read,
+  Cloud SQL accepts both, Alembic adds a dependency. Default: **stay
+  with raw SQL until there are 2+ devs.**
+- **Should `run_dev.py` stay at the repo root or move under `datum/`?**
+  Root is friendlier for `py run_dev.py` muscle memory. `datum/` is more
+  correct. Default: **leave at root**, it's a dev-only file.
+- **Do we write `web/README.md` now or when other engineers ask to
+  contribute?** Writing it now is cheap and prevents the "everyone asks"
+  drift. Default: **now, alongside Phase 3**.
+- **Structured logging in Phase 2 or Phase 6 (#85)?** Doing it now makes
+  the GCP cutover cleaner but couples two unrelated changes. Default:
+  **defer to Phase 6**, keep this plan focused.
+- **Do we keep `supabase_client.py` side-by-side during SQLAlchemy bring-up
+  for a dual-write period, or cut over in one commit?** Dual-write is
+  safer but adds temporary complexity. Given the Supabase DB is
+  single-tenant and low-volume, a single-commit cutover is probably fine,
+  but the feature-flag approach gives you an escape hatch. Default:
+  **feature-flag, flip when tests pass.**

--- a/scripts/gcp/00-provision.sh
+++ b/scripts/gcp/00-provision.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 00-provision.sh — end-to-end Datum GCP provisioning wrapper.
+#
+# Usage:
+#   export PROJECT_ID=your-project-id
+#   export BILLING_ACCOUNT=XXXXXX-XXXXXX-XXXXXX
+#   gcloud auth login     # browser flow; do this first
+#   gcloud config set project "$PROJECT_ID"
+#   gcloud beta billing projects link "$PROJECT_ID" --billing-account="$BILLING_ACCOUNT"
+#   bash scripts/gcp/00-provision.sh
+#
+# The script is idempotent. Re-running after a partial failure picks up
+# where it left off — each resource check-before-creates.
+#
+# To tear down: bash scripts/gcp/99-teardown.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "$HERE/env.sh"
+
+say "Datum GCP provisioning → project $PROJECT_ID in $REGION"
+echo
+
+for phase in 01-apis 02-vpc 03-psc-sql 04-service-accounts 05-secrets 06-cloud-sql 07-vms; do
+  echo
+  say "Phase: $phase"
+  bash "$HERE/${phase}.sh"
+done
+
+echo
+ok "Provisioning complete."
+echo
+echo "Next steps:"
+echo "  1. Populate secret values:"
+for s in "${SECRETS[@]}"; do
+  if [[ "$s" != "db-url" ]]; then
+    echo "       echo -n 'VALUE' | gcloud secrets versions add $s --data-file=- --project=$PROJECT_ID"
+  fi
+done
+echo "  2. SSH to a VM and confirm connectivity:"
+echo "       gcloud compute ssh $RUNTIME_VM --zone=$ZONE --project=$PROJECT_ID --tunnel-through-iap"
+echo "  3. Verify Cloud SQL reachable from datum-runtime:"
+echo "       gcloud compute ssh $RUNTIME_VM --zone=$ZONE --tunnel-through-iap -- \\"
+echo "         'sudo apt-get update && sudo apt-get install -y postgresql-client && \\"
+echo "          psql \"\$(gcloud secrets versions access latest --secret=db-url)\" -c \"select 1;\"'"

--- a/scripts/gcp/01-apis.sh
+++ b/scripts/gcp/01-apis.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# 01-apis.sh — enable the GCP APIs Datum depends on.
+# Idempotent: `gcloud services enable` is a no-op if the API is already on.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+say "Enabling APIs on project $PROJECT_ID"
+
+APIS=(
+  compute.googleapis.com
+  sqladmin.googleapis.com
+  secretmanager.googleapis.com
+  iap.googleapis.com
+  servicenetworking.googleapis.com
+  cloudscheduler.googleapis.com
+  cloudresourcemanager.googleapis.com
+  iam.googleapis.com
+  logging.googleapis.com
+)
+
+gcloud services enable "${APIS[@]}" --project="$PROJECT_ID"
+ok "APIs enabled (${#APIS[@]} services)"

--- a/scripts/gcp/02-vpc.sh
+++ b/scripts/gcp/02-vpc.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# 02-vpc.sh — custom-mode VPC, primary subnet with secondary ranges reserved
+# for future GKE, Cloud Router + Cloud NAT for private egress, and firewall
+# rules for IAP SSH and internal traffic.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+# ── VPC ────────────────────────────────────────────────────────────────────
+ensure \
+  "gcloud compute networks describe $VPC_NAME --project=$PROJECT_ID" \
+  "gcloud compute networks create $VPC_NAME \
+     --project=$PROJECT_ID \
+     --subnet-mode=custom \
+     --bgp-routing-mode=regional" \
+  "VPC $VPC_NAME"
+
+# ── Subnet (primary + secondary ranges for future GKE) ─────────────────────
+ensure \
+  "gcloud compute networks subnets describe $SUBNET_NAME \
+     --region=$REGION --project=$PROJECT_ID" \
+  "gcloud compute networks subnets create $SUBNET_NAME \
+     --project=$PROJECT_ID \
+     --network=$VPC_NAME \
+     --region=$REGION \
+     --range=$SUBNET_PRIMARY_RANGE \
+     --secondary-range=pods=$SUBNET_SECONDARY_PODS,services=$SUBNET_SECONDARY_SVC \
+     --enable-private-ip-google-access" \
+  "subnet $SUBNET_NAME"
+
+# ── Cloud Router (prerequisite for Cloud NAT) ──────────────────────────────
+ensure \
+  "gcloud compute routers describe $ROUTER_NAME \
+     --region=$REGION --project=$PROJECT_ID" \
+  "gcloud compute routers create $ROUTER_NAME \
+     --project=$PROJECT_ID \
+     --network=$VPC_NAME \
+     --region=$REGION" \
+  "Cloud Router $ROUTER_NAME"
+
+# ── Cloud NAT — outbound internet for private VMs ──────────────────────────
+ensure \
+  "gcloud compute routers nats describe $NAT_NAME \
+     --router=$ROUTER_NAME --region=$REGION --project=$PROJECT_ID" \
+  "gcloud compute routers nats create $NAT_NAME \
+     --project=$PROJECT_ID \
+     --router=$ROUTER_NAME \
+     --region=$REGION \
+     --nat-all-subnet-ip-ranges \
+     --auto-allocate-nat-external-ips" \
+  "Cloud NAT $NAT_NAME"
+
+# ── Firewall rule: allow SSH from IAP range only ───────────────────────────
+ensure \
+  "gcloud compute firewall-rules describe datum-allow-iap-ssh --project=$PROJECT_ID" \
+  "gcloud compute firewall-rules create datum-allow-iap-ssh \
+     --project=$PROJECT_ID \
+     --network=$VPC_NAME \
+     --direction=INGRESS \
+     --action=ALLOW \
+     --rules=tcp:22 \
+     --source-ranges=$IAP_SOURCE_RANGE \
+     --target-tags=ssh-access \
+     --description='Allow SSH from Google IAP forwarders only'" \
+  "firewall rule datum-allow-iap-ssh"
+
+# ── Firewall rule: allow all internal VPC traffic ──────────────────────────
+ensure \
+  "gcloud compute firewall-rules describe datum-allow-internal --project=$PROJECT_ID" \
+  "gcloud compute firewall-rules create datum-allow-internal \
+     --project=$PROJECT_ID \
+     --network=$VPC_NAME \
+     --direction=INGRESS \
+     --action=ALLOW \
+     --rules=all \
+     --source-ranges=$SUBNET_PRIMARY_RANGE \
+     --description='Allow all internal traffic within the primary subnet'" \
+  "firewall rule datum-allow-internal"
+
+ok "VPC ready"

--- a/scripts/gcp/03-psc-sql.sh
+++ b/scripts/gcp/03-psc-sql.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# 03-psc-sql.sh — Private Service Connection for Cloud SQL.
+# Reserves an IP range on the VPC and establishes peering with
+# servicenetworking.googleapis.com so managed services (Cloud SQL) can
+# allocate private IPs inside the VPC.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+# ── Reserve the PSC IP range ───────────────────────────────────────────────
+ensure \
+  "gcloud compute addresses describe $PSC_RANGE_NAME \
+     --global --project=$PROJECT_ID" \
+  "gcloud compute addresses create $PSC_RANGE_NAME \
+     --project=$PROJECT_ID \
+     --global \
+     --purpose=VPC_PEERING \
+     --addresses=$PSC_RANGE_START \
+     --prefix-length=$PSC_RANGE_PREFIX \
+     --network=$VPC_NAME \
+     --description='Reserved range for Cloud SQL private IP'" \
+  "PSC IP range $PSC_RANGE_NAME"
+
+# ── Establish VPC peering with servicenetworking ───────────────────────────
+# `vpc-peerings connect` is not describe-compatible in the same way, so check
+# by listing existing peerings on the network.
+if gcloud services vpc-peerings list \
+     --network="$VPC_NAME" \
+     --service=servicenetworking.googleapis.com \
+     --project="$PROJECT_ID" \
+     --format="value(reservedPeeringRanges)" 2>/dev/null | grep -q "$PSC_RANGE_NAME"; then
+  skip "VPC peering with servicenetworking"
+else
+  say "creating VPC peering with servicenetworking"
+  gcloud services vpc-peerings connect \
+    --project="$PROJECT_ID" \
+    --service=servicenetworking.googleapis.com \
+    --ranges="$PSC_RANGE_NAME" \
+    --network="$VPC_NAME"
+  ok "VPC peering with servicenetworking"
+fi
+
+ok "PSC ready for Cloud SQL"

--- a/scripts/gcp/04-service-accounts.sh
+++ b/scripts/gcp/04-service-accounts.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# 04-service-accounts.sh — per-VM service accounts and IAM bindings.
+# datum-runtime-sa    runs the nightly sync and Flask API
+# datum-dev-sa        used when Shane SSHes into datum-dev
+#
+# Project-level roles bound here: Cloud SQL Client, Log Writer.
+# Secret Accessor is bound PER-SECRET in 05-secrets.sh so datum-dev-sa can
+# be denied access to aps-refresh-token (runtime-only).
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+RUNTIME_EMAIL="${RUNTIME_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+DEV_EMAIL="${DEV_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# ── Create service accounts ────────────────────────────────────────────────
+ensure \
+  "gcloud iam service-accounts describe $RUNTIME_EMAIL --project=$PROJECT_ID" \
+  "gcloud iam service-accounts create $RUNTIME_SA \
+     --project=$PROJECT_ID \
+     --display-name='Datum runtime (sync + API)'" \
+  "service account $RUNTIME_SA"
+
+ensure \
+  "gcloud iam service-accounts describe $DEV_EMAIL --project=$PROJECT_ID" \
+  "gcloud iam service-accounts create $DEV_SA \
+     --project=$PROJECT_ID \
+     --display-name='Datum dev VM'" \
+  "service account $DEV_SA"
+
+# ── Project-level role bindings ────────────────────────────────────────────
+# add-iam-policy-binding is effectively idempotent (no-op if the binding
+# already exists).
+say "binding project-level IAM roles"
+
+for ROLE in roles/cloudsql.client roles/logging.logWriter; do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:$RUNTIME_EMAIL" \
+    --role="$ROLE" \
+    --condition=None \
+    --quiet >/dev/null
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:$DEV_EMAIL" \
+    --role="$ROLE" \
+    --condition=None \
+    --quiet >/dev/null
+done
+
+ok "IAM bindings applied"
+
+# Give IAM a moment to propagate before 05-secrets.sh binds per-secret roles.
+# Without this, per-secret bindings occasionally fail with
+# "service account not found" on fresh SAs.
+sleep 10

--- a/scripts/gcp/04-service-accounts.sh
+++ b/scripts/gcp/04-service-accounts.sh
@@ -27,6 +27,13 @@ ensure \
      --display-name='Datum dev VM'" \
   "service account $DEV_SA"
 
+# Wait for IAM propagation before binding roles. SA creation returns
+# immediately but the SA isn't always visible to add-iam-policy-binding
+# for ~30s. A missing SA surfaces as a confusing "Policy modification
+# failed" error with a misleading lint-condition hint.
+say "waiting for SA propagation (30s)"
+sleep 30
+
 # ── Project-level role bindings ────────────────────────────────────────────
 # add-iam-policy-binding is effectively idempotent (no-op if the binding
 # already exists).
@@ -46,8 +53,3 @@ for ROLE in roles/cloudsql.client roles/logging.logWriter; do
 done
 
 ok "IAM bindings applied"
-
-# Give IAM a moment to propagate before 05-secrets.sh binds per-secret roles.
-# Without this, per-secret bindings occasionally fail with
-# "service account not found" on fresh SAs.
-sleep 10

--- a/scripts/gcp/05-secrets.sh
+++ b/scripts/gcp/05-secrets.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# 05-secrets.sh — create Secret Manager slots (empty) and grant access.
+# Values are populated later via `gcloud secrets versions add`.
+# datum-dev-sa does not get aps-refresh-token (token rotation belongs to the
+# runtime SA; dev shouldn't contend).
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+RUNTIME_EMAIL="${RUNTIME_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+DEV_EMAIL="${DEV_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Secrets that dev should NOT see. Runtime gets access to everything.
+DEV_DENIED=(aps-refresh-token)
+
+is_dev_denied() {
+  local s="$1"
+  for denied in "${DEV_DENIED[@]}"; do
+    [[ "$s" == "$denied" ]] && return 0
+  done
+  return 1
+}
+
+for SECRET in "${SECRETS[@]}"; do
+  ensure \
+    "gcloud secrets describe $SECRET --project=$PROJECT_ID" \
+    "gcloud secrets create $SECRET \
+       --project=$PROJECT_ID \
+       --replication-policy=automatic" \
+    "secret $SECRET"
+
+  # Runtime SA gets access to every secret.
+  gcloud secrets add-iam-policy-binding "$SECRET" \
+    --project="$PROJECT_ID" \
+    --member="serviceAccount:$RUNTIME_EMAIL" \
+    --role="roles/secretmanager.secretAccessor" \
+    --condition=None \
+    --quiet >/dev/null
+
+  # Dev SA gets access unless the secret is on the denied list.
+  if is_dev_denied "$SECRET"; then
+    skip "dev-sa access to $SECRET (denied by policy)"
+  else
+    gcloud secrets add-iam-policy-binding "$SECRET" \
+      --project="$PROJECT_ID" \
+      --member="serviceAccount:$DEV_EMAIL" \
+      --role="roles/secretmanager.secretAccessor" \
+      --condition=None \
+      --quiet >/dev/null
+  fi
+done
+
+ok "Secret Manager slots ready (${#SECRETS[@]} secrets)"

--- a/scripts/gcp/06-cloud-sql.sh
+++ b/scripts/gcp/06-cloud-sql.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# 06-cloud-sql.sh — create the Cloud SQL Postgres instance with private IP,
+# add the `datum` database, create the application user, and push the
+# connection string into Secret Manager `db-url`.
+#
+# Provisioning takes 10–15 minutes. The script blocks until the instance is
+# RUNNABLE before creating the database and user.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+VPC_SELF_LINK="projects/${PROJECT_ID}/global/networks/${VPC_NAME}"
+
+# ── Instance ───────────────────────────────────────────────────────────────
+ensure \
+  "gcloud sql instances describe $SQL_INSTANCE --project=$PROJECT_ID" \
+  "gcloud sql instances create $SQL_INSTANCE \
+     --project=$PROJECT_ID \
+     --database-version=$SQL_VERSION \
+     --tier=$SQL_TIER \
+     --region=$REGION \
+     --network=$VPC_SELF_LINK \
+     --no-assign-ip \
+     --storage-size=$SQL_STORAGE_GB \
+     --storage-type=SSD \
+     --backup-start-time=03:00 \
+     --maintenance-window-day=SUN \
+     --maintenance-window-hour=04" \
+  "Cloud SQL instance $SQL_INSTANCE"
+
+# Wait for the instance to reach RUNNABLE before doing anything else.
+say "waiting for $SQL_INSTANCE to become RUNNABLE (may take several minutes)"
+until [[ "$(gcloud sql instances describe "$SQL_INSTANCE" \
+             --project="$PROJECT_ID" --format='value(state)')" == "RUNNABLE" ]]; do
+  printf '.'; sleep 15
+done
+echo
+ok "$SQL_INSTANCE is RUNNABLE"
+
+# ── Database ───────────────────────────────────────────────────────────────
+ensure \
+  "gcloud sql databases describe $SQL_DATABASE \
+     --instance=$SQL_INSTANCE --project=$PROJECT_ID" \
+  "gcloud sql databases create $SQL_DATABASE \
+     --instance=$SQL_INSTANCE \
+     --project=$PROJECT_ID" \
+  "database $SQL_DATABASE"
+
+# ── User ───────────────────────────────────────────────────────────────────
+if gcloud sql users list --instance="$SQL_INSTANCE" --project="$PROJECT_ID" \
+     --format='value(name)' | grep -qx "$SQL_USER"; then
+  skip "user $SQL_USER"
+  SQL_PASSWORD=""  # unknown; existing password not retrievable
+else
+  say "creating user $SQL_USER with generated password"
+  SQL_PASSWORD="$(openssl rand -base64 24 | tr -d '=+/' | head -c 32)"
+  gcloud sql users create "$SQL_USER" \
+    --instance="$SQL_INSTANCE" \
+    --project="$PROJECT_ID" \
+    --password="$SQL_PASSWORD" >/dev/null
+  ok "user $SQL_USER"
+fi
+
+# ── Store connection string in Secret Manager ──────────────────────────────
+# Only push a new version when we know the password (i.e. just created the
+# user). Re-runs on an existing user leave the existing secret in place.
+if [[ -n "${SQL_PASSWORD:-}" ]]; then
+  PRIVATE_IP="$(gcloud sql instances describe "$SQL_INSTANCE" \
+                  --project="$PROJECT_ID" \
+                  --format='value(ipAddresses[0].ipAddress)')"
+  DB_URL="postgresql://${SQL_USER}:${SQL_PASSWORD}@${PRIVATE_IP}:5432/${SQL_DATABASE}"
+  echo -n "$DB_URL" | gcloud secrets versions add db-url \
+    --project="$PROJECT_ID" \
+    --data-file=- >/dev/null
+  ok "db-url secret populated with new connection string"
+else
+  skip "db-url secret (user pre-existed; secret left as-is)"
+fi
+
+ok "Cloud SQL ready"

--- a/scripts/gcp/07-vms.sh
+++ b/scripts/gcp/07-vms.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# 07-vms.sh — create datum-runtime (e2-micro, always-on) and datum-dev
+# (e2-standard-2, scheduled start/stop in a later phase).
+# Both are Ubuntu 24.04 LTS, no public IP, IAP-only SSH, attached to the
+# custom subnet with their own service accounts.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+RUNTIME_EMAIL="${RUNTIME_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+DEV_EMAIL="${DEV_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# ── datum-runtime ──────────────────────────────────────────────────────────
+ensure \
+  "gcloud compute instances describe $RUNTIME_VM \
+     --zone=$ZONE --project=$PROJECT_ID" \
+  "gcloud compute instances create $RUNTIME_VM \
+     --project=$PROJECT_ID \
+     --zone=$ZONE \
+     --machine-type=$RUNTIME_MACHINE_TYPE \
+     --image-family=$VM_IMAGE_FAMILY \
+     --image-project=$VM_IMAGE_PROJECT \
+     --subnet=$SUBNET_NAME \
+     --no-address \
+     --service-account=$RUNTIME_EMAIL \
+     --scopes=cloud-platform \
+     --tags=ssh-access \
+     --boot-disk-size=30GB \
+     --boot-disk-type=pd-standard \
+     --metadata=enable-oslogin=TRUE" \
+  "VM $RUNTIME_VM"
+
+# ── datum-dev ──────────────────────────────────────────────────────────────
+ensure \
+  "gcloud compute instances describe $DEV_VM \
+     --zone=$ZONE --project=$PROJECT_ID" \
+  "gcloud compute instances create $DEV_VM \
+     --project=$PROJECT_ID \
+     --zone=$ZONE \
+     --machine-type=$DEV_MACHINE_TYPE \
+     --image-family=$VM_IMAGE_FAMILY \
+     --image-project=$VM_IMAGE_PROJECT \
+     --subnet=$SUBNET_NAME \
+     --no-address \
+     --service-account=$DEV_EMAIL \
+     --scopes=cloud-platform \
+     --tags=ssh-access,dev-schedule \
+     --boot-disk-size=50GB \
+     --boot-disk-type=pd-balanced \
+     --metadata=enable-oslogin=TRUE" \
+  "VM $DEV_VM"
+
+ok "VMs ready"
+echo
+echo "SSH via IAP:"
+echo "  gcloud compute ssh $RUNTIME_VM --zone=$ZONE --project=$PROJECT_ID --tunnel-through-iap"
+echo "  gcloud compute ssh $DEV_VM     --zone=$ZONE --project=$PROJECT_ID --tunnel-through-iap"

--- a/scripts/gcp/99-teardown.sh
+++ b/scripts/gcp/99-teardown.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# 99-teardown.sh — delete everything 00-provision.sh created, in reverse
+# dependency order. APIs are left enabled (disabling them is cheap to skip
+# and risks knock-on effects on other projects).
+#
+# REQUIRES EXPLICIT CONFIRMATION. Does not run unless you type the project ID.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+echo "This will PERMANENTLY DELETE Datum infrastructure from project: $PROJECT_ID"
+echo "  - VMs: $RUNTIME_VM, $DEV_VM"
+echo "  - Cloud SQL: $SQL_INSTANCE (all data + backups destroyed)"
+echo "  - Secrets: ${SECRETS[*]}"
+echo "  - Service accounts: $RUNTIME_SA, $DEV_SA"
+echo "  - VPC: $VPC_NAME (subnets, NAT, router, firewall, PSC)"
+echo
+read -r -p "Type the project ID to confirm: " CONFIRM
+[[ "$CONFIRM" == "$PROJECT_ID" ]] || die "Confirmation did not match — aborting"
+
+RUNTIME_EMAIL="${RUNTIME_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+DEV_EMAIL="${DEV_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Best-effort deletes: don't bail if a resource is already gone.
+safe_delete() {
+  local label="$1"; shift
+  if "$@" &>/dev/null; then
+    ok "deleted $label"
+  else
+    skip "$label (already gone or delete failed harmlessly)"
+  fi
+}
+
+# ── VMs ────────────────────────────────────────────────────────────────────
+for VM in "$RUNTIME_VM" "$DEV_VM"; do
+  safe_delete "VM $VM" \
+    gcloud compute instances delete "$VM" \
+      --zone="$ZONE" --project="$PROJECT_ID" --quiet
+done
+
+# ── Cloud SQL ──────────────────────────────────────────────────────────────
+safe_delete "Cloud SQL $SQL_INSTANCE" \
+  gcloud sql instances delete "$SQL_INSTANCE" \
+    --project="$PROJECT_ID" --quiet
+
+# ── Secrets ────────────────────────────────────────────────────────────────
+for SECRET in "${SECRETS[@]}"; do
+  safe_delete "secret $SECRET" \
+    gcloud secrets delete "$SECRET" --project="$PROJECT_ID" --quiet
+done
+
+# ── Service accounts ──────────────────────────────────────────────────────
+for EMAIL in "$RUNTIME_EMAIL" "$DEV_EMAIL"; do
+  safe_delete "service account $EMAIL" \
+    gcloud iam service-accounts delete "$EMAIL" \
+      --project="$PROJECT_ID" --quiet
+done
+
+# ── VPC peering ────────────────────────────────────────────────────────────
+safe_delete "VPC peering with servicenetworking" \
+  gcloud services vpc-peerings delete \
+    --service=servicenetworking.googleapis.com \
+    --network="$VPC_NAME" \
+    --project="$PROJECT_ID" --quiet
+
+safe_delete "PSC range $PSC_RANGE_NAME" \
+  gcloud compute addresses delete "$PSC_RANGE_NAME" \
+    --global --project="$PROJECT_ID" --quiet
+
+# ── Firewall rules ────────────────────────────────────────────────────────
+for RULE in datum-allow-iap-ssh datum-allow-internal; do
+  safe_delete "firewall rule $RULE" \
+    gcloud compute firewall-rules delete "$RULE" \
+      --project="$PROJECT_ID" --quiet
+done
+
+# ── NAT + router ──────────────────────────────────────────────────────────
+safe_delete "Cloud NAT $NAT_NAME" \
+  gcloud compute routers nats delete "$NAT_NAME" \
+    --router="$ROUTER_NAME" --region="$REGION" --project="$PROJECT_ID" --quiet
+
+safe_delete "Cloud Router $ROUTER_NAME" \
+  gcloud compute routers delete "$ROUTER_NAME" \
+    --region="$REGION" --project="$PROJECT_ID" --quiet
+
+# ── Subnet + VPC ──────────────────────────────────────────────────────────
+safe_delete "subnet $SUBNET_NAME" \
+  gcloud compute networks subnets delete "$SUBNET_NAME" \
+    --region="$REGION" --project="$PROJECT_ID" --quiet
+
+safe_delete "VPC $VPC_NAME" \
+  gcloud compute networks delete "$VPC_NAME" \
+    --project="$PROJECT_ID" --quiet
+
+echo
+ok "Teardown complete."

--- a/scripts/gcp/env.sh
+++ b/scripts/gcp/env.sh
@@ -1,0 +1,80 @@
+# scripts/gcp/env.sh — configuration for the Datum GCP provisioning scripts.
+# Source this before running any 0N-*.sh script, or run via 00-provision.sh
+# which sources it automatically.
+#
+# Edit these values before each run. The two that change between personal
+# (dry-run) and Grace (production) accounts are PROJECT_ID and BILLING_ACCOUNT.
+
+# ── Account / project ──────────────────────────────────────────────────────
+: "${PROJECT_ID:?PROJECT_ID must be set (e.g. export PROJECT_ID=datum-dev-shane)}"
+# BILLING_ACCOUNT is documented in 00-provision.sh for the one-time billing
+# link step. It's optional at script-run time (billing just needs to be
+# linked by the time APIs get enabled).
+BILLING_ACCOUNT="${BILLING_ACCOUNT:-}"
+
+# ── Region / zone ──────────────────────────────────────────────────────────
+REGION="${REGION:-us-central1}"
+ZONE="${ZONE:-us-central1-a}"
+
+# ── VPC / networking ───────────────────────────────────────────────────────
+VPC_NAME="datum-vpc"
+SUBNET_NAME="datum-${REGION}"
+SUBNET_PRIMARY_RANGE="10.10.0.0/20"
+SUBNET_SECONDARY_PODS="10.20.0.0/16"
+SUBNET_SECONDARY_SVC="10.30.0.0/20"
+PSC_RANGE_NAME="datum-psc-range"
+PSC_RANGE_START="10.40.0.0"
+PSC_RANGE_PREFIX="20"
+ROUTER_NAME="datum-router"
+NAT_NAME="datum-nat"
+IAP_SOURCE_RANGE="35.235.240.0/20"
+
+# ── Service accounts ───────────────────────────────────────────────────────
+RUNTIME_SA="datum-runtime-sa"
+DEV_SA="datum-dev-sa"
+
+# ── Cloud SQL ──────────────────────────────────────────────────────────────
+SQL_INSTANCE="datum-db"
+SQL_DATABASE="datum"
+SQL_USER="datum_app"
+SQL_TIER="db-f1-micro"
+SQL_VERSION="POSTGRES_15"
+SQL_STORAGE_GB="10"
+
+# ── VMs ────────────────────────────────────────────────────────────────────
+RUNTIME_VM="datum-runtime"
+DEV_VM="datum-dev"
+VM_IMAGE_FAMILY="ubuntu-2404-lts-amd64"
+VM_IMAGE_PROJECT="ubuntu-os-cloud"
+RUNTIME_MACHINE_TYPE="e2-micro"
+DEV_MACHINE_TYPE="e2-standard-2"
+
+# ── Secrets (created as empty slots; values populated later) ───────────────
+SECRETS=(
+  plex-api-key
+  plex-api-secret
+  plex-tenant-id
+  db-url
+  aps-client-id
+  aps-client-secret
+  aps-refresh-token
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+# Colored status prints. Keep noise low so piped output stays readable.
+say()  { printf "\033[1;36m==> %s\033[0m\n" "$*"; }
+ok()   { printf "\033[1;32m ✓  %s\033[0m\n" "$*"; }
+skip() { printf "\033[0;33m -  %s (exists, skipping)\033[0m\n" "$*"; }
+die()  { printf "\033[1;31m ✗  %s\033[0m\n" "$*" >&2; exit 1; }
+
+# Idempotency helper: run $2 if $1 returns non-zero (i.e. resource missing).
+ensure() {
+  local check_cmd="$1"; local create_cmd="$2"; local label="$3"
+  if eval "$check_cmd" &>/dev/null; then
+    skip "$label"
+  else
+    say "creating $label"
+    eval "$create_cmd" || die "failed to create $label"
+    ok "$label"
+  fi
+}


### PR DESCRIPTION
## Summary
- Adds idempotent shell scripts under `scripts/gcp/` that provision the `datum-prod-493615` project end-to-end: APIs, VPC + Cloud NAT, PSC, private-IP Cloud SQL Postgres 15, service accounts, Secret Manager slots, and the `datum-runtime` / `datum-dev` VMs.
- Adds `docs/GCP_MIGRATION.md` and `docs/REORG_AND_STACK.md` capturing the migration plan and the planned SQLAlchemy + psycopg3 stack swap.
- Infra is already live on `datum-prod-493615`; these scripts reflect what was actually run.

## Test plan
- [ ] pytest check passes (docs + shell only; no Python touched)
- [ ] Manual: re-running any `scripts/gcp/0*.sh` on the live project is a no-op