### PR TITLE
feat(infra): secret-populate script + next-session prompts

### DIFF
--- a/docs/GCP_MIGRATION.md
+++ b/docs/GCP_MIGRATION.md
@@ -2,6 +2,9 @@
 
 **Status:** Planning (2026-04-17). No code changes in the session that wrote this doc.
 **Umbrella issue:** [#85](https://github.com/grace-shane/Datum/issues/85)
+**Next-session prompts:** see [`NEXT_SESSION.md`](./NEXT_SESSION.md) for canned
+prompts covering Cloud Scheduler start/stop and the Supabase → Cloud SQL DB
+migration.
 
 This document captures the agreed architecture for moving Datum off Supabase +
 Autodesk Desktop Connector (ADC) + the locked-down work machine, and onto GCP +

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -1,0 +1,70 @@
+# NEXT_SESSION.md — prompts for the next Datum Claude session on `datum-dev`
+
+This file holds canned prompts to paste into a fresh Claude Code session
+running on the `datum-dev` GCP VM. The VM already has all repo plugins
+installed; it just needs a `git pull` on `master` before the session
+starts.
+
+Read these in order:
+
+- [`BRIEFING.md`](./BRIEFING.md) — overall project context
+- [`GCP_MIGRATION.md`](./GCP_MIGRATION.md) — what's already provisioned
+- [`REORG_AND_STACK.md`](./REORG_AND_STACK.md) — the pending stack swap
+
+## Prompt 1 — Cloud Scheduler start/stop for `datum-dev`
+
+```
+Read docs/GCP_MIGRATION.md, then set up Cloud Scheduler to start
+datum-dev each weekday morning (07:00 America/Chicago) and stop it each
+evening (19:00 America/Chicago). Use the HTTP target against
+compute.googleapis.com with OAuth and the runtime service account.
+
+Add a new idempotent script scripts/gcp/08-scheduler.sh that creates
+both jobs and the minimal IAM bindings needed for the SA to
+start/stop the instance. Document the expected monthly-cost delta
+(baseline ~$50/mo 24/7 → ~$15/mo weekday-only) in a short section at
+the bottom of docs/GCP_MIGRATION.md.
+
+Open a PR on grace-shane/Datum with --repo grace-shane/Datum (do not
+rely on gh's default remote — it picks upstream, which is wrong).
+```
+
+## Prompt 2 — Populate Supabase slots + migrate DB to Cloud SQL
+
+```
+Phase 2 of docs/REORG_AND_STACK.md: move the staging DB from Supabase
+to the Cloud SQL instance datum-db.
+
+Before any migration work, add two Secret Manager slots for the
+existing Supabase project (we still need to read from it to dump):
+supabase-url and supabase-service-role-key. Update
+scripts/gcp/env.sh SECRETS array and re-run scripts/gcp/05-secrets.sh
+plus scripts/gcp/10-populate-secrets.sh.
+
+Then: pg_dump from Supabase (Shane has full admin there), restore
+into datum-db, swap the app's DB layer to SQLAlchemy + psycopg3 as
+specified in REORG_AND_STACK.md Phase 2. Keep Supabase reads working
+behind a feature flag for one deploy cycle so we can roll back.
+
+Write a plan before touching code. Confirm with Shane before running
+pg_dump — it's a one-way step in the sense that it locks in a
+cutover moment.
+```
+
+## Prompt 3 — General session kickoff (if doing neither of the above)
+
+```
+Read CLAUDE.md and follow its reading order. Then check Notion's
+Current State block to see what's actually next. If nothing's
+pressing, look at TODO.md for the next unblocked GitHub issue.
+```
+
+## Gotchas this VM will hit
+
+- `gh` auto-picks the `upstream` remote (old `just-shane/plex-api` fork).
+  Always pass `--repo grace-shane/Datum`.
+- The `datum-runtime` VM holds `aps-refresh-token`; `datum-dev` does not
+  (by IAM policy in `05-secrets.sh`). Don't try to read that secret from
+  this machine.
+- Plex writes stay gated behind `PLEX_ALLOW_WRITES=1`. The GCP move did
+  not change that contract.

--- a/scripts/gcp/10-populate-secrets.sh
+++ b/scripts/gcp/10-populate-secrets.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# 10-populate-secrets.sh — interactively populate Secret Manager slots
+# created by 05-secrets.sh.
+#
+# Run this from a machine that has gcloud auth'd against the target project
+# (Shane's Legion laptop as of 2026-04-17). Prompts for each empty slot.
+# Skips slots that already have a version unless --force is passed.
+# Always skips aps-refresh-token (rotated by the runtime SA, not populated
+# manually).
+#
+# Designed for partial success: a failure on one secret does not abort the
+# rest. A summary prints at the end.
+
+set -uo pipefail
+source "$(dirname "$0")/env.sh"
+
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --force|-f) FORCE=1 ;;
+    -h|--help)
+      cat <<EOF
+Usage: $0 [--force]
+
+Interactively populates empty Secret Manager slots in project \$PROJECT_ID.
+  --force   overwrite slots that already have a version.
+
+Always skips aps-refresh-token (runtime-rotated).
+Enter an empty value at any prompt to skip that secret.
+EOF
+      exit 0
+      ;;
+    *) die "unknown arg: $arg" ;;
+  esac
+done
+
+# Slots we never populate manually.
+RUNTIME_ROTATED=(aps-refresh-token)
+
+is_runtime_rotated() {
+  local s="$1"
+  for r in "${RUNTIME_ROTATED[@]}"; do
+    [[ "$s" == "$r" ]] && return 0
+  done
+  return 1
+}
+
+has_version() {
+  local s="$1"
+  # Returns 0 if at least one enabled version exists.
+  gcloud secrets versions list "$s" \
+    --project="$PROJECT_ID" \
+    --filter="state=ENABLED" \
+    --format="value(name)" 2>/dev/null | grep -q .
+}
+
+added=()
+skipped=()
+failed=()
+
+say "populating secrets in project ${PROJECT_ID} (force=${FORCE})"
+echo
+
+for SECRET in "${SECRETS[@]}"; do
+  if is_runtime_rotated "$SECRET"; then
+    skip "$SECRET (runtime-rotated, not populated here)"
+    skipped+=("$SECRET")
+    continue
+  fi
+
+  if has_version "$SECRET" && [[ $FORCE -eq 0 ]]; then
+    skip "$SECRET (already has a version — pass --force to overwrite)"
+    skipped+=("$SECRET")
+    continue
+  fi
+
+  printf "\033[1;36m==> value for %s (empty to skip): \033[0m" "$SECRET"
+  # -s hides input; -r avoids backslash interpretation.
+  read -r -s value
+  echo
+
+  if [[ -z "$value" ]]; then
+    skip "$SECRET (empty input)"
+    skipped+=("$SECRET")
+    continue
+  fi
+
+  if printf '%s' "$value" | gcloud secrets versions add "$SECRET" \
+       --project="$PROJECT_ID" \
+       --data-file=- >/dev/null 2>&1; then
+    ok "$SECRET"
+    added+=("$SECRET")
+  else
+    printf "\033[1;31m ✗  %s (gcloud error — run again or check access)\033[0m\n" "$SECRET"
+    failed+=("$SECRET")
+  fi
+
+  unset value
+done
+
+echo
+say "summary"
+printf "  added:   %s\n" "${added[*]:-(none)}"
+printf "  skipped: %s\n" "${skipped[*]:-(none)}"
+printf "  failed:  %s\n" "${failed[*]:-(none)}"
+
+# Non-zero exit only if something failed. Missing values (skipped) are fine.
+[[ ${#failed[@]} -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- `scripts/gcp/10-populate-secrets.sh` — interactive Secret Manager populator. Skips slots that already have a version (pass `--force` to overwrite), always skips `aps-refresh-token` (runtime-rotated), and tolerates per-secret failures so one bad `gcloud` call does not abort the run. Intended to run from Shane's Legion (the gcloud-auth'd machine).
- `docs/NEXT_SESSION.md` — canned prompts for the next Datum Claude session on `datum-dev`: Cloud Scheduler start/stop, Supabase → Cloud SQL migration, plus the `gh --repo grace-shane/Datum` gotcha.
- `docs/GCP_MIGRATION.md` — linked to `NEXT_SESSION.md` so the boot chain picks it up.

## Test plan
- [ ] pytest passes (no Python touched; bash + docs only)
- [ ] Manual: run `scripts/gcp/10-populate-secrets.sh` on the Legion and confirm empty input skips, bad input surfaces a per-secret failure, and `--force` overwrites an existing version