### PR TITLE
fix(db): anon SELECT policy for plex_supply_items — Bundle A close-out

### DIFF
--- a/db/migrations/0007_anon_read_plex_supply_items.sql
+++ b/db/migrations/0007_anon_read_plex_supply_items.sql
@@ -1,0 +1,15 @@
+-- Allow anon read on plex_supply_items so the browser can render the
+-- "Plex Staging Payload" card on ToolDetailPage (#81).
+--
+-- Migration 0006 enabled RLS on plex_supply_items but didn't add a
+-- policy, so the anon client at web/src/pages/ToolDetailPage.tsx
+-- `.from("plex_supply_items").select("*")` silently returns nothing.
+-- Staging-payload data is already derivable from the anon-readable
+-- tools rows — exposing it here just saves the browser from
+-- recomputing the 6 fields.
+
+CREATE POLICY "plex_supply_items_anon_read"
+  ON public.plex_supply_items
+  FOR SELECT
+  TO anon
+  USING (true);


### PR DESCRIPTION
## Summary

One-file migration fixing the last open acceptance criterion on #81. Migration 0006 enabled RLS on `plex_supply_items` but didn't add any policy, so the anon client at [`web/src/pages/ToolDetailPage.tsx:109-113`](../blob/master/web/src/pages/ToolDetailPage.tsx#L109-L113) silently returns nothing — the Plex Staging Payload card will never render in production.

Migration 0007 adds the matching `anon SELECT` policy (patterned after `0004_anon_read_reference_catalog.sql`). The 6 payload fields are already derivable from the anon-readable `tools` rows, so exposure surface is unchanged.

Ships as part of Bundle A close-out triage: verifying PR #84's sprint work (#79/#80/#81/#76/#67) is fully landed on master, then closing the issues. This is the only residual implementation gap; the rest of Bundle A is issue closes + in-app verification.

## Test plan

- [ ] CI pytest green (Python code untouched)
- [ ] Apply migration 0007 against the Supabase project
- [ ] Hit `datum.graceops.dev/tools/<guid>` and confirm "Plex Staging Payload" card now populates (currently silent-empty in prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)