### PR TITLE
feat(infra): Cloud Scheduler start/stop for datum-dev (08-scheduler.sh)

### DIFF
--- a/docs/GCP_MIGRATION.md
+++ b/docs/GCP_MIGRATION.md
@@ -56,7 +56,7 @@ Three forcing functions collided in April 2026:
   Cloudflare (datum.graceops.dev) ──▶ Flask on runtime VM ──▶ React UI
 
   ┌─────────────────┐
-  │  datum-dev      │  Cloud Scheduler: start 7am CT / stop 5pm CT (Mon–Fri)
+  │  datum-dev      │  Cloud Scheduler: start 07:00 CT / stop 19:00 CT (Mon–Fri)
   │  e2-standard-2  │
   │  Ubuntu 22.04   │  SSH target for VS Code Remote / Claude Code
   └─────────────────┘
@@ -68,7 +68,7 @@ Three forcing functions collided in April 2026:
 
 | VM | Purpose | Machine type | OS | Runtime model |
 |---|---|---|---|---|
-| `datum-dev` | Cloud dev environment — replaces the locked-down work machine. SSH target for VS Code Remote / Claude Code. | `e2-standard-2` | Ubuntu 22.04 | Business hours only. Cloud Scheduler start 7am CT / stop 5pm CT, Mon–Fri. Off weekends and evenings. |
+| `datum-dev` | Cloud dev environment — replaces the locked-down work machine. SSH target for VS Code Remote / Claude Code. | `e2-standard-2` | Ubuntu 22.04 | Business hours only. Cloud Scheduler start 07:00 CT / stop 19:00 CT, Mon–Fri. Off weekends and evenings. See [Cost — `datum-dev` weekday-only schedule](#cost--datum-dev-weekday-only-schedule) for the math. |
 | `datum-runtime` | Nightly sync cron + Flask API surface for the React UI | `e2-micro` | Ubuntu 22.04 | Always-on in `us-central1` (free tier) |
 
 ### Why split them
@@ -236,3 +236,37 @@ implementation PRs will work through.**
 - **APS token vs Consumer Key lifetime.** Plex Consumer Key rotates every 31
   days; APS tokens rotate on their own cycle. Two independent rotation alarms;
   document both in the runbook.
+
+---
+
+## Cost — `datum-dev` weekday-only schedule
+
+`scripts/gcp/08-scheduler.sh` creates two Cloud Scheduler jobs that
+start `datum-dev` weekdays at 07:00 America/Chicago and stop it at
+19:00 America/Chicago. That's 12h × 5 days × ~4.33 weeks ≈ 260h/mo
+versus 730h/mo for always-on — a ~64% compute reduction.
+
+| Mode | Hours/mo | `e2-standard-2` cost (us-central1, list) |
+|---|---:|---:|
+| Always-on (24/7) | 730 | ~$50/mo |
+| Weekday 07:00–19:00 CT | ~260 | ~$15/mo |
+
+Persistent disk bills separately and isn't affected by stop/start —
+the $35/mo delta is compute-only. On stop, the boot disk and hostname
+are preserved; on start, the same VM comes back up.
+
+**IAM scope.** The script grants the runtime service account
+`roles/compute.instanceAdmin.v1` on the `datum-dev` instance only
+(not project-level), so the Scheduler auth identity can still only
+touch that one VM.
+
+**Gotchas.**
+
+- An SSH session into `datum-dev` at 19:00 CT gets killed when the
+  stop job fires. For late work, trigger the start job manually:
+  `gcloud scheduler jobs run datum-dev-start --location=$REGION --project=$PROJECT_ID`.
+- The schedule is weekday-only (`0 7 * * 1-5` / `0 19 * * 1-5`). Weekend
+  work needs a manual `gcloud compute instances start datum-dev ...`.
+- Cloud Scheduler jobs live in `$REGION` (currently `us-central1`).
+  If you ever change `REGION` in `env.sh` the existing jobs won't follow —
+  delete them from the old region and re-run `08-scheduler.sh`.

--- a/scripts/gcp/08-scheduler.sh
+++ b/scripts/gcp/08-scheduler.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# 08-scheduler.sh — Cloud Scheduler jobs to start/stop datum-dev on a
+# weekday-only schedule (07:00 / 19:00 America/Chicago, Mon–Fri).
+#
+# Why: datum-dev is an e2-standard-2 — on at all times it's ~$50/mo.
+# Running it only during weekday business hours cuts that to ~$15/mo
+# and forces us to keep VM setup scripted (state rots if we leave it
+# on for weeks).
+#
+# Mechanism: two HTTP-target Cloud Scheduler jobs hitting the Compute
+# Engine REST API (.../instances/<name>/start and .../stop), authenticating
+# with OAuth using the runtime service account.
+#
+# IAM: the runtime SA is granted roles/compute.instanceAdmin.v1 scoped
+# to the datum-dev instance only (not project-level), so it can still
+# only touch that one VM.
+set -euo pipefail
+source "$(dirname "$0")/env.sh"
+
+RUNTIME_EMAIL="${RUNTIME_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+SCHEDULE_TZ="America/Chicago"
+START_JOB="datum-dev-start"
+STOP_JOB="datum-dev-stop"
+START_SCHEDULE="0 7 * * 1-5"
+STOP_SCHEDULE="0 19 * * 1-5"
+DEV_VM_URI="https://compute.googleapis.com/compute/v1/projects/${PROJECT_ID}/zones/${ZONE}/instances/${DEV_VM}"
+
+# ── Instance-level IAM for the runtime SA ──────────────────────────────────
+# add-iam-policy-binding is idempotent — re-running is a no-op if the
+# binding already exists.
+say "granting $RUNTIME_SA start/stop on instance $DEV_VM"
+gcloud compute instances add-iam-policy-binding "$DEV_VM" \
+  --project="$PROJECT_ID" \
+  --zone="$ZONE" \
+  --member="serviceAccount:$RUNTIME_EMAIL" \
+  --role="roles/compute.instanceAdmin.v1" \
+  --condition=None \
+  --quiet >/dev/null
+ok "instance IAM binding applied"
+
+# ── Start job (weekdays 07:00 America/Chicago) ─────────────────────────────
+ensure \
+  "gcloud scheduler jobs describe $START_JOB --location=$REGION --project=$PROJECT_ID" \
+  "gcloud scheduler jobs create http $START_JOB \
+     --project=$PROJECT_ID \
+     --location=$REGION \
+     --schedule='$START_SCHEDULE' \
+     --time-zone='$SCHEDULE_TZ' \
+     --uri='${DEV_VM_URI}/start' \
+     --http-method=POST \
+     --oauth-service-account-email=$RUNTIME_EMAIL \
+     --description='Start $DEV_VM weekday mornings (07:00 CT)'" \
+  "scheduler job $START_JOB"
+
+# ── Stop job (weekdays 19:00 America/Chicago) ──────────────────────────────
+ensure \
+  "gcloud scheduler jobs describe $STOP_JOB --location=$REGION --project=$PROJECT_ID" \
+  "gcloud scheduler jobs create http $STOP_JOB \
+     --project=$PROJECT_ID \
+     --location=$REGION \
+     --schedule='$STOP_SCHEDULE' \
+     --time-zone='$SCHEDULE_TZ' \
+     --uri='${DEV_VM_URI}/stop' \
+     --http-method=POST \
+     --oauth-service-account-email=$RUNTIME_EMAIL \
+     --description='Stop $DEV_VM weekday evenings (19:00 CT)'" \
+  "scheduler job $STOP_JOB"
+
+ok "scheduler jobs ready"
+echo
+echo "Manual trigger (useful for testing or a one-off late night):"
+echo "  gcloud scheduler jobs run $START_JOB --location=$REGION --project=$PROJECT_ID"
+echo "  gcloud scheduler jobs run $STOP_JOB  --location=$REGION --project=$PROJECT_ID"


### PR DESCRIPTION
## Summary

- Adds `scripts/gcp/08-scheduler.sh` — idempotent Cloud Scheduler wiring that starts `datum-dev` weekdays at 07:00 America/Chicago and stops it at 19:00. HTTP target against `compute.googleapis.com` with OAuth using the runtime service account.
- Grants `roles/compute.instanceAdmin.v1` **at the instance level on `datum-dev` only** (not project-level), so the scheduler auth identity can still only touch that one VM.
- `docs/GCP_MIGRATION.md`: new "Cost — `datum-dev` weekday-only schedule" section at the bottom with the compute-hour math (730h → ~260h/mo, ~$50/mo → ~$15/mo list). Updated the two in-line references that said "5pm CT" to 19:00 CT so the architecture diagram and VM topology table match the schedule the script actually creates.

Carved out of [NEXT_SESSION.md Prompt 1](./docs/NEXT_SESSION.md) / Phase 6 of [TODO.md](./TODO.md) / umbrella #85.

## Test plan

- [ ] `bash -n scripts/gcp/08-scheduler.sh` passes (syntax check — verified locally)
- [ ] On a GCP project with `04-service-accounts.sh` + `07-vms.sh` already applied, run `bash scripts/gcp/08-scheduler.sh` and verify:
  - [ ] `gcloud scheduler jobs list --location=$REGION --project=$PROJECT_ID` shows `datum-dev-start` and `datum-dev-stop`
  - [ ] Re-running the script is a no-op (idempotency)
  - [ ] `gcloud scheduler jobs run datum-dev-start ...` transitions `datum-dev` RUNNING, and `... datum-dev-stop` transitions it TERMINATED
  - [ ] The runtime SA's project-level IAM is unchanged (start/stop is bound at instance level)
- [ ] CI `pytest` stays green (no Python touched — docs + shell only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)