### PR TITLE
feat(plex-mock): Plex-mimic HTTP server for write-pipeline validation (#92)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ scratch/
 
 # Claude Code per-machine permissions cache (regenerated on demand)
 .claude/settings.local.json
+
+# Plex mock — ephemeral capture data (POSTs the sync sent against the mock)
+tools/plex_mock/captures/
+tools/plex_mock/*.db
+tools/plex_mock/*.db-journal

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,3 @@ scratch/
 
 # Claude Code per-machine permissions cache (regenerated on demand)
 .claude/settings.local.json
-
-# Plex mock — ephemeral capture data (POSTs the sync sent against the mock)
-tools/plex_mock/captures/
-tools/plex_mock/*.db
-tools/plex_mock/*.db-journal

--- a/docs/Plex_API_Reference.md
+++ b/docs/Plex_API_Reference.md
@@ -23,6 +23,22 @@ All Plex APIs are routed through the developer portal. There is no session token
 - **Rate Limit**: 200 API calls per minute across all endpoints.
 - **Base URL**: `https://connect.plex.com` (Production) / `https://test.connect.plex.com` (Test)
 
+### `PLEX_BASE_URL` override
+
+`plex_api.py` honors a `PLEX_BASE_URL` environment variable that overrides
+both `BASE_URL` and `PLEX_USE_TEST`. Used by the write-validation
+workflow in [#92](https://github.com/grace-shane/Datum/issues/92) to
+point `datum-sync` at the local Plex-mimic mock
+(`tools/plex_mock/server.py`) instead of `connect.plex.com`. Unset in
+normal production operation.
+
+Resolution order (first match wins):
+
+1. Explicit `base_url=` kwarg to `PlexClient()` — tests and ad-hoc scripts
+2. `PLEX_BASE_URL` env var — deployment-time override (the mock)
+3. `PLEX_USE_TEST=1` → `test.connect.plex.com`
+4. Default → `connect.plex.com`
+
 **Required Header:**
 
 ```http

--- a/plex_api.py
+++ b/plex_api.py
@@ -48,6 +48,12 @@ TENANT_ID  = os.environ.get("PLEX_TENANT_ID", GRACE_TENANT_ID)
 
 BASE_URL = "https://connect.plex.com"
 TEST_URL = "https://test.connect.plex.com"
+# PLEX_BASE_URL — explicit override for the Plex base URL (e.g. the local
+# mock at tools/plex_mock/server.py running on localhost:8080). Empty
+# string means "no override"; BASE_URL / TEST_URL selection applies.
+# Used by the write-validation workflow in issue #92 so the sync can
+# dress-rehearse against a fake-Plex without touching connect.plex.com.
+OVERRIDE_URL = os.environ.get("PLEX_BASE_URL", "").strip()
 USE_TEST = os.environ.get("PLEX_USE_TEST", "").strip().lower() in (
     "1", "true", "yes", "on", "enabled",
 )
@@ -59,8 +65,18 @@ TOOL_LIB_DIR = "Z:\\Engineering\\Tooling\\Fusion_Libraries"  # Mapped drive path
 # BASE CLIENT
 # ─────────────────────────────────────────────
 class PlexClient:
-    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False):
-        self.base = TEST_URL if use_test else BASE_URL
+    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False, base_url=None):
+        # Resolution order:
+        #   1. explicit base_url kwarg (tests, ad-hoc scripts)
+        #   2. PLEX_BASE_URL env var (deployment-time override — the mock)
+        #   3. TEST_URL if use_test else BASE_URL (original behavior)
+        explicit = (base_url or "").strip()
+        if explicit:
+            self.base = explicit
+        elif OVERRIDE_URL:
+            self.base = OVERRIDE_URL
+        else:
+            self.base = TEST_URL if use_test else BASE_URL
         self.headers = {
             "X-Plex-Connect-Api-Key": api_key,
             "Content-Type": "application/json",

--- a/plex_api.py
+++ b/plex_api.py
@@ -70,8 +70,9 @@ class PlexClient:
         #   1. explicit base_url kwarg (tests, ad-hoc scripts)
         #   2. PLEX_BASE_URL env var (deployment-time override — the mock)
         #   3. TEST_URL if use_test else BASE_URL (original behavior)
-        if base_url:
-            self.base = base_url
+        explicit = (base_url or "").strip()
+        if explicit:
+            self.base = explicit
         elif OVERRIDE_URL:
             self.base = OVERRIDE_URL
         else:

--- a/plex_api.py
+++ b/plex_api.py
@@ -48,12 +48,6 @@ TENANT_ID  = os.environ.get("PLEX_TENANT_ID", GRACE_TENANT_ID)
 
 BASE_URL = "https://connect.plex.com"
 TEST_URL = "https://test.connect.plex.com"
-# PLEX_BASE_URL — explicit override for the Plex base URL (e.g. the local
-# mock at tools/plex_mock/server.py running on localhost:8080). Empty
-# string means "no override"; BASE_URL / TEST_URL selection applies.
-# Used by the write-validation workflow in issue #92 so the sync can
-# dress-rehearse against a fake-Plex without touching connect.plex.com.
-OVERRIDE_URL = os.environ.get("PLEX_BASE_URL", "").strip()
 USE_TEST = os.environ.get("PLEX_USE_TEST", "").strip().lower() in (
     "1", "true", "yes", "on", "enabled",
 )
@@ -65,18 +59,8 @@ TOOL_LIB_DIR = "Z:\\Engineering\\Tooling\\Fusion_Libraries"  # Mapped drive path
 # BASE CLIENT
 # ─────────────────────────────────────────────
 class PlexClient:
-    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False, base_url=None):
-        # Resolution order:
-        #   1. explicit base_url kwarg (tests, ad-hoc scripts)
-        #   2. PLEX_BASE_URL env var (deployment-time override — the mock)
-        #   3. TEST_URL if use_test else BASE_URL (original behavior)
-        explicit = (base_url or "").strip()
-        if explicit:
-            self.base = explicit
-        elif OVERRIDE_URL:
-            self.base = OVERRIDE_URL
-        else:
-            self.base = TEST_URL if use_test else BASE_URL
+    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False):
+        self.base = TEST_URL if use_test else BASE_URL
         self.headers = {
             "X-Plex-Connect-Api-Key": api_key,
             "Content-Type": "application/json",

--- a/plex_api.py
+++ b/plex_api.py
@@ -48,6 +48,12 @@ TENANT_ID  = os.environ.get("PLEX_TENANT_ID", GRACE_TENANT_ID)
 
 BASE_URL = "https://connect.plex.com"
 TEST_URL = "https://test.connect.plex.com"
+# PLEX_BASE_URL — explicit override for the Plex base URL (e.g. the local
+# mock at tools/plex_mock/server.py running on localhost:8080). Empty
+# string means "no override"; BASE_URL / TEST_URL selection applies.
+# Used by the write-validation workflow in issue #92 so the sync can
+# dress-rehearse against a fake-Plex without touching connect.plex.com.
+OVERRIDE_URL = os.environ.get("PLEX_BASE_URL", "").strip()
 USE_TEST = os.environ.get("PLEX_USE_TEST", "").strip().lower() in (
     "1", "true", "yes", "on", "enabled",
 )
@@ -59,8 +65,17 @@ TOOL_LIB_DIR = "Z:\\Engineering\\Tooling\\Fusion_Libraries"  # Mapped drive path
 # BASE CLIENT
 # ─────────────────────────────────────────────
 class PlexClient:
-    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False):
-        self.base = TEST_URL if use_test else BASE_URL
+    def __init__(self, api_key, api_secret="", tenant_id="", use_test=False, base_url=None):
+        # Resolution order:
+        #   1. explicit base_url kwarg (tests, ad-hoc scripts)
+        #   2. PLEX_BASE_URL env var (deployment-time override — the mock)
+        #   3. TEST_URL if use_test else BASE_URL (original behavior)
+        if base_url:
+            self.base = base_url
+        elif OVERRIDE_URL:
+            self.base = OVERRIDE_URL
+        else:
+            self.base = TEST_URL if use_test else BASE_URL
         self.headers = {
             "X-Plex-Connect-Api-Key": api_key,
             "Content-Type": "application/json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ datum-sync-inventory = "sync_tool_inventory:cli"
 datum-ingest-reference = "ingest_reference:main"
 datum-enrich = "enrich:main"
 datum-populate-supply-items = "populate_supply_items:cli"
+datum-plex-mock-serve    = "tools.plex_mock.server:main"
+datum-plex-mock-snapshot = "tools.plex_mock.capture_snapshots:main"
+datum-plex-mock-diff     = "tools.plex_mock.diff:main"
 
 [tool.setuptools]
 # Flat layout — all modules live at the repo root, no src/ directory.
@@ -43,5 +46,6 @@ py-modules = [
     "enrich",
     "ingest_reference",
 ]
-# Don't try to auto-discover packages — there are none.
-packages = []
+# Explicit package list — flat root modules use py-modules above;
+# sub-packages with __init__.py are listed here.
+packages = ["tools", "tools.plex_mock"]

--- a/tests/fixtures/plex_mock/expected_supply_items.json
+++ b/tests/fixtures/plex_mock/expected_supply_items.json
@@ -1,0 +1,24 @@
+{
+  "supply_items_post_shape": {
+    "required_fields": [
+      "category",
+      "description",
+      "group",
+      "inventoryUnit",
+      "supplyItemNumber",
+      "type"
+    ],
+    "forbidden_fields": [
+      "id",
+      "posted_to_plex_at"
+    ],
+    "field_types": {
+      "category": "str",
+      "description": "str",
+      "group": "str",
+      "inventoryUnit": "str",
+      "supplyItemNumber": "str",
+      "type": "str"
+    }
+  }
+}

--- a/tests/test_plex_api.py
+++ b/tests/test_plex_api.py
@@ -64,6 +64,15 @@ class TestPlexClientHeaders:
 # Environment routing
 # ─────────────────────────────────────────────
 class TestPlexClientEnvironment:
+    @pytest.fixture(autouse=True)
+    def _no_base_url_override(self, monkeypatch):
+        """Ensure PLEX_BASE_URL is unset + module reloaded so OVERRIDE_URL == ''."""
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        import importlib
+        importlib.reload(plex_api)
+        yield
+        importlib.reload(plex_api)
+
     def test_use_test_true_uses_test_url(self):
         c = PlexClient(api_key="k", use_test=True)
         assert c.base == TEST_URL
@@ -78,6 +87,24 @@ class TestPlexClientEnvironment:
         # Default constructor arg is use_test=False
         c = PlexClient(api_key="k")
         assert c.base == BASE_URL
+
+    def test_explicit_base_url_arg_wins(self):
+        c = PlexClient(api_key="k", base_url="http://localhost:8080")
+        assert c.base == "http://localhost:8080"
+
+    def test_explicit_base_url_arg_wins_even_over_use_test(self):
+        c = PlexClient(api_key="k", use_test=True, base_url="http://localhost:8080")
+        assert c.base == "http://localhost:8080"
+
+    def test_empty_base_url_falls_through_to_default(self, monkeypatch):
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        import importlib
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k", base_url="")
+        assert c.base == plex_api.BASE_URL
+        c = plex_api.PlexClient(api_key="k", base_url="   ")
+        assert c.base == plex_api.BASE_URL
+        importlib.reload(plex_api)
 
 
 # ─────────────────────────────────────────────
@@ -140,6 +167,39 @@ class TestModuleDefaults:
         monkeypatch.setenv("PLEX_USE_TEST", "nope")
         importlib.reload(plex_api)
         assert plex_api.USE_TEST is False
+        importlib.reload(plex_api)
+
+    def test_override_url_empty_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        importlib.reload(plex_api)
+        assert plex_api.OVERRIDE_URL == ""
+        importlib.reload(plex_api)
+
+    def test_override_url_set_from_env(self, monkeypatch):
+        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
+        importlib.reload(plex_api)
+        assert plex_api.OVERRIDE_URL == "http://localhost:8080"
+        importlib.reload(plex_api)
+
+    def test_client_uses_override_url_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k")
+        assert c.base == "http://localhost:8080"
+        importlib.reload(plex_api)
+
+    def test_client_override_url_wins_over_use_test(self, monkeypatch):
+        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k", use_test=True)
+        assert c.base == "http://localhost:8080"
+        importlib.reload(plex_api)
+
+    def test_client_unchanged_when_override_unset(self, monkeypatch):
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k")
+        assert c.base == plex_api.BASE_URL
         importlib.reload(plex_api)
 
 

--- a/tests/test_plex_api.py
+++ b/tests/test_plex_api.py
@@ -64,15 +64,6 @@ class TestPlexClientHeaders:
 # Environment routing
 # ─────────────────────────────────────────────
 class TestPlexClientEnvironment:
-    @pytest.fixture(autouse=True)
-    def _no_base_url_override(self, monkeypatch):
-        """Ensure PLEX_BASE_URL is unset + module reloaded so OVERRIDE_URL == ''."""
-        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
-        import importlib
-        importlib.reload(plex_api)
-        yield
-        importlib.reload(plex_api)
-
     def test_use_test_true_uses_test_url(self):
         c = PlexClient(api_key="k", use_test=True)
         assert c.base == TEST_URL
@@ -87,24 +78,6 @@ class TestPlexClientEnvironment:
         # Default constructor arg is use_test=False
         c = PlexClient(api_key="k")
         assert c.base == BASE_URL
-
-    def test_explicit_base_url_arg_wins(self):
-        c = PlexClient(api_key="k", base_url="http://localhost:8080")
-        assert c.base == "http://localhost:8080"
-
-    def test_explicit_base_url_arg_wins_even_over_use_test(self):
-        c = PlexClient(api_key="k", use_test=True, base_url="http://localhost:8080")
-        assert c.base == "http://localhost:8080"
-
-    def test_empty_base_url_falls_through_to_default(self, monkeypatch):
-        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
-        import importlib
-        importlib.reload(plex_api)
-        c = plex_api.PlexClient(api_key="k", base_url="")
-        assert c.base == plex_api.BASE_URL
-        c = plex_api.PlexClient(api_key="k", base_url="   ")
-        assert c.base == plex_api.BASE_URL
-        importlib.reload(plex_api)
 
 
 # ─────────────────────────────────────────────
@@ -167,39 +140,6 @@ class TestModuleDefaults:
         monkeypatch.setenv("PLEX_USE_TEST", "nope")
         importlib.reload(plex_api)
         assert plex_api.USE_TEST is False
-        importlib.reload(plex_api)
-
-    def test_override_url_empty_when_env_unset(self, monkeypatch):
-        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
-        importlib.reload(plex_api)
-        assert plex_api.OVERRIDE_URL == ""
-        importlib.reload(plex_api)
-
-    def test_override_url_set_from_env(self, monkeypatch):
-        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
-        importlib.reload(plex_api)
-        assert plex_api.OVERRIDE_URL == "http://localhost:8080"
-        importlib.reload(plex_api)
-
-    def test_client_uses_override_url_when_env_set(self, monkeypatch):
-        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
-        importlib.reload(plex_api)
-        c = plex_api.PlexClient(api_key="k")
-        assert c.base == "http://localhost:8080"
-        importlib.reload(plex_api)
-
-    def test_client_override_url_wins_over_use_test(self, monkeypatch):
-        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
-        importlib.reload(plex_api)
-        c = plex_api.PlexClient(api_key="k", use_test=True)
-        assert c.base == "http://localhost:8080"
-        importlib.reload(plex_api)
-
-    def test_client_unchanged_when_override_unset(self, monkeypatch):
-        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
-        importlib.reload(plex_api)
-        c = plex_api.PlexClient(api_key="k")
-        assert c.base == plex_api.BASE_URL
         importlib.reload(plex_api)
 
 

--- a/tests/test_plex_api.py
+++ b/tests/test_plex_api.py
@@ -79,6 +79,14 @@ class TestPlexClientEnvironment:
         c = PlexClient(api_key="k")
         assert c.base == BASE_URL
 
+    def test_explicit_base_url_arg_wins(self):
+        c = PlexClient(api_key="k", base_url="http://localhost:8080")
+        assert c.base == "http://localhost:8080"
+
+    def test_explicit_base_url_arg_wins_even_over_use_test(self):
+        c = PlexClient(api_key="k", use_test=True, base_url="http://localhost:8080")
+        assert c.base == "http://localhost:8080"
+
 
 # ─────────────────────────────────────────────
 # Throttle initialization
@@ -140,6 +148,39 @@ class TestModuleDefaults:
         monkeypatch.setenv("PLEX_USE_TEST", "nope")
         importlib.reload(plex_api)
         assert plex_api.USE_TEST is False
+        importlib.reload(plex_api)
+
+    def test_override_url_empty_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        importlib.reload(plex_api)
+        assert plex_api.OVERRIDE_URL == ""
+        importlib.reload(plex_api)
+
+    def test_override_url_set_from_env(self, monkeypatch):
+        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
+        importlib.reload(plex_api)
+        assert plex_api.OVERRIDE_URL == "http://localhost:8080"
+        importlib.reload(plex_api)
+
+    def test_client_uses_override_url_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k")
+        assert c.base == "http://localhost:8080"
+        importlib.reload(plex_api)
+
+    def test_client_override_url_wins_over_use_test(self, monkeypatch):
+        monkeypatch.setenv("PLEX_BASE_URL", "http://localhost:8080")
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k", use_test=True)
+        assert c.base == "http://localhost:8080"
+        importlib.reload(plex_api)
+
+    def test_client_unchanged_when_override_unset(self, monkeypatch):
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k")
+        assert c.base == plex_api.BASE_URL
         importlib.reload(plex_api)
 
 

--- a/tests/test_plex_api.py
+++ b/tests/test_plex_api.py
@@ -64,6 +64,15 @@ class TestPlexClientHeaders:
 # Environment routing
 # ─────────────────────────────────────────────
 class TestPlexClientEnvironment:
+    @pytest.fixture(autouse=True)
+    def _no_base_url_override(self, monkeypatch):
+        """Ensure PLEX_BASE_URL is unset + module reloaded so OVERRIDE_URL == ''."""
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        import importlib
+        importlib.reload(plex_api)
+        yield
+        importlib.reload(plex_api)
+
     def test_use_test_true_uses_test_url(self):
         c = PlexClient(api_key="k", use_test=True)
         assert c.base == TEST_URL
@@ -86,6 +95,16 @@ class TestPlexClientEnvironment:
     def test_explicit_base_url_arg_wins_even_over_use_test(self):
         c = PlexClient(api_key="k", use_test=True, base_url="http://localhost:8080")
         assert c.base == "http://localhost:8080"
+
+    def test_empty_base_url_falls_through_to_default(self, monkeypatch):
+        monkeypatch.delenv("PLEX_BASE_URL", raising=False)
+        import importlib
+        importlib.reload(plex_api)
+        c = plex_api.PlexClient(api_key="k", base_url="")
+        assert c.base == plex_api.BASE_URL
+        c = plex_api.PlexClient(api_key="k", base_url="   ")
+        assert c.base == plex_api.BASE_URL
+        importlib.reload(plex_api)
 
 
 # ─────────────────────────────────────────────

--- a/tests/test_plex_mock_diff.py
+++ b/tests/test_plex_mock_diff.py
@@ -81,3 +81,20 @@ class TestDiffRun:
         result = diff_run(store=store, run_id="r1", expected=expected)
         assert result.ok is False
         assert any("description" in m and "str" in m for m in result.issues)
+
+    def test_checked_counter_reflects_rows(self, store: CaptureStore, expected: dict):
+        body = {
+            "category": "Tools & Inserts", "description": "x",
+            "group": "Machining - End Mills", "inventoryUnit": "Ea",
+            "supplyItemNumber": "ABC-1", "type": "SUPPLY",
+        }
+        store.append(method="POST", path="/inventory/v1/inventory-definitions/supply-items", body=body, run_id="r1")
+        store.append(method="POST", path="/inventory/v1/inventory-definitions/supply-items", body=body, run_id="r1")
+        result = diff_run(store=store, run_id="r1", expected=expected)
+        assert result.checked == 2
+        assert result.ok is True
+
+    def test_empty_run_returns_ok_with_zero_checked(self, store: CaptureStore, expected: dict):
+        result = diff_run(store=store, run_id="nope", expected=expected)
+        assert result.ok is True
+        assert result.checked == 0

--- a/tests/test_plex_mock_diff.py
+++ b/tests/test_plex_mock_diff.py
@@ -1,0 +1,83 @@
+"""Tests for the Plex-mock diff CLI."""
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.plex_mock.diff import diff_run, DiffResult
+from tools.plex_mock.store import CaptureStore
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "plex_mock" / "expected_supply_items.json"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CaptureStore:
+    return CaptureStore(tmp_path / "captures.db")
+
+
+@pytest.fixture
+def expected() -> dict:
+    return json.loads(FIXTURE.read_text())
+
+
+class TestDiffRun:
+    def test_clean_run_returns_no_issues(self, store: CaptureStore, expected: dict):
+        store.append(
+            method="POST",
+            path="/inventory/v1/inventory-definitions/supply-items",
+            body={
+                "category": "Tools & Inserts", "description": "x",
+                "group": "Machining - End Mills", "inventoryUnit": "Ea",
+                "supplyItemNumber": "ABC-1", "type": "SUPPLY",
+            },
+            run_id="r1",
+        )
+        result = diff_run(store=store, run_id="r1", expected=expected)
+        assert isinstance(result, DiffResult)
+        assert result.issues == []
+        assert result.ok is True
+
+    def test_missing_required_field_flagged(self, store: CaptureStore, expected: dict):
+        store.append(
+            method="POST",
+            path="/inventory/v1/inventory-definitions/supply-items",
+            body={"supplyItemNumber": "ABC-1"},  # missing everything else
+            run_id="r1",
+        )
+        result = diff_run(store=store, run_id="r1", expected=expected)
+        assert result.ok is False
+        msgs = " ".join(result.issues)
+        assert "missing" in msgs.lower()
+        assert "category" in msgs
+
+    def test_forbidden_field_flagged(self, store: CaptureStore, expected: dict):
+        store.append(
+            method="POST",
+            path="/inventory/v1/inventory-definitions/supply-items",
+            body={
+                "category": "Tools & Inserts", "description": "x",
+                "group": "Machining - End Mills", "inventoryUnit": "Ea",
+                "supplyItemNumber": "ABC-1", "type": "SUPPLY",
+                "id": "client-should-not-send-this",
+            },
+            run_id="r1",
+        )
+        result = diff_run(store=store, run_id="r1", expected=expected)
+        assert result.ok is False
+        assert any("forbidden" in m.lower() and "id" in m for m in result.issues)
+
+    def test_wrong_field_type_flagged(self, store: CaptureStore, expected: dict):
+        store.append(
+            method="POST",
+            path="/inventory/v1/inventory-definitions/supply-items",
+            body={
+                "category": "Tools & Inserts", "description": 42,  # should be str
+                "group": "Machining - End Mills", "inventoryUnit": "Ea",
+                "supplyItemNumber": "ABC-1", "type": "SUPPLY",
+            },
+            run_id="r1",
+        )
+        result = diff_run(store=store, run_id="r1", expected=expected)
+        assert result.ok is False
+        assert any("description" in m and "str" in m for m in result.issues)

--- a/tests/test_plex_mock_server.py
+++ b/tests/test_plex_mock_server.py
@@ -134,6 +134,14 @@ class TestSupplyItemsPost:
         rv = client.post("/inventory/v1/inventory-definitions/supply-items", json=payload)
         assert rv.status_code == 409
 
+    def test_post_409_does_not_capture(self, client):
+        payload = {"supplyItemNumber": "ABC-1", "description": "dup"}
+        rv = client.post("/inventory/v1/inventory-definitions/supply-items", json=payload)
+        assert rv.status_code == 409
+        store = client.application.config["PLEX_MOCK_STORE"]
+        rows = store.query(run_id=client.application.config["PLEX_MOCK_RUN_ID"])
+        assert len(rows) == 0
+
 
 class TestSupplyItemsPut:
     def test_put_200_and_captured(self, client):

--- a/tests/test_plex_mock_server.py
+++ b/tests/test_plex_mock_server.py
@@ -91,3 +91,92 @@ class TestMalformedSnapshot:
         with pytest.raises(ValueError) as excinfo:
             create_app(snapshots_dir=d, db_path=tmp_path / "c.db", run_id="r1")
         assert "supply_items_list.json" in str(excinfo.value)
+
+
+import uuid
+
+
+class TestSupplyItemsPost:
+    def test_post_returns_201_with_synthetic_id(self, client):
+        payload = {"supplyItemNumber": "NEW-1", "description": "New tool",
+                   "category": "Tools & Inserts", "group": "Machining - End Mills",
+                   "inventoryUnit": "Ea", "type": "SUPPLY"}
+        rv = client.post("/inventory/v1/inventory-definitions/supply-items", json=payload)
+        assert rv.status_code == 201
+        body = rv.get_json()
+        assert "id" in body
+        uuid.UUID(body["id"])  # valid uuid4
+        assert body["supplyItemNumber"] == "NEW-1"
+
+    def test_post_echoes_payload_fields(self, client):
+        payload = {"supplyItemNumber": "NEW-2", "description": "x",
+                   "group": "Machining - Drills", "inventoryUnit": "Ea",
+                   "category": "Tools & Inserts", "type": "SUPPLY"}
+        rv = client.post("/inventory/v1/inventory-definitions/supply-items", json=payload)
+        body = rv.get_json()
+        for k, v in payload.items():
+            assert body[k] == v
+
+    def test_post_persists_to_capture_store(self, client):
+        from tools.plex_mock.store import CaptureStore
+        payload = {"supplyItemNumber": "NEW-3"}
+        client.post("/inventory/v1/inventory-definitions/supply-items", json=payload)
+        store: CaptureStore = client.application.config["PLEX_MOCK_STORE"]
+        rows = store.query(run_id=client.application.config["PLEX_MOCK_RUN_ID"])
+        assert len(rows) == 1
+        assert rows[0]["method"] == "POST"
+        assert rows[0]["path"].endswith("/supply-items")
+        assert rows[0]["body"]["supplyItemNumber"] == "NEW-3"
+
+    def test_post_409_on_duplicate_supply_item_number(self, client):
+        # Snapshot already has "ABC-1" — mock should treat that as a conflict
+        payload = {"supplyItemNumber": "ABC-1", "description": "dup"}
+        rv = client.post("/inventory/v1/inventory-definitions/supply-items", json=payload)
+        assert rv.status_code == 409
+
+
+class TestSupplyItemsPut:
+    def test_put_200_and_captured(self, client):
+        payload = {"description": "updated description"}
+        rv = client.put(
+            "/inventory/v1/inventory-definitions/supply-items/11111111-1111-1111-1111-111111111111",
+            json=payload,
+        )
+        assert rv.status_code == 200
+        assert rv.get_json()["description"] == "updated description"
+
+        store = client.application.config["PLEX_MOCK_STORE"]
+        rows = store.query(run_id=client.application.config["PLEX_MOCK_RUN_ID"], method="PUT")
+        assert len(rows) == 1
+
+    def test_put_404_on_unknown_id(self, client):
+        rv = client.put(
+            "/inventory/v1/inventory-definitions/supply-items/not-a-real-id",
+            json={"description": "x"},
+        )
+        assert rv.status_code == 404
+
+
+class TestWorkcenterWrites:
+    def test_put_workcenter_captured(self, client):
+        # #6 probe — we don't yet know the body shape, just confirm the mock
+        # records whatever we send it.
+        payload = {"unknownFieldForProbe": True}
+        rv = client.put(
+            "/production/v1/production-definitions/workcenters/0b6cf62b-2809-4d3d-ab24-369cd0171f62",
+            json=payload,
+        )
+        assert rv.status_code == 200
+        store = client.application.config["PLEX_MOCK_STORE"]
+        rows = store.query(run_id=client.application.config["PLEX_MOCK_RUN_ID"], method="PUT")
+        assert any(r["body"].get("unknownFieldForProbe") is True for r in rows)
+
+    def test_patch_workcenter_captured(self, client):
+        rv = client.patch(
+            "/production/v1/production-definitions/workcenters/0b6cf62b-2809-4d3d-ab24-369cd0171f62",
+            json={"note": "patched"},
+        )
+        assert rv.status_code == 200
+        store = client.application.config["PLEX_MOCK_STORE"]
+        rows = store.query(run_id=client.application.config["PLEX_MOCK_RUN_ID"], method="PATCH")
+        assert len(rows) == 1

--- a/tests/test_plex_mock_server.py
+++ b/tests/test_plex_mock_server.py
@@ -1,0 +1,82 @@
+"""Tests for the Plex-mock Flask server."""
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.plex_mock.server import create_app
+
+
+@pytest.fixture
+def snapshots_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "snapshots"
+    d.mkdir()
+    supply = [
+        {"id": "11111111-1111-1111-1111-111111111111", "supplyItemNumber": "ABC-1",
+         "description": "Test tool", "category": "Tools & Inserts",
+         "group": "Machining - End Mills", "inventoryUnit": "Ea", "type": "SUPPLY"},
+        {"id": "22222222-2222-2222-2222-222222222222", "supplyItemNumber": "ABC-2",
+         "description": "Test tool 2", "category": "Tools & Inserts",
+         "group": "Machining - Drills", "inventoryUnit": "Ea", "type": "SUPPLY"},
+    ]
+    workcenters = [
+        {"workcenterId": "0b6cf62b-2809-4d3d-ab24-369cd0171f62",
+         "workcenterCode": "879", "name": "Brother Speedio 879",
+         "workcenterGroup": "MILLS"},
+    ]
+    (d / "supply_items_list.json").write_text(json.dumps(supply))
+    (d / "workcenters_list.json").write_text(json.dumps(workcenters))
+    return d
+
+
+@pytest.fixture
+def client(tmp_path: Path, snapshots_dir: Path):
+    app = create_app(snapshots_dir=snapshots_dir, db_path=tmp_path / "captures.db", run_id="test-run")
+    return app.test_client()
+
+
+class TestSupplyItemsGetList:
+    def test_returns_200(self, client):
+        rv = client.get("/inventory/v1/inventory-definitions/supply-items")
+        assert rv.status_code == 200
+
+    def test_returns_snapshot_body(self, client):
+        rv = client.get("/inventory/v1/inventory-definitions/supply-items")
+        body = rv.get_json()
+        assert isinstance(body, list)
+        assert len(body) == 2
+        assert body[0]["supplyItemNumber"] == "ABC-1"
+
+
+class TestSupplyItemsGetById:
+    def test_returns_200_when_found(self, client):
+        rv = client.get("/inventory/v1/inventory-definitions/supply-items/11111111-1111-1111-1111-111111111111")
+        assert rv.status_code == 200
+        assert rv.get_json()["supplyItemNumber"] == "ABC-1"
+
+    def test_returns_404_when_unknown(self, client):
+        rv = client.get("/inventory/v1/inventory-definitions/supply-items/does-not-exist")
+        assert rv.status_code == 404
+
+
+class TestWorkcentersGet:
+    def test_returns_200_list(self, client):
+        rv = client.get("/production/v1/production-definitions/workcenters")
+        assert rv.status_code == 200
+        assert len(rv.get_json()) == 1
+
+    def test_returns_200_by_id(self, client):
+        rv = client.get("/production/v1/production-definitions/workcenters/0b6cf62b-2809-4d3d-ab24-369cd0171f62")
+        assert rv.status_code == 200
+        assert rv.get_json()["workcenterCode"] == "879"
+
+    def test_returns_404_for_unknown_workcenter(self, client):
+        rv = client.get("/production/v1/production-definitions/workcenters/nope")
+        assert rv.status_code == 404
+
+
+class TestHealth:
+    def test_health_endpoint(self, client):
+        rv = client.get("/healthz")
+        assert rv.status_code == 200
+        assert rv.get_json() == {"ok": True}

--- a/tests/test_plex_mock_server.py
+++ b/tests/test_plex_mock_server.py
@@ -80,3 +80,14 @@ class TestHealth:
         rv = client.get("/healthz")
         assert rv.status_code == 200
         assert rv.get_json() == {"ok": True}
+
+
+class TestMalformedSnapshot:
+    def test_malformed_json_raises_value_error_with_path(self, tmp_path: Path):
+        d = tmp_path / "snapshots"
+        d.mkdir()
+        (d / "supply_items_list.json").write_text("not json at all")
+        (d / "workcenters_list.json").write_text("[]")
+        with pytest.raises(ValueError) as excinfo:
+            create_app(snapshots_dir=d, db_path=tmp_path / "c.db", run_id="r1")
+        assert "supply_items_list.json" in str(excinfo.value)

--- a/tests/test_plex_mock_store.py
+++ b/tests/test_plex_mock_store.py
@@ -1,0 +1,77 @@
+"""Tests for the Plex-mock SQLite capture store."""
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tools.plex_mock.store import CaptureStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CaptureStore:
+    return CaptureStore(tmp_path / "captures.db")
+
+
+class TestCaptureStoreInit:
+    def test_creates_db_file_on_open(self, tmp_path: Path):
+        db = tmp_path / "captures.db"
+        assert not db.exists()
+        CaptureStore(db)
+        assert db.exists()
+
+    def test_creates_table_schema(self, store: CaptureStore):
+        with sqlite3.connect(store.path) as con:
+            cols = {row[1] for row in con.execute("PRAGMA table_info(captures)")}
+        assert {"id", "ts", "method", "path", "body_json", "run_id"} <= cols
+
+
+class TestCaptureStoreAppend:
+    def test_append_returns_integer_id(self, store: CaptureStore):
+        rid = store.append(method="POST", path="/foo", body={"a": 1}, run_id="r1")
+        assert isinstance(rid, int)
+        assert rid >= 1
+
+    def test_append_persists_row(self, store: CaptureStore):
+        store.append(method="POST", path="/foo", body={"a": 1}, run_id="r1")
+        rows = store.query(run_id="r1")
+        assert len(rows) == 1
+        assert rows[0]["method"] == "POST"
+        assert rows[0]["path"] == "/foo"
+        assert rows[0]["body"] == {"a": 1}
+        assert rows[0]["run_id"] == "r1"
+
+    def test_append_stores_body_as_json(self, store: CaptureStore):
+        payload = {"nested": {"k": [1, 2, 3]}}
+        store.append(method="PUT", path="/x", body=payload, run_id="r1")
+        with sqlite3.connect(store.path) as con:
+            raw = con.execute("SELECT body_json FROM captures").fetchone()[0]
+        assert json.loads(raw) == payload
+
+    def test_append_handles_null_body(self, store: CaptureStore):
+        store.append(method="PATCH", path="/x", body=None, run_id="r1")
+        rows = store.query(run_id="r1")
+        assert rows[0]["body"] is None
+
+
+class TestCaptureStoreQuery:
+    def test_query_filters_by_run_id(self, store: CaptureStore):
+        store.append(method="POST", path="/a", body={}, run_id="r1")
+        store.append(method="POST", path="/b", body={}, run_id="r2")
+        assert len(store.query(run_id="r1")) == 1
+        assert len(store.query(run_id="r2")) == 1
+
+    def test_query_filters_by_method(self, store: CaptureStore):
+        store.append(method="POST", path="/a", body={}, run_id="r1")
+        store.append(method="PUT", path="/a", body={}, run_id="r1")
+        assert len(store.query(run_id="r1", method="POST")) == 1
+        assert len(store.query(run_id="r1", method="PUT")) == 1
+
+    def test_query_orders_by_id_ascending(self, store: CaptureStore):
+        store.append(method="POST", path="/a", body={"n": 1}, run_id="r1")
+        store.append(method="POST", path="/b", body={"n": 2}, run_id="r1")
+        rows = store.query(run_id="r1")
+        assert [r["body"]["n"] for r in rows] == [1, 2]
+
+    def test_query_empty_when_no_match(self, store: CaptureStore):
+        assert store.query(run_id="nope") == []

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Internal tooling for the Datum project (not packaged for distribution)."""

--- a/tools/plex_mock/README.md
+++ b/tools/plex_mock/README.md
@@ -1,0 +1,6 @@
+# Plex-Mimic Mock
+
+Local HTTP server mimicking the Plex REST surface. See issue #92 and
+`docs/superpowers/plans/2026-04-17-plex-mimic-mock.md` for the full plan.
+
+Full usage + validation-window protocol lands in Task 9 of the plan.

--- a/tools/plex_mock/README.md
+++ b/tools/plex_mock/README.md
@@ -1,6 +1,59 @@
 # Plex-Mimic Mock
 
-Local HTTP server mimicking the Plex REST surface. See issue #92 and
-`docs/superpowers/plans/2026-04-17-plex-mimic-mock.md` for the full plan.
+Local HTTP server mirroring the Plex REST surface for write-pipeline
+validation. Tracked in [#92](https://github.com/grace-shane/Datum/issues/92);
+blocks [#3](https://github.com/grace-shane/Datum/issues/3) and
+[#6](https://github.com/grace-shane/Datum/issues/6).
 
-Full usage + validation-window protocol lands in Task 9 of the plan.
+## Quick start
+
+```bash
+# Refresh snapshots from real Plex (read-only; safe to re-run)
+python -m tools.plex_mock.capture_snapshots
+
+# Start the mock on localhost:8080
+python -m tools.plex_mock.server --run-id $(date +%Y%m%d-%H%M%S)
+
+# In another shell: point the sync at it
+PLEX_BASE_URL=http://127.0.0.1:8080 \
+PLEX_ALLOW_WRITES=1 \
+  datum-sync
+
+# After the run: diff captures against the expected payload shape
+python -m tools.plex_mock.diff \
+  --run-id <run-id from first command> \
+  --db tools/plex_mock/captures.db \
+  --expected tests/fixtures/plex_mock/expected_supply_items.json
+```
+
+## What it serves
+
+| Endpoint | Behavior |
+|---|---|
+| `GET  /healthz` | liveness probe, returns `{"ok": true}` |
+| `GET  /inventory/v1/inventory-definitions/supply-items` | serves `snapshots/supply_items_list.json` |
+| `GET  /inventory/v1/inventory-definitions/supply-items/{id}` | one record from the snapshot; 404 if unknown |
+| `POST /inventory/v1/inventory-definitions/supply-items` | captures body, returns 201 with synthetic UUID; 409 if `supplyItemNumber` collides with snapshot |
+| `PUT  /inventory/v1/inventory-definitions/supply-items/{id}` | captures body, merges over snapshot record, returns 200; 404 if unknown |
+| `GET  /production/v1/production-definitions/workcenters` | serves `snapshots/workcenters_list.json` |
+| `GET  /production/v1/production-definitions/workcenters/{id}` | one record; 404 if unknown |
+| `PUT/PATCH /production/v1/production-definitions/workcenters/{id}` | captures body, returns merged record (the #6 probe path) |
+
+Every write lands in `captures.db` keyed by `run_id` for later diffing.
+
+## Validation-window protocol
+
+Before we flip `PLEX_ALLOW_WRITES=1` against real `connect.plex.com`:
+
+1. Three consecutive `datum-sync` runs against the mock produce identical capture sets (same count, same payload shapes).
+2. `datum-plex-mock-diff` reports CLEAN against `expected_supply_items.json` for all three runs.
+3. Rehearsal notes in `tools/plex_mock/REHEARSAL_NOTES.md` document at least one full mock-sync cycle end-to-end.
+4. Only then: PR that enables writes to real Plex, and only with explicit Shane approval in the PR description.
+
+The mock is the validation surface. `test.connect.plex.com` (`PLEX_USE_TEST=1`) is not — the Datum Consumer Key only authenticates against production (see `docs/BRIEFING.md`).
+
+## Deploy on `datum-runtime`
+
+See `tools/plex_mock/systemd/datum-plex-mock.service`. Copy into
+`/etc/systemd/system/`, `systemctl daemon-reload && systemctl enable --now datum-plex-mock`.
+Bound to `127.0.0.1:8080` — no external exposure, no TLS needed.

--- a/tools/plex_mock/__init__.py
+++ b/tools/plex_mock/__init__.py
@@ -1,0 +1,5 @@
+"""
+Local mock HTTP server mirroring the Plex REST surface for write-pipeline
+validation. See tools/plex_mock/README.md and issue #92.
+"""
+__version__ = "0.1.0"

--- a/tools/plex_mock/capture_snapshots.py
+++ b/tools/plex_mock/capture_snapshots.py
@@ -1,0 +1,51 @@
+"""
+One-off: hit real connect.plex.com and persist GET responses for the two
+endpoints the mock needs to serve. Commit the output files.
+
+Run with credentials loaded the usual way (.env.local + bootstrap.py):
+
+    python -m tools.plex_mock.capture_snapshots
+
+Refresh when the Plex shape changes. This script only GETs — safe to
+run any time without the PLEX_ALLOW_WRITES guard.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from plex_api import API_KEY, API_SECRET, TENANT_ID, USE_TEST, PlexClient
+
+
+SNAPSHOTS_DIR = Path(__file__).parent / "snapshots"
+
+
+def capture(client: PlexClient, collection: str, version: str, resource: str, outfile: str) -> int:
+    env = client.get_envelope(collection, version, resource)
+    if not env["ok"]:
+        print(f"  FAILED {collection}/{version}/{resource}: HTTP {env['status']}", file=sys.stderr)
+        return 1
+    data = env["body"]
+    out = SNAPSHOTS_DIR / outfile
+    out.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    count = len(data) if isinstance(data, list) else 1
+    print(f"  wrote {out.relative_to(Path.cwd())} ({count} records, {out.stat().st_size} bytes)")
+    return 0
+
+
+def main() -> int:
+    if not API_KEY:
+        print("PLEX_API_KEY is not set; can't capture snapshots.", file=sys.stderr)
+        return 2
+    client = PlexClient(API_KEY, API_SECRET, TENANT_ID, use_test=USE_TEST)
+    rc = 0
+    rc |= capture(client, "inventory", "v1", "inventory-definitions/supply-items",
+                  "supply_items_list.json")
+    rc |= capture(client, "production", "v1", "production-definitions/workcenters",
+                  "workcenters_list.json")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/plex_mock/diff.py
+++ b/tools/plex_mock/diff.py
@@ -27,6 +27,7 @@ TYPE_MAP = {"str": str, "int": int, "float": float, "bool": bool, "list": list, 
 @dataclass
 class DiffResult:
     issues: list[str] = field(default_factory=list)
+    checked: int = 0
 
     @property
     def ok(self) -> bool:
@@ -60,6 +61,7 @@ def diff_run(*, store: CaptureStore, run_id: str, expected: dict) -> DiffResult:
     for row in store.query(run_id=run_id, method="POST"):
         if not row["path"].endswith("/supply-items"):
             continue
+        result.checked += 1
         body = row["body"] or {}
         result.issues.extend(_check_supply_item_post(body, shape, row["id"]))
     return result
@@ -83,9 +85,12 @@ def main() -> int:
     expected = json.loads(args.expected.read_text())
     result = diff_run(store=store, run_id=args.run_id, expected=expected)
     if result.ok:
-        print(f"plex-mock diff: CLEAN (run_id={args.run_id})")
+        if result.checked == 0:
+            print(f"plex-mock diff: CLEAN but ZERO rows checked (run_id={args.run_id}) — is the run_id correct?", file=sys.stderr)
+            return 3
+        print(f"plex-mock diff: CLEAN (run_id={args.run_id}, {result.checked} supply-items POSTs checked)")
         return 0
-    print(f"plex-mock diff: DRIFT (run_id={args.run_id}, {len(result.issues)} issues)")
+    print(f"plex-mock diff: DRIFT (run_id={args.run_id}, {result.checked} checked, {len(result.issues)} issues)")
     for issue in result.issues:
         print(f"  {issue}")
     return 1

--- a/tools/plex_mock/diff.py
+++ b/tools/plex_mock/diff.py
@@ -1,0 +1,95 @@
+"""
+Diff captured Plex-mock POSTs against an expected-payload fixture.
+
+Checks each supply-items POST for:
+  - required fields present
+  - forbidden fields absent (things the client shouldn't send)
+  - field types match the fixture
+
+Exit code 0 on clean, 1 on drift. Usage:
+
+    python -m tools.plex_mock.diff --run-id <run> --db <path> --expected <path>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tools.plex_mock.store import CaptureStore
+
+
+TYPE_MAP = {"str": str, "int": int, "float": float, "bool": bool, "list": list, "dict": dict}
+
+
+@dataclass
+class DiffResult:
+    issues: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+def _check_supply_item_post(body: dict, shape: dict, row_id: int) -> list[str]:
+    issues: list[str] = []
+    for f in shape["required_fields"]:
+        if f not in body:
+            issues.append(f"row {row_id}: missing required field '{f}'")
+    for f in shape["forbidden_fields"]:
+        if f in body:
+            issues.append(f"row {row_id}: forbidden field '{f}' present")
+    for f, t in shape["field_types"].items():
+        if f in body:
+            expected_t = TYPE_MAP.get(t)
+            if expected_t and not isinstance(body[f], expected_t):
+                actual = type(body[f]).__name__
+                issues.append(f"row {row_id}: field '{f}' expected {t}, got {actual}")
+    return issues
+
+
+def diff_run(*, store: CaptureStore, run_id: str, expected: dict) -> DiffResult:
+    result = DiffResult()
+    shape = expected.get("supply_items_post_shape")
+    if not shape:
+        result.issues.append("fixture missing 'supply_items_post_shape'")
+        return result
+
+    for row in store.query(run_id=run_id, method="POST"):
+        if not row["path"].endswith("/supply-items"):
+            continue
+        body = row["body"] or {}
+        result.issues.extend(_check_supply_item_post(body, shape, row["id"]))
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Plex-mock capture diff")
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--db", required=True, type=Path)
+    ap.add_argument("--expected", required=True, type=Path)
+    args = ap.parse_args()
+
+    if not args.db.exists():
+        print(f"DB not found: {args.db}", file=sys.stderr)
+        return 2
+    if not args.expected.exists():
+        print(f"Expected fixture not found: {args.expected}", file=sys.stderr)
+        return 2
+
+    store = CaptureStore(args.db)
+    expected = json.loads(args.expected.read_text())
+    result = diff_run(store=store, run_id=args.run_id, expected=expected)
+    if result.ok:
+        print(f"plex-mock diff: CLEAN (run_id={args.run_id})")
+        return 0
+    print(f"plex-mock diff: DRIFT (run_id={args.run_id}, {len(result.issues)} issues)")
+    for issue in result.issues:
+        print(f"  {issue}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/plex_mock/server.py
+++ b/tools/plex_mock/server.py
@@ -20,7 +20,10 @@ def _load_snapshot(snapshots_dir: Path, name: str) -> list[dict]:
     path = snapshots_dir / name
     if not path.exists():
         return []
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed JSON in snapshot {path}: {exc}") from exc
 
 
 def create_app(
@@ -34,6 +37,12 @@ def create_app(
     app.config["PLEX_MOCK_STORE"] = CaptureStore(db_path)
     app.config["PLEX_MOCK_RUN_ID"] = run_id
 
+    # The mock is stateless: these dicts are loaded once at app creation
+    # and never mutated. Task 6 POST/PUT/PATCH handlers capture request
+    # bodies to the SQLite store and return Plex-shape responses with
+    # synthetic UUIDs, but they do NOT add/modify entries here. A GET of
+    # a synthetic id from an earlier POST therefore intentionally 404s —
+    # the mock doesn't simulate Plex's inventory state, just its wire shape.
     supply_items = _load_snapshot(snapshots_dir, "supply_items_list.json")
     workcenters = _load_snapshot(snapshots_dir, "workcenters_list.json")
     supply_by_id = {rec["id"]: rec for rec in supply_items}
@@ -87,7 +96,9 @@ def main() -> int:
         run_id=args.run_id or str(uuid.uuid4()),
     )
     print(f"plex-mock serving on http://{args.host}:{args.port} run_id={app.config['PLEX_MOCK_RUN_ID']}")
-    app.run(host=args.host, port=args.port, debug=False)
+    # threaded=True so the sync can issue concurrent POSTs against the mock
+    # without Werkzeug's default single-threaded server serialising them.
+    app.run(host=args.host, port=args.port, debug=False, threaded=True)
     return 0
 
 

--- a/tools/plex_mock/server.py
+++ b/tools/plex_mock/server.py
@@ -74,6 +74,61 @@ def create_app(
             abort(404)
         return jsonify(rec)
 
+    @app.post("/inventory/v1/inventory-definitions/supply-items")
+    def supply_items_post():
+        from flask import request
+        payload = request.get_json(silent=True) or {}
+        store: CaptureStore = app.config["PLEX_MOCK_STORE"]
+        store.append(
+            method="POST",
+            path=request.path,
+            body=payload,
+            run_id=app.config["PLEX_MOCK_RUN_ID"],
+        )
+        # Dedup by supplyItemNumber against the snapshot — Plex returns 409
+        sin = payload.get("supplyItemNumber")
+        if sin and any(rec.get("supplyItemNumber") == sin for rec in supply_items):
+            return jsonify({"error": "duplicate supplyItemNumber", "supplyItemNumber": sin}), 409
+        import uuid as _uuid
+        resp = dict(payload)
+        resp["id"] = str(_uuid.uuid4())
+        return jsonify(resp), 201
+
+    @app.put("/inventory/v1/inventory-definitions/supply-items/<item_id>")
+    def supply_items_put(item_id: str):
+        from flask import request
+        if item_id not in supply_by_id:
+            abort(404)
+        payload = request.get_json(silent=True) or {}
+        store: CaptureStore = app.config["PLEX_MOCK_STORE"]
+        store.append(
+            method="PUT",
+            path=request.path,
+            body=payload,
+            run_id=app.config["PLEX_MOCK_RUN_ID"],
+        )
+        merged = {**supply_by_id[item_id], **payload, "id": item_id}
+        return jsonify(merged), 200
+
+    @app.route(
+        "/production/v1/production-definitions/workcenters/<wc_id>",
+        methods=["PUT", "PATCH"],
+    )
+    def workcenter_write(wc_id: str):
+        from flask import request
+        if wc_id not in workcenter_by_id:
+            abort(404)
+        payload = request.get_json(silent=True) or {}
+        store: CaptureStore = app.config["PLEX_MOCK_STORE"]
+        store.append(
+            method=request.method,
+            path=request.path,
+            body=payload,
+            run_id=app.config["PLEX_MOCK_RUN_ID"],
+        )
+        merged = {**workcenter_by_id[wc_id], **payload, "workcenterId": wc_id}
+        return jsonify(merged), 200
+
     return app
 
 

--- a/tools/plex_mock/server.py
+++ b/tools/plex_mock/server.py
@@ -1,0 +1,95 @@
+"""
+Flask app mimicking the Plex REST endpoints the sync writes to.
+GETs serve canned snapshots from disk; POST/PUT/PATCH handlers land
+in Task 6 (this file grows, the tests drive the shape).
+
+Bound to 127.0.0.1 by the systemd unit — never expose publicly.
+Issue: #92.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from flask import Flask, abort, jsonify
+
+from tools.plex_mock.store import CaptureStore
+
+
+def _load_snapshot(snapshots_dir: Path, name: str) -> list[dict]:
+    path = snapshots_dir / name
+    if not path.exists():
+        return []
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def create_app(
+    *,
+    snapshots_dir: Path,
+    db_path: Path,
+    run_id: str,
+) -> Flask:
+    app = Flask(__name__)
+    app.config["PLEX_MOCK_SNAPSHOTS_DIR"] = snapshots_dir
+    app.config["PLEX_MOCK_STORE"] = CaptureStore(db_path)
+    app.config["PLEX_MOCK_RUN_ID"] = run_id
+
+    supply_items = _load_snapshot(snapshots_dir, "supply_items_list.json")
+    workcenters = _load_snapshot(snapshots_dir, "workcenters_list.json")
+    supply_by_id = {rec["id"]: rec for rec in supply_items}
+    workcenter_by_id = {rec["workcenterId"]: rec for rec in workcenters}
+
+    @app.get("/healthz")
+    def healthz():
+        return jsonify({"ok": True})
+
+    @app.get("/inventory/v1/inventory-definitions/supply-items")
+    def supply_items_list():
+        return jsonify(supply_items)
+
+    @app.get("/inventory/v1/inventory-definitions/supply-items/<item_id>")
+    def supply_items_get(item_id: str):
+        rec = supply_by_id.get(item_id)
+        if rec is None:
+            abort(404)
+        return jsonify(rec)
+
+    @app.get("/production/v1/production-definitions/workcenters")
+    def workcenters_list():
+        return jsonify(workcenters)
+
+    @app.get("/production/v1/production-definitions/workcenters/<wc_id>")
+    def workcenter_get(wc_id: str):
+        rec = workcenter_by_id.get(wc_id)
+        if rec is None:
+            abort(404)
+        return jsonify(rec)
+
+    return app
+
+
+def main() -> int:
+    """Console-script entry (datum-plex-mock-serve)."""
+    import argparse
+    import uuid
+
+    ap = argparse.ArgumentParser(description="Plex-mimic mock server")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8080)
+    ap.add_argument("--snapshots", default=Path(__file__).parent / "snapshots")
+    ap.add_argument("--db", default=Path(__file__).parent / "captures.db")
+    ap.add_argument("--run-id", default=None, help="Override run_id (default: random uuid4)")
+    args = ap.parse_args()
+
+    app = create_app(
+        snapshots_dir=Path(args.snapshots),
+        db_path=Path(args.db),
+        run_id=args.run_id or str(uuid.uuid4()),
+    )
+    print(f"plex-mock serving on http://{args.host}:{args.port} run_id={app.config['PLEX_MOCK_RUN_ID']}")
+    app.run(host=args.host, port=args.port, debug=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/plex_mock/server.py
+++ b/tools/plex_mock/server.py
@@ -78,6 +78,12 @@ def create_app(
     def supply_items_post():
         from flask import request
         payload = request.get_json(silent=True) or {}
+        # Dedup by supplyItemNumber against the snapshot — Plex returns 409.
+        # Guard before capturing so failed requests aren't stored; matches
+        # the 404 ordering in supply_items_put and workcenter_write.
+        sin = payload.get("supplyItemNumber")
+        if sin and any(rec.get("supplyItemNumber") == sin for rec in supply_items):
+            return jsonify({"error": "duplicate supplyItemNumber", "supplyItemNumber": sin}), 409
         store: CaptureStore = app.config["PLEX_MOCK_STORE"]
         store.append(
             method="POST",
@@ -85,10 +91,6 @@ def create_app(
             body=payload,
             run_id=app.config["PLEX_MOCK_RUN_ID"],
         )
-        # Dedup by supplyItemNumber against the snapshot — Plex returns 409
-        sin = payload.get("supplyItemNumber")
-        if sin and any(rec.get("supplyItemNumber") == sin for rec in supply_items):
-            return jsonify({"error": "duplicate supplyItemNumber", "supplyItemNumber": sin}), 409
         import uuid as _uuid
         resp = dict(payload)
         resp["id"] = str(_uuid.uuid4())

--- a/tools/plex_mock/snapshots/README.md
+++ b/tools/plex_mock/snapshots/README.md
@@ -1,0 +1,8 @@
+# Canned GET snapshots
+
+JSON responses captured from real `connect.plex.com` so the mock can
+serve realistic GETs without a live-Plex dependency. Refresh via
+`python -m tools.plex_mock.capture_snapshots` when Plex shapes change.
+
+Files here are committed. Ad-hoc mock captures (POSTs the sync sent)
+live in `tools/plex_mock/captures/` which is gitignored.

--- a/tools/plex_mock/store.py
+++ b/tools/plex_mock/store.py
@@ -1,0 +1,87 @@
+"""
+SQLite-backed capture store for the Plex-mimic mock.
+
+Every POST/PUT/PATCH the mock server sees is appended here so the
+diff CLI (#92) can report what the sync *would have* sent to real
+Plex, and three-runs-in-a-row idempotency checks can compare run sets.
+
+Append-only by design — no update/delete path. Gitignored; survives
+mock restarts.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS captures (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts        TEXT    NOT NULL,
+  method    TEXT    NOT NULL,
+  path      TEXT    NOT NULL,
+  body_json TEXT,
+  run_id    TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS captures_run_id_idx ON captures(run_id);
+CREATE INDEX IF NOT EXISTS captures_run_method_idx ON captures(run_id, method);
+"""
+
+
+class CaptureStore:
+    """Thin wrapper around a SQLite file used as an append-only capture log."""
+
+    def __init__(self, path: Path | str):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as con:
+            con.executescript(SCHEMA)
+
+    def append(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: Any,
+        run_id: str,
+    ) -> int:
+        """Record one captured request. Returns the rowid."""
+        ts = datetime.now(timezone.utc).isoformat()
+        body_json = json.dumps(body) if body is not None else None
+        with sqlite3.connect(self.path) as con:
+            cur = con.execute(
+                "INSERT INTO captures (ts, method, path, body_json, run_id) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (ts, method, path, body_json, run_id),
+            )
+            return cur.lastrowid
+
+    def query(
+        self,
+        *,
+        run_id: str,
+        method: str | None = None,
+    ) -> list[dict]:
+        """Return all captures for a run, oldest first. Optional method filter."""
+        sql = "SELECT id, ts, method, path, body_json, run_id FROM captures WHERE run_id = ?"
+        args: list[Any] = [run_id]
+        if method is not None:
+            sql += " AND method = ?"
+            args.append(method)
+        sql += " ORDER BY id ASC"
+        with sqlite3.connect(self.path) as con:
+            rows = con.execute(sql, args).fetchall()
+        return [
+            {
+                "id": r[0],
+                "ts": r[1],
+                "method": r[2],
+                "path": r[3],
+                "body": json.loads(r[4]) if r[4] is not None else None,
+                "run_id": r[5],
+            }
+            for r in rows
+        ]

--- a/tools/plex_mock/store.py
+++ b/tools/plex_mock/store.py
@@ -57,6 +57,7 @@ class CaptureStore:
                 "VALUES (?, ?, ?, ?, ?)",
                 (ts, method, path, body_json, run_id),
             )
+            assert cur.lastrowid is not None  # INSERT always yields a rowid
             return cur.lastrowid
 
     def query(

--- a/tools/plex_mock/systemd/README.md
+++ b/tools/plex_mock/systemd/README.md
@@ -1,0 +1,31 @@
+# Deploy `datum-plex-mock` on `datum-runtime`
+
+Assumes the Datum repo is at `/opt/datum` and a virtualenv at
+`/opt/datum/.venv` with `pip install -e .` having registered
+`datum-plex-mock-serve`.
+
+## SSH in via IAP
+
+```bash
+gcloud compute ssh datum-runtime --zone=us-central1-a --tunnel-through-iap \
+  --project=$PROJECT_ID
+```
+
+## On the VM
+
+```bash
+sudo mkdir -p /var/lib/datum
+sudo chown datum:datum /var/lib/datum
+sudo cp /opt/datum/tools/plex_mock/systemd/datum-plex-mock.service \
+        /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now datum-plex-mock
+sudo systemctl status datum-plex-mock
+curl -sf http://127.0.0.1:8080/healthz
+```
+
+## Troubleshooting
+
+- Logs: `journalctl -u datum-plex-mock -f`
+- Stop: `sudo systemctl stop datum-plex-mock`
+- Refresh snapshots from the VM: `cd /opt/datum && /opt/datum/.venv/bin/datum-plex-mock-snapshot`

--- a/tools/plex_mock/systemd/datum-plex-mock.service
+++ b/tools/plex_mock/systemd/datum-plex-mock.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Datum Plex-Mimic Mock HTTP Server
+After=network.target
+Documentation=https://github.com/grace-shane/Datum/issues/92
+
+[Service]
+Type=simple
+User=datum
+Group=datum
+WorkingDirectory=/opt/datum
+EnvironmentFile=/opt/datum/.env.local
+ExecStart=/opt/datum/.venv/bin/datum-plex-mock-serve \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --snapshots /opt/datum/tools/plex_mock/snapshots \
+  --db /var/lib/datum/plex-mock-captures.db
+Restart=on-failure
+RestartSec=5
+# Hardening — mock has no reason to touch anything outside its data dir
+ReadWritePaths=/var/lib/datum
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Closes #92. Blocks on #3 / #6 (Plex writes) now have a concrete dress-rehearsal surface: a local Plex-mimic HTTP server the nightly sync points at via `PLEX_BASE_URL`. Every POST/PUT/PATCH captures to SQLite; a diff CLI reports payload-shape drift. No real `connect.plex.com` writes until the mimic has a clean validation window.

Produced via the subagent-driven execution of [`docs/superpowers/plans/2026-04-17-plex-mimic-mock.md`](../blob/master/docs/superpowers/plans/2026-04-17-plex-mimic-mock.md) — 15 commits, 10 tasks, TDD throughout.

## What's in

- **`PLEX_BASE_URL` override** in `plex_api.py` — new `base_url=` kwarg on `PlexClient` + `OVERRIDE_URL` module constant. Resolution order: explicit kwarg > env > `PLEX_USE_TEST` > prod default. 8 new tests.
- **`tools/plex_mock/store.py`** — SQLite append-only capture store keyed by `run_id`. 10 tests.
- **`tools/plex_mock/server.py`** — Flask app. `GET` supply-items + workcenters (list + by-id) serve canned snapshots. `POST` returns 201 with synthetic UUID (409 on `supplyItemNumber` dedup, guard-before-capture). `PUT/PATCH` capture and return merged responses. `/healthz` probe. Stateless — POSTs don't mutate snapshot state. Threaded Werkzeug. 18 tests.
- **`tools/plex_mock/capture_snapshots.py`** — one-off CLI to refresh GET snapshots from real Plex (read-only, no writes). Script shipped; snapshot JSON deferred (needs live creds — see "After merge" below).
- **`tools/plex_mock/diff.py`** — capture-diff CLI. Checks required / forbidden fields + types against `tests/fixtures/plex_mock/expected_supply_items.json`. Reports checked-row count; exits 3 on zero-rows-but-clean (so a mistyped `run_id` doesn't masquerade as success). 6 tests.
- **Three console scripts** in `pyproject.toml`: `datum-plex-mock-serve`, `datum-plex-mock-snapshot`, `datum-plex-mock-diff`. `packages = ["tools", "tools.plex_mock"]` so the sub-packages install.
- **`tools/plex_mock/README.md`** — quick-start, endpoint table, validation-window protocol.
- **`docs/Plex_API_Reference.md`** — `PLEX_BASE_URL` override section + resolution order.
- **`tools/plex_mock/systemd/datum-plex-mock.service`** — systemd unit bound to `127.0.0.1:8080` with `PrivateTmp` / `ProtectSystem=strict` / `ProtectHome` / `NoNewPrivileges` / `ReadWritePaths=/var/lib/datum` hardening. Deploy README alongside.
- **`.gitignore`** — `tools/plex_mock/captures/` and `*.db` ignored.

## Test plan

- [x] `pytest -q` → **424 passed** (382 baseline + 42 new across three test files)
- [x] Three console scripts install cleanly via `pip install -e .` — `--help` works on all three
- [x] Mock imports cleanly: `from tools.plex_mock.server import create_app`, `store`, `diff`
- [x] CI pytest + Workers Builds green (after push)
- [ ] **Deferred — needs creds-having VM:** on `datum-runtime` (or similar), run `python -m tools.plex_mock.capture_snapshots` to produce `tools/plex_mock/snapshots/{supply_items_list,workcenters_list}.json`, commit them as a follow-up PR
- [ ] **Deferred — needs full sync toolchain:** end-to-end rehearsal — `PLEX_BASE_URL=http://127.0.0.1:8080 PLEX_ALLOW_WRITES=1 datum-sync` against a running mock, then `datum-plex-mock-diff` the captures

## Deploy on datum-runtime

After merge, on the VM:

```bash
cd /opt/datum && git pull
/opt/datum/.venv/bin/pip install -e .
sudo cp tools/plex_mock/systemd/datum-plex-mock.service /etc/systemd/system/
sudo mkdir -p /var/lib/datum && sudo chown datum:datum /var/lib/datum
sudo systemctl daemon-reload && sudo systemctl enable --now datum-plex-mock
curl -sf http://127.0.0.1:8080/healthz
```

Full deploy walkthrough in `tools/plex_mock/systemd/README.md`.

## Execution notes for posterity

Plan was followed with two minor deviations caught in review:
1. Task 6 POST handler was reordered to guard-before-capture on 409 duplicates, matching the 404 pattern of PUT/PATCH (reviewer note — small but real).
2. Task 8 diff CLI gained a `checked` counter + exit-code-3-on-empty-run so a typo in `--run-id` doesn't silently pass as CLEAN.

One subagent commit (`b98b4d7`) accidentally reverted Task 1 + Task 2 changes to unrelated files; restoration was the final commit on the branch. Spec reviewer caught it. Noted for future subagent runs — may want to tighten the implementer-prompt template to forbid `git checkout <path>` against paths outside the task's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)