### PR TITLE
docs: refresh stale content — #25 closed, Phase 5 shipped, APS primary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,6 @@ gh pr merge <number> --auto --squash
 
 - A test environment for the Datum Plex app — production is the
   only environment we have credentials for. Be cautious.
-- A scheduled deploy yet (Phase 5 work, issues #9-#11)
 - A CI badge or release versioning yet
 - Any tooling-API endpoints — Plex's tool data lives under
   `inventory/v1/inventory-definitions/supply-items`, NOT

--- a/TODO.md
+++ b/TODO.md
@@ -21,10 +21,10 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 ## Phase 3: Plex API Source-of-Truth Implementation
 
 - [x] **DONE (PR #21).** Implement API call to retrieve current tooling inventory — `extract_supply_items(client)` in `plex_api.py` hits `inventory/v1/inventory-definitions/supply-items` (2,516 records), filters to `category="Tools & Inserts"` (1,109 records), and writes a CSV snapshot to `outputs/`. Verified live: 30 KB response, 1.4s round trip. → [#2](https://github.com/grace-shane/datum/issues/2) *(closed)*
-- [ ] Implement API call to upsert supply-items — `build_supply_item_payload(fusion_tool)` writes to `inventory/v1/inventory-definitions/supply-items` with `supplyItemNumber=<vendor part-id>`. Drafting can begin against the verified read path. → [#3](https://github.com/grace-shane/datum/issues/3)
-- [ ] Implement Tool Assembly handling — Plex's supply-item schema is identity-only (no holder linkage). Tool assemblies as a separate concept may not exist in this app's API surface. **Investigate or descope.** → [#4](https://github.com/grace-shane/datum/issues/4)
-- [ ] Implement API call to link tools to Routings/Operations — `mdm/v1/operations` exposes only `code, id, inventoryType, type` with no FK to tools. **Linkage may not be possible via API**; may require CSV upload or different approach. → [#5](https://github.com/grace-shane/datum/issues/5)
-- [ ] Implement API call to update tooling within the specific Workcenter Document — verified read path is `production/v1/production-definitions/workcenters/{id}`. We have the workcenterCode → Brother Speedio mapping (879, 880). Write shape TBD. → [#6](https://github.com/grace-shane/datum/issues/6)
+- [ ] Implement API call to upsert supply-items — `build_supply_item_payload(fusion_tool)` reads from the Supabase `tools` table and writes to `inventory/v1/inventory-definitions/supply-items` with `supplyItemNumber=<vendor part-id>`. Staging table + payload computation in flight via the sprint PRs #82 / #84. → [#3](https://github.com/grace-shane/datum/issues/3)
+- [ ] Implement Tool Assembly handling — **blocked on Classic Web Services access.** Plex REST supply-items are identity-only; Classic `Part_Operation` Data Sources are the likely path. See BRIEFING §"Classic Web Services" and `docs/Plex_Classic_API_Request.md`. → [#4](https://github.com/grace-shane/datum/issues/4)
+- [ ] Implement API call to link tools to Routings/Operations — **blocked on Classic Web Services access.** REST `mdm/v1/operations` has no FK to tools; `scheduling/v1/jobs` deep-dive (114,684 records) confirmed zero tool/operation FKs. → [#5](https://github.com/grace-shane/datum/issues/5)
+- [ ] Implement API call to update tooling within the specific Workcenter Document — **blocked on Classic Web Services access** (Classic DCS_v2). REST workcenter endpoint is 11 identity fields, no document/attachment sub-resources. → [#6](https://github.com/grace-shane/datum/issues/6)
 - [x] **IT blocker resolved.** The Datum app on production with the Grace tenant authenticates correctly. The earlier "tenant routing" / "subscription approvals" investigation was a red herring caused by a credential typo. See BRIEFING.md "History of incorrect hypotheses" for the postmortem. → [#1](https://github.com/grace-shane/datum/issues/1)
 
 ## Phase 4: Data Mapping & Sync Logic
@@ -40,7 +40,36 @@ This document outlines the step-by-step implementation plan for the Autodesk Fus
 
 ## Phase 5: Automation & Deployment
 
-- [ ] Finalize the synchronization script. → [#9](https://github.com/grace-shane/datum/issues/9)
-- [ ] Deploy the script to a server or always-on PC with access to the network share. → [#10](https://github.com/grace-shane/datum/issues/10)
-- [ ] Schedule the script to run daily at midnight (e.g., using Windows Task Scheduler). → [#11](https://github.com/grace-shane/datum/issues/11)
-- [ ] Rotate the Plex API key before production (previous key is still in git history). → [#12](https://github.com/grace-shane/datum/issues/12)
+- [x] **DONE (PR #44).** Finalize the synchronization script — `sync.py` nightly CLI entrypoint + `pyproject.toml` packaging. → [#9](https://github.com/grace-shane/datum/issues/9) *(closed)*
+- [x] **DONE (PR #47).** Deploy the script — nightly sync runs on an always-on host. → [#10](https://github.com/grace-shane/datum/issues/10) *(closed)*
+- [x] **DONE (PR #47).** Schedule the script to run nightly at midnight. → [#11](https://github.com/grace-shane/datum/issues/11) *(closed)*
+- [x] **DONE (PR #33).** Rotate the Plex API key — old key from git history no longer authenticates; the `Datum` Consumer Key is current. Next rotation deadline 2026-05-08 tracked separately. → [#12](https://github.com/grace-shane/datum/issues/12) *(closed)*
+
+---
+
+## Built beyond the original roadmap
+
+Work that has landed since the Phase 1–5 roadmap was written, tracked via GitHub Issues and not part of the original plan:
+
+- **Supabase staging layer (#31, PR #32 + #34)** — `libraries` / `tools` / `cutting_presets` tables on a dedicated Supabase DB. Fusion JSON ingests here first; Plex gets only the identity slice. Table prefix `fusion2plex_` was removed in PR #34 once the DB isolation made it redundant.
+- **APS cloud integration (PR #43)** — `aps_client.py` pulls tool libraries from Autodesk Platform Services. `sync.py` is now APS-first with local ADC as fallback; ADC removal is tracked under the GCP migration epic ([#85](https://github.com/grace-shane/Datum/issues/85)).
+- **Pre-sync validation gate (#25, PR #28)** — `validate_library.py` with CLI / programmatic / Flask entry points per `docs/validate_library_spec.md`. Gates every sync run.
+- **React UI (PR #41 + subsequent)** — tool browser, library browser, Scripts page, last-sync indicator. Deployed to Cloudflare Workers (PR #70).
+- **Vendor reference catalog + geometry-based enrichment (PR #48)** — `enrich.py`, wired upstream in the sync pipeline (PR #54).
+- **Plex `plex_supply_items` staging pipeline (sprint: #79/#80/#81/#67/#76, PRs #82 + #84)** — prerequisite for #3 upsert work.
+- **Tool inventory qty sync (#75, PRs #77 + #78)** — Plex → Supabase qty cache.
+- **Classic Web Services discovery (PR #42)** — documented the SOAP path at `plexonline.com/Modules/Xmla/XmlDataSource.asmx` that can unblock #4 / #5 / #6. Access request pending; see `docs/Plex_Classic_API_Request.md`.
+
+## Phase 6: GCP migration (umbrella [#85](https://github.com/grace-shane/Datum/issues/85))
+
+Move Datum off Supabase + Autodesk Desktop Connector and onto GCP + the Autodesk Platform Services HTTP API. Architecture and affected-code map live in [`docs/GCP_MIGRATION.md`](./docs/GCP_MIGRATION.md).
+
+- [ ] Provision GCP (`datum-dev` e2-standard-2, `datum-runtime` e2-micro, Cloud SQL `db-f1-micro`, Secret Manager)
+- [ ] Apply schema to Cloud SQL (bare table names, matches current Supabase)
+- [ ] `bootstrap.py` Secret Manager loader path (additive)
+- [ ] `db_client.py` — drop-in replacement for `supabase_client.py`
+- [ ] Replace/refactor `tool_library_loader.py` to APS-backed; remove local-ADC fallback branch in `sync.py`
+- [ ] Update Flask `/api/fusion/validate` GET + `/api/fusion/libraries` to pull from APS
+- [ ] Cloud Scheduler — nightly sync + dev VM start/stop
+- [ ] Cloudflare DNS — `datum.graceops.dev`
+- [ ] Decom Supabase + strip ADC references from docs

--- a/docs/BRIEFING.md
+++ b/docs/BRIEFING.md
@@ -111,15 +111,27 @@ Tenant IDs are not secrets — they are committed as defaults in
 ## Architecture
 
 ```
-Fusion 360 .json (network share, via Autodesk Desktop Connector)
-  └── tool_library_loader.py    reads + validates JSON, stale-file guard
-  └── validate_library.py       pre-sync validation gate (spec only, #25)
-  └── transform layer           build_supply_item_payload (in progress, #3)
-  └── plex_api.py / PlexClient  pushes to Plex REST API
-        ├── inventory/v1/inventory-definitions/supply-items   cutting tools (category="Tools & Inserts")
-        ├── mdm/v1/suppliers                                  resolve vendor UUIDs
-        └── production/v1/production-definitions/workcenters  machine setup docs (per-id write shape TBD, #6)
+Fusion 360 tool libraries
+  ├── APS cloud (primary, PR #43)  ── aps_client.py                     ─┐
+  └── ADC network share (fallback) ── tool_library_loader.py             │
+                                                                         ▼
+  validate_library.py    pre-sync validation gate (PR #28, spec: docs/validate_library_spec.md)
+         │
+         ▼
+  Supabase staging (PR #32, schema: libraries / tools / cutting_presets)
+         ├── enrich.py                 vendor catalog + geometry-based enrichment (PR #48, wired PR #54)
+         ├── React UI (PR #41)         tool browser / library browser / scripts / qty indicators — deployed to Cloudflare Workers (PR #70)
+         ▼
+  transform layer    build_supply_item_payload (in progress, #3 — sprint PRs #82 / #84)
+         │
+         ▼
+  plex_api.py / PlexClient    Plex REST API
+         ├── inventory/v1/inventory-definitions/supply-items   cutting tools (category="Tools & Inserts")
+         ├── mdm/v1/suppliers                                  resolve vendor UUIDs
+         └── production/v1/production-definitions/workcenters  machine setup docs (per-id write — blocked on Classic API, #6)
 ```
+
+The nightly sync runs via the `sync.py` CLI (PR #44), scheduled on an always-on host (PR #47). Going forward, the GCP migration ([#85](https://github.com/grace-shane/Datum/issues/85)) will drop the ADC fallback entirely, replace Supabase with Cloud SQL, and move scheduling to Cloud Scheduler — see `docs/GCP_MIGRATION.md`.
 
 ### Industry hierarchy (Plex data model)
 
@@ -329,6 +341,42 @@ Sync filter: include only `type != "holder" AND type != "probe"`
 - Stale file guard — aborts if files older than 25h (ADC sync stall detection)
 - `PermissionError` and `JSONDecodeError` handling (ADC mid-sync file locks)
 - `report_library_contents()` — diagnostic summary
+- **Status:** local-ADC path only. `aps_client.py` is the primary source today; this loader is the fallback. Scheduled for removal under the GCP migration epic (#85).
+
+### aps_client.py (PR #43)
+- OAuth client for Autodesk Platform Services (Fusion Hub online)
+- Lists hub projects and downloads tool library JSON over HTTP
+- Primary source for `sync.py`; removes the ADC install requirement on the runtime host
+
+### validate_library.py (PR #28, spec: `docs/validate_library_spec.md`)
+- Pre-sync validation gate — FAIL aborts the sync; WARNs surface in verbose/debug
+- Three entry points: CLI, programmatic (called from `tool_library_loader.load_library`), Flask `/api/fusion/validate`
+- Library-level + per-tool rule tables, cached supplier lookup for vendor validation
+- Source-agnostic engine — survives the APS migration with only a CLI default-path change
+
+### supabase_client.py + sync_supabase.py (PR #32)
+- Dedicated Supabase project (`datum`, us-east-2): `libraries` / `tools` / `cutting_presets`
+- `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` in `.env.local` — server-side only, never shipped to the browser
+- Full tool record (geometry, holders, pockets) lives here; Plex gets the identity slice via `build_supply_item_payload` (#3)
+- PR #34 dropped the `fusion2plex_` table prefix once DB isolation made it redundant
+- Scheduled for replacement by Cloud SQL under the GCP migration epic (#85)
+
+### enrich.py (PR #48, wired in the sync pipeline via PR #54)
+- Vendor reference catalog + geometry-based tool enrichment
+- Runs before staging writes so enriched records land in Supabase directly
+
+### Plex staging pipeline (sprint PRs #82 / #84, issues #79 / #80 / #81)
+- `plex_supply_items` staging table + payload computation
+- Feeds the upsert path in #3
+
+### sync.py + nightly deploy (PRs #44, #46, #47)
+- `sync.py` CLI entrypoint, APS-first with local ADC fallback
+- `--log-file` flag for persistent nightly logs (PR #46)
+- Deployed to an always-on host; scheduled nightly at midnight (PR #47)
+
+### React UI (PR #41 + successive)
+- Tool browser, library browser, Scripts page, last-sync indicator, qty columns
+- Deployed to Cloudflare Workers Static Assets (PR #70)
 
 ### bootstrap.py
 - Loads `.env.local` (gitignored) into `os.environ` via `setdefault`
@@ -356,46 +404,55 @@ Sync filter: include only `type != "holder" AND type != "probe"`
 - `pytest` suite in `tests/`. CI on PRs to `master` via
   `.github/workflows/test.yml`. Branch protection on master requires the
   `pytest` check to pass before merge. Auto-merge enabled.
-- Currently 156 tests, all green.
+- Currently 262 tests, all green (as of 2026-04-17).
 
 ---
 
 ## Immediate TODO (in priority order)
 
 All items below are mirrored as GitHub Issues — see
-https://github.com/grace-shane/datum/issues for live status.
+https://github.com/grace-shane/Datum/issues for live status.
 
-1. ~~Fix PlexClient constructor — add api_secret, include header~~ DONE
-2. ~~Find the real Plex tooling endpoint~~ DONE — it's
-   `inventory/v1/inventory-definitions/supply-items` with
-   `category="Tools & Inserts"`. 1,109 records already exist.
-3. ~~Read baseline tooling inventory from supply-items~~ DONE (PR #21,
-   issue #2 closed). `extract_supply_items(client)` in plex_api.py
-   returns the filtered list and writes a CSV snapshot. Verified
-   live: 1,109 records, 30 KB response, 1.4s round trip.
-4. **`validate_library.py` pre-sync validation gate — issue #25.**
-   Implement the full spec at `docs/validate_library_spec.md`: three
-   entry points (CLI / programmatic / Flask), library-level + per-tool
-   rule tables, cached supplier lookup for vendor validation, integration
-   hook in `tool_library_loader.load_library()` that aborts the sync on
-   FAIL. **Gates all write-side work below** — must land before #3 or
-   #7 can safely touch production.
-5. `build_supply_item_payload(fusion_tool: dict) -> dict` — issue #3.
-   Maps Fusion tool to a supply-item POST body with
+### Done (historical record — kept for context)
+
+- ~~PlexClient constructor, api_secret header~~
+- ~~Find the real Plex tooling endpoint~~ — `inventory/v1/inventory-definitions/supply-items` with `category="Tools & Inserts"`; 1,109 records
+- ~~Read baseline tooling inventory from supply-items~~ — PR #21, issue #2
+- ~~`validate_library.py` pre-sync validation gate~~ — PR #28, issue #25
+- ~~Supabase staging layer (`libraries` / `tools` / `cutting_presets`)~~ — PR #32 + #34, issue #31
+- ~~APS cloud integration — no local Fusion install required~~ — PR #43
+- ~~Nightly sync CLI entrypoint + packaging~~ — PR #44, issue #9
+- ~~Deploy nightly sync to always-on host, scheduled at midnight~~ — PR #47, issues #10 / #11
+- ~~Plex API key rotation cadence established~~ — PR #33, issue #12 (next rotation 2026-05-08)
+- ~~Vendor reference catalog + geometry-based enrichment~~ — PR #48 / #54
+- ~~React UI scaffold + Cloudflare Workers deploy~~ — PRs #41 / #68 / #70
+- ~~Plex `plex_supply_items` staging table + qty sync~~ — PRs #77 / #78 / #82 / #84
+
+### Active / next
+
+1. `build_supply_item_payload(fusion_tool: dict) -> dict` — issue #3.
+   Reads from Supabase `tools`; maps to a supply-item POST body with
    `category="Tools & Inserts"`, `group="Machining"`,
-   `supplyItemNumber=<vendor part-id>`, `description=<fusion description>`.
-   Runs validate_library gate first.
-6. Match-and-upsert logic by `supplyItemNumber` — issue #3.
-   Read existing supply-items via extract_supply_items(), match by
-   vendor part number, decide POST (new) vs PUT (update existing).
-7. Workcenter doc push — issue #6. Use the verified path
-   `production/v1/production-definitions/workcenters/{id}` and the
-   workcenterCode → Brother Speedio mapping (codes 879, 880).
-   We have READ-only verified; write endpoint shape still TBD.
-8. Core sync logic — upsert with `supplyItemNumber` dedup — issue #7.
-   Dry-run by default. Real writes require `PLEX_ALLOW_WRITES=1`.
-   Calls validate_library gate before every run.
-9. Error handling + logging to network share text file — issue #8.
+   `supplyItemNumber=<vendor part-id>`. Staging pipeline (PRs #82 / #84)
+   has landed the prerequisites.
+2. Match-and-upsert logic by `supplyItemNumber` — issue #3.
+   Decide POST (new) vs PUT (update existing) against the 1,109 current
+   supply-items. Writes require `PLEX_ALLOW_WRITES=1`.
+3. Core sync logic — upsert with `supplyItemNumber` dedup — issue #7.
+   Dry-run by default. Calls validate_library gate before every run.
+4. Error handling + logging on run failures — issue #8. `--log-file`
+   scaffold landed in PR #46; issue remains open for broader error paths.
+5. GCP migration (umbrella [#85](https://github.com/grace-shane/Datum/issues/85))
+   — see `docs/GCP_MIGRATION.md` for scope, affected code, and sequence.
+
+### Blocked on Plex Classic Web Services access
+
+6. Tool assemblies — issue #4. Classic `Part_Operation` Data Sources likely path.
+7. Routing / operation linkage — issue #5. Classic Part Operations + tool assignments.
+8. Workcenter doc push — issue #6. Classic DCS_v2. REST workcenter endpoint
+   is 11 identity fields, no document/attachment sub-resources.
+
+Access request tracked in `docs/Plex_Classic_API_Request.md`.
 
 ### Architectural decisions — #4 and #5 (updated 2026-04-10)
 

--- a/docs/validate_library_spec.md
+++ b/docs/validate_library_spec.md
@@ -1,8 +1,8 @@
 # `validate_library.py` — Full Design Spec
 
 **Project:** Fusion 360 → Plex tooling sync — Grace Engineering
-**Repo:** https://github.com/grace-shane/plex-api
-**Status:** Spec only — implementation tracked as GitHub issue [#25](https://github.com/grace-shane/plex-api/issues/25)
+**Repo:** https://github.com/grace-shane/Datum
+**Status:** Implemented — landed in [PR #28](https://github.com/grace-shane/Datum/pull/28) (2026-04-08), closing issue [#25](https://github.com/grace-shane/Datum/issues/25). This document is retained as the design reference.
 
 ---
 


### PR DESCRIPTION
## Summary
- Refreshes `CLAUDE.md`, `TODO.md`, `docs/BRIEFING.md`, and `docs/validate_library_spec.md` to reflect current state: #25 closed, Phase 5 shipped, APS as primary auth path.
- Docs-only change — no code paths touched.

## Test plan
- [ ] pytest check passes (docs-only)
- [ ] Manual re-read of BRIEFING.md to confirm it matches current reality