### PR TITLE
fix(ui): bump main tool table corner radius (#83)

### DIFF
--- a/web/src/pages/ToolsPage.tsx
+++ b/web/src/pages/ToolsPage.tsx
@@ -453,7 +453,7 @@ export function ToolsPage() {
         )}
       </div>
 
-      <div className="overflow-x-auto rounded-md border">
+      <div className="overflow-hidden rounded-lg border">
         <Table>
           <TableHeader>
             <TableRow>


### PR DESCRIPTION
## Summary

One-line change to [`web/src/pages/ToolsPage.tsx:456`](../blob/master/web/src/pages/ToolsPage.tsx#L456). Closes #83.

- `rounded-md` → `rounded-lg` (6px → 8px). Matches button and input radii elsewhere in the design system.
- `overflow-x-auto` → `overflow-hidden` on the outer wrapper so the rounded corners actually clip child content (header-row border, first/last-row hover highlights). The shadcn `Table` primitive already wraps the `<table>` in its own `<div className="relative w-full overflow-x-auto">`, so horizontal scrolling still works via that inner container — the outer `overflow-x-auto` was redundant.

## Design note

Interpreting the issue title "add corner radius" as "make it more rounded" since the wrapper already had `rounded-md`. Chose `rounded-lg` to match the ambient button/input family. If you'd rather match the Card radius (`rounded-xl`, 12px), say the word and I'll bump it. If you want the same treatment on `ToolDetailPage.tsx:360` and `BuildLibraryPage.tsx:329` (which still use `rounded-md`), happy to roll that in as a follow-up.

## Test plan

- [x] Change is a literal Tailwind class-string swap, no TS/build risk
- [ ] CI pytest green (unaffected — no Python touched)
- [ ] CI Workers Builds green (tailwind compile)
- [ ] Visual verify at `datum.graceops.dev/tools` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)